### PR TITLE
Map Object resizing, v3!

### DIFF
--- a/src/libtiled/hexagonalrenderer.cpp
+++ b/src/libtiled/hexagonalrenderer.cpp
@@ -234,7 +234,7 @@ void HexagonalRenderer::drawTileLayer(QPainter *painter,
             const Cell &cell = layer->cellAt(rowTile);
 
             if (!cell.isEmpty())
-                renderer.render(cell, rowPos, CellRenderer::BottomLeft);
+                renderer.render(cell, rowPos, QSizeF(0, 0), CellRenderer::BottomLeft);
 
             rowPos.rx() += p.tileWidth;
         }

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -72,10 +72,13 @@ QRectF IsometricRenderer::boundingRect(const MapObject *object) const
         const Tile *tile = object->cell().tile;
         const QSize imgSize = tile->image().size();
         const QPoint tileOffset = tile->tileset()->tileOffset();
-        return QRectF(bottomCenter.x() + tileOffset.x() - imgSize.width() / 2,
-                      bottomCenter.y() + tileOffset.y() - imgSize.height(),
-                      imgSize.width(),
-                      imgSize.height()).adjusted(-1, -1 - nameHeight, 1, 1);
+        const QSizeF objectSize = object->size();
+        const QSizeF scale(objectSize.width() / imgSize.width(), objectSize.height() / imgSize.height());
+
+        return QRectF(bottomCenter.x() + (tileOffset.x() * scale.width()) - objectSize.width() / 2,
+                      bottomCenter.y() + (tileOffset.y() * scale.height()) - objectSize.height(),
+                      objectSize.width(),
+                      objectSize.height()).adjusted(-1, -1 - nameHeight, 1, 1);
     } else if (!object->polygon().isEmpty()) {
         const qreal extraSpace = qMax(objectLineWidth() / 2, qreal(1));
         const QPointF &pos = object->position();

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -232,7 +232,7 @@ void IsometricRenderer::drawTileLayer(QPainter *painter,
             if (layer->contains(columnItr)) {
                 const Cell &cell = layer->cellAt(columnItr);
                 if (!cell.isEmpty()) {
-                    renderer.render(cell, QPointF(x, y),
+                    renderer.render(cell, QPointF(x, y), QSizeF(0, 0),
                                     CellRenderer::BottomLeft);
                 }
             }
@@ -299,7 +299,7 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
             painter->drawText(textPos, name);
         }
 
-        CellRenderer(painter).render(cell, pos,
+        CellRenderer(painter).render(cell, pos, object->size(),
                                      CellRenderer::BottomCenter);
 
         if (testFlag(ShowTileObjectOutlines)) {

--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -839,8 +839,17 @@ MapObject *MapReaderPrivate::readObject()
     if (ok)
         object->setRotation(rotation);
 
-    if (gid)
+    if (gid) {
         object->setCell(cellForGid(gid));
+        
+        if (object->cell().isEmpty() == false) {
+            const QSizeF &tileSize = object->cell().tile->size();
+            if (width == 0)
+                object->setWidth(tileSize.width());
+            if (height == 0)
+                object->setHeight(tileSize.height());
+        }
+    }
 
     const int visible = visibleRef.toString().toInt(&ok);
     if (ok)

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -107,19 +107,21 @@ CellRenderer::CellRenderer(QPainter *painter)
  * flush when finished doing drawCell calls. This function is also called by
  * the destructor so usually an explicit call it not needed.
  */
-void CellRenderer::render(const Cell &cell, const QPointF &pos, Origin origin)
+void CellRenderer::render(const Cell &cell, const QPointF &pos, const QSizeF &cellSize, Origin origin)
 {
     if (mTile != cell.tile)
         flush();
 
     const QPixmap &image = cell.tile->currentFrameImage();
     const QSizeF size = image.size();
+    const QSizeF objectSize = (cellSize == QSizeF(0,0)) ? size : cellSize;
+    const QSizeF scale(objectSize.width() / size.width(), objectSize.height() / size.height());
     const QPoint offset = cell.tile->tileset()->tileOffset();
-    const QPointF sizeHalf = QPointF(size.width() / 2, size.height() / 2);
+    const QPointF sizeHalf = QPointF(objectSize.width() / 2, objectSize.height() / 2);
 
     QPainter::PixmapFragment fragment;
-    fragment.x = pos.x() + offset.x() + sizeHalf.x();
-    fragment.y = pos.y() + offset.y() + sizeHalf.y() - size.height();
+    fragment.x = pos.x() + (offset.x() * scale.width()) + sizeHalf.x();
+    fragment.y = pos.y() + (offset.y() * scale.height()) + sizeHalf.y() - objectSize.height();
     fragment.sourceLeft = 0;
     fragment.sourceTop = 0;
     fragment.width = size.width();
@@ -128,14 +130,18 @@ void CellRenderer::render(const Cell &cell, const QPointF &pos, Origin origin)
     fragment.scaleY = cell.flippedVertically ? -1 : 1;
     fragment.rotation = 0;
     fragment.opacity = 1;
+    
+    bool flippedHorizontally = cell.flippedHorizontally;
+    bool flippedVertically = cell.flippedVertically;
 
     if (origin == BottomCenter)
         fragment.x -= sizeHalf.x();
 
     if (cell.flippedAntiDiagonally) {
         fragment.rotation = 90;
-        fragment.scaleX *= -1;
-        std::swap(fragment.scaleX, fragment.scaleY);
+        
+        flippedHorizontally = cell.flippedVertically;
+        flippedVertically = !cell.flippedHorizontally;
 
         // Compensate for the swap of image dimensions
         const qreal halfDiff = sizeHalf.y() - sizeHalf.x();
@@ -143,8 +149,11 @@ void CellRenderer::render(const Cell &cell, const QPointF &pos, Origin origin)
         if (origin != BottomCenter)
             fragment.x += halfDiff;
     }
+    
+    fragment.scaleX = scale.width() * (flippedHorizontally ? -1 : 1);
+    fragment.scaleY = scale.height() * (flippedVertically ? -1 : 1);
 
-    if (mIsOpenGL || (fragment.scaleX > 0 && fragment.scaleY > 0)) {
+    if (mIsOpenGL || (fragment.scaleX == 1 && fragment.scaleY == 1)) {
         mTile = cell.tile;
         mFragments.append(fragment);
         return;

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -259,7 +259,7 @@ public:
 
     ~CellRenderer() { flush(); }
 
-    void render(const Cell &cell, const QPointF &pos, Origin origin);
+    void render(const Cell &cell, const QPointF &pos, const QSizeF &size, Origin origin);
     void flush();
 
 private:

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -66,10 +66,13 @@ QRectF OrthogonalRenderer::boundingRect(const MapObject *object) const
         const Tile *tile = object->cell().tile;
         const QSize imgSize = tile->image().size();
         const QPoint tileOffset = tile->tileset()->tileOffset();
-        boundingRect = QRectF(bottomLeft.x() + tileOffset.x(),
-                              bottomLeft.y() + tileOffset.y() - imgSize.height(),
-                              imgSize.width(),
-                              imgSize.height()).adjusted(-1, -1, 1, 1);
+        const QSizeF objectSize = object->size();
+        const QSizeF scale(objectSize.width() / imgSize.width(), objectSize.height() / imgSize.height());
+
+        boundingRect = QRectF(bottomLeft.x() + (tileOffset.x() * scale.width()),
+                              bottomLeft.y() + (tileOffset.y() * scale.height()) - objectSize.height(),
+                              objectSize.width(),
+                              objectSize.height()).adjusted(-1, -1, 1, 1);
     } else {
         const qreal extraSpace = qMax(objectLineWidth() / 2, qreal(1));
 
@@ -270,6 +273,7 @@ void OrthogonalRenderer::drawTileLayer(QPainter *painter,
 
             renderer.render(cell,
                             QPointF(x * tileWidth, (y + 1) * tileHeight),
+                            QSizeF(0, 0),
                             CellRenderer::BottomLeft);
         }
     }
@@ -306,7 +310,7 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
     const Cell &cell = object->cell();
 
     if (!cell.isEmpty()) {
-        CellRenderer(painter).render(cell, QPointF(),
+        CellRenderer(painter).render(cell, QPointF(), object->size(),
                                      CellRenderer::BottomLeft);
 
         if (testFlag(ShowTileObjectOutlines)) {

--- a/src/tiled/createobjecttool.cpp
+++ b/src/tiled/createobjecttool.cpp
@@ -183,6 +183,11 @@ void CreateObjectTool::startNewMapObject(const QPointF &pos,
         return;
     newMapObject->setPosition(pos);
 
+    if (mMode == CreateTile) {
+        if (newMapObject->cell().isEmpty() == false) {
+            newMapObject->setSize(newMapObject->cell().tile->size());
+        }
+    }
     objectGroup->addObject(newMapObject);
 
     mNewMapObjectItem = new MapObjectItem(newMapObject, mapDocument());

--- a/src/tiled/mapobjectitem.cpp
+++ b/src/tiled/mapobjectitem.cpp
@@ -47,156 +47,15 @@
 using namespace Tiled;
 using namespace Tiled::Internal;
 
-namespace Tiled {
-namespace Internal {
-
-/**
- * Some handle item that indicates a point on an object can be dragged.
- */
-class Handle : public QGraphicsItem
-{
-public:
-    Handle(MapObjectItem *mapObjectItem)
-        : QGraphicsItem(mapObjectItem)
-        , mMapObjectItem(mapObjectItem)
-    {
-        setFlags(QGraphicsItem::ItemIsMovable |
-                 QGraphicsItem::ItemSendsGeometryChanges |
-                 QGraphicsItem::ItemIgnoresTransformations |
-                 QGraphicsItem::ItemIgnoresParentOpacity);
-    }
-
-    QRectF boundingRect() const;
-    void paint(QPainter *painter,
-               const QStyleOptionGraphicsItem *option,
-               QWidget *widget = 0);
-
-protected:
-    MapObjectItem *mMapObjectItem;
-};
-
-/**
- * A resize handle that allows resizing of a map object.
- */
-class ResizeHandle : public Handle
-{
-public:
-    ResizeHandle(MapObjectItem *mapObjectItem)
-        : Handle(mapObjectItem)
-    {
-        setCursor(Qt::SizeFDiagCursor);
-    }
-
-protected:
-    void mousePressEvent(QGraphicsSceneMouseEvent *event);
-    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
-
-    QVariant itemChange(GraphicsItemChange change, const QVariant &value);
-
-private:
-    QSizeF mOldSize;
-};
-
-} // namespace Internal
-} // namespace Tiled
-
-
-QRectF Handle::boundingRect() const
-{
-    return QRectF(-5, -5, 10 + 1, 10 + 1);
-}
-
-void Handle::paint(QPainter *painter,
-                   const QStyleOptionGraphicsItem *,
-                   QWidget *)
-{
-    painter->setBrush(mMapObjectItem->color());
-    painter->setPen(Qt::black);
-    painter->drawRect(QRectF(-5, -5, 10, 10));
-}
-
-
-void ResizeHandle::mousePressEvent(QGraphicsSceneMouseEvent *event)
-{
-    // Remember the old size since we may resize the object
-    if (event->button() == Qt::LeftButton)
-        mOldSize = mMapObjectItem->mapObject()->size();
-
-    Handle::mousePressEvent(event);
-}
-
-void ResizeHandle::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
-{
-    Handle::mouseReleaseEvent(event);
-
-    // If we resized the object, create an undo command
-    MapObject *obj = mMapObjectItem->mapObject();
-    if (event->button() == Qt::LeftButton && mOldSize != obj->size()) {
-        MapDocument *document = mMapObjectItem->mapDocument();
-        QUndoCommand *cmd = new ResizeMapObject(document, obj, mOldSize);
-        document->undoStack()->push(cmd);
-    }
-}
-
-QVariant ResizeHandle::itemChange(GraphicsItemChange change,
-                                  const QVariant &value)
-{
-    if (!mMapObjectItem->mSyncing) {
-        MapRenderer *renderer = mMapObjectItem->mapDocument()->renderer();
-
-        if (change == ItemPositionChange) {
-            bool snapToGrid = Preferences::instance()->snapToGrid();
-            bool snapToFineGrid = Preferences::instance()->snapToFineGrid();
-            if (QApplication::keyboardModifiers() & Qt::ControlModifier) {
-                snapToGrid = !snapToGrid;
-                snapToFineGrid = false;
-            }
-
-            // Calculate the absolute pixel position
-            const QPointF itemPos = mMapObjectItem->pos();
-            QPointF pixelPos = value.toPointF() + itemPos;
-
-            // Calculate the new coordinates in pixels
-            QPointF tileCoords = renderer->screenToTileCoords(pixelPos);
-            const QPointF objectPos = mMapObjectItem->mapObject()->position();
-            const QPointF objectTilePos = renderer->pixelToTileCoords(objectPos);
-            tileCoords -= objectTilePos;
-            tileCoords.setX(qMax(tileCoords.x(), qreal(0)));
-            tileCoords.setY(qMax(tileCoords.y(), qreal(0)));
-            if (snapToFineGrid) {
-                int gridFine = Preferences::instance()->gridFine();
-                tileCoords = (tileCoords * gridFine).toPoint();
-                tileCoords /= gridFine;
-            } else if (snapToGrid)
-                tileCoords = tileCoords.toPoint();
-            tileCoords += objectTilePos;
-
-            return renderer->tileToScreenCoords(tileCoords) - itemPos;
-        }
-        else if (change == ItemPositionHasChanged) {
-            // Update the size of the map object
-            const QPointF newPos = value.toPointF() + mMapObjectItem->pos();
-            QPointF tileCoords = renderer->screenToPixelCoords(newPos);
-            tileCoords -= mMapObjectItem->mapObject()->position();
-            mMapObjectItem->resizeObject(QSizeF(tileCoords.x(), tileCoords.y()));
-        }
-    }
-
-    return Handle::itemChange(change, value);
-}
-
-
 MapObjectItem::MapObjectItem(MapObject *object, MapDocument *mapDocument,
                              ObjectGroupItem *parent):
     QGraphicsItem(parent),
     mObject(object),
     mMapDocument(mapDocument),
     mIsEditable(false),
-    mSyncing(false),
-    mResizeHandle(new ResizeHandle(this))
+    mSyncing(false)
 {
     syncWithMapObject();
-    mResizeHandle->setVisible(false);
 }
 
 void MapObjectItem::syncWithMapObject()
@@ -212,7 +71,6 @@ void MapObjectItem::syncWithMapObject()
     if (mColor != color) {
         mColor = color;
         update();
-        mResizeHandle->update();
     }
 
     QString toolTip = mName;
@@ -240,9 +98,6 @@ void MapObjectItem::syncWithMapObject()
         // Notify the graphics scene about the geometry change in advance
         prepareGeometryChange();
         mBoundingRect = bounds;
-        const QPointF bottomRight = mObject->bounds().bottomRight();
-        const QPointF handlePos = renderer->pixelToScreenCoords(bottomRight);
-        mResizeHandle->setPos(handlePos - pixelPos);
     }
 
     mSyncing = false;
@@ -256,9 +111,6 @@ void MapObjectItem::setEditable(bool editable)
         return;
 
     mIsEditable = editable;
-
-    const bool handlesVisible = mIsEditable && mObject->cell().isEmpty();
-    mResizeHandle->setVisible(handlesVisible && mObject->polygon().isEmpty());
 
     if (mIsEditable)
         setCursor(Qt::SizeAllCursor);

--- a/src/tiled/mapobjectitem.h
+++ b/src/tiled/mapobjectitem.h
@@ -119,10 +119,6 @@ private:
     QColor mColor;      // Cached color of the object
     bool mIsEditable;
     bool mSyncing;
-    ResizeHandle *mResizeHandle;
-
-    friend class Handle;
-    friend class ResizeHandle;
 };
 
 } // namespace Internal

--- a/src/tiled/objectselectiontool.cpp
+++ b/src/tiled/objectselectiontool.cpp
@@ -31,6 +31,7 @@
 #include "objectgroup.h"
 #include "preferences.h"
 #include "raiselowerhelper.h"
+#include "resizemapobject.h"
 #include "rotatemapobject.h"
 #include "selectionrectangle.h"
 
@@ -80,11 +81,15 @@ public:
     }
 };
 
-enum Corner {
+enum AnchorPosition {
     TopLeft,
     TopRight,
     BottomLeft,
-    BottomRight
+    BottomRight,
+    TopMiddle,
+    CenterLeft,
+    CenterRight,
+    BottomMiddle
 };
 
 static QPainterPath createArrow()
@@ -117,7 +122,7 @@ static QPainterPath createArrow()
     path.lineTo(arrowHeadPos - arrowHeadWidth, arrowHeadLength);
     path.closeSubpath();
 
-    path.translate(-3, -3);
+    path.translate(0, 0);
 
     return path;
 }
@@ -128,7 +133,7 @@ static QPainterPath createArrow()
 class CornerHandle : public QGraphicsItem
 {
 public:
-    CornerHandle(Corner corner, QGraphicsItem *parent = 0)
+    CornerHandle(AnchorPosition corner, QGraphicsItem *parent = 0)
         : QGraphicsItem(parent)
     {
         setFlags(QGraphicsItem::ItemIgnoresTransformations |
@@ -141,7 +146,7 @@ public:
         case TopLeft:       setRotation(180);   break;
         case TopRight:      setRotation(-90);   break;
         case BottomLeft:    setRotation(90);    break;
-        case BottomRight:   break;
+        default:            break; // BottomRight
         }
     }
 
@@ -177,6 +182,67 @@ QVariant CornerHandle::itemChange(GraphicsItemChange change,
     return QGraphicsItem::itemChange(change, value);
 }
 
+/**
+ * A resize handle that allows resizing of map objects.
+ */
+class ResizeHandle : public QGraphicsItem
+{
+public:
+    ResizeHandle(AnchorPosition anchorPosition, QGraphicsItem *parent = 0)
+        : QGraphicsItem(parent)
+    {
+        setFlags(QGraphicsItem::ItemIgnoresTransformations |
+                 QGraphicsItem::ItemIgnoresParentOpacity);
+        setAcceptHoverEvents(true);
+        setCursor(Qt::SizeFDiagCursor);
+        setZValue(10000 + 2);
+        
+        mResizingOrigin = QPointF(0, 0);
+        mResizingLimitHorizontal = false;
+        mResizingLimitVertical = false;
+        
+        switch(anchorPosition) {
+        case TopLeft:       setCursor(Qt::SizeFDiagCursor); break;
+        case TopRight:      setCursor(Qt::SizeBDiagCursor); break;
+        case BottomLeft:    setCursor(Qt::SizeBDiagCursor); break;
+        case BottomRight:   setCursor(Qt::SizeFDiagCursor); break;
+        case TopMiddle:     setCursor(Qt::SizeVerCursor); mResizingLimitHorizontal = true; break;
+        case CenterLeft:    setCursor(Qt::SizeHorCursor); mResizingLimitVertical = true; break;
+        case CenterRight:   setCursor(Qt::SizeHorCursor); mResizingLimitVertical = true; break;
+        default:            setCursor(Qt::SizeVerCursor); mResizingLimitHorizontal = true; break;
+        }
+    }
+    
+    void setResizingOrigin(QPointF scalingOrigin) { mResizingOrigin = scalingOrigin; }
+    QPointF getResizingOrigin() const { return mResizingOrigin; }
+    
+    bool getResizingLimitHorizontal() const { return mResizingLimitHorizontal; }
+    bool getResizingLimitVertical() const { return mResizingLimitVertical; }
+    
+    QRectF boundingRect() const;
+    
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *);
+   
+private:
+    QPointF mResizingOrigin;
+    bool mResizingLimitHorizontal;
+    bool mResizingLimitVertical;
+};
+
+QRectF ResizeHandle::boundingRect() const
+{
+    return QRectF(-5, -5, 10 + 1, 10 + 1);
+}
+
+void ResizeHandle::paint(QPainter *painter,
+                   const QStyleOptionGraphicsItem *,
+                   QWidget *)
+{
+    painter->setBrush(Qt::white);
+    painter->setPen(Qt::black);
+    painter->drawRect(QRectF(-5, -5, 10, 10));
+}
+
 } // namespace Internal
 } // namespace Tiled
 
@@ -190,10 +256,13 @@ ObjectSelectionTool::ObjectSelectionTool(QObject *parent)
     , mMousePressed(false)
     , mClickedObjectItem(0)
     , mClickedCornerHandle(0)
+    , mClickedResizeHandle(0)
     , mMode(NoMode)
 {
     for (int i = 0; i < 4; ++i)
-        mCornerHandles[i] = new CornerHandle(static_cast<Corner>(i));
+        mCornerHandles[i] = new CornerHandle(static_cast<AnchorPosition>(i));
+    for (int i = 0; i < 8; ++i)
+        mResizeHandles[i] = new ResizeHandle(static_cast<AnchorPosition>(i));
 }
 
 ObjectSelectionTool::~ObjectSelectionTool()
@@ -203,6 +272,8 @@ ObjectSelectionTool::~ObjectSelectionTool()
 
     for (int i = 0; i < 4; ++i)
         delete mCornerHandles[i];
+    for (int i = 0; i < 8; ++i)
+        delete mResizeHandles[i];
 }
 
 void ObjectSelectionTool::activate(MapScene *scene)
@@ -222,6 +293,8 @@ void ObjectSelectionTool::activate(MapScene *scene)
     scene->addItem(mRotationOriginIndicator);
     for (int i = 0; i < 4; ++i)
         scene->addItem(mCornerHandles[i]);
+    for (int i = 0; i < 8; ++i)
+        scene->addItem(mResizeHandles[i]);
 }
 
 void ObjectSelectionTool::deactivate(MapScene *scene)
@@ -229,6 +302,8 @@ void ObjectSelectionTool::deactivate(MapScene *scene)
     scene->removeItem(mRotationOriginIndicator);
     for (int i = 0; i < 4; ++i)
         scene->removeItem(mCornerHandles[i]);
+    for (int i = 0; i < 8; ++i)
+        scene->removeItem(mResizeHandles[i]);
 
     disconnect(mapDocument(), SIGNAL(objectsChanged(QList<MapObject*>)),
                this, SLOT(updateHandles()));
@@ -307,6 +382,8 @@ void ObjectSelectionTool::mouseMoved(const QPointF &pos,
                 startMoving();
             else if (mClickedCornerHandle)
                 startRotating();
+            else if (mClickedResizeHandle)
+                startResizing();
             else
                 startSelecting();
         }
@@ -321,6 +398,13 @@ void ObjectSelectionTool::mouseMoved(const QPointF &pos,
         break;
     case Rotating:
         updateRotatingItems(pos, modifiers);
+        break;
+    case Resizing:
+        if (mMovingItems.size() == 1) {
+            updateResizingSingleItem(pos, modifiers);
+        } else {
+            updateResizingItems(pos, modifiers);
+        }
         break;
     case NoMode:
         break;
@@ -345,17 +429,20 @@ void ObjectSelectionTool::mousePressed(QGraphicsSceneMouseEvent *event)
         mStart = event->scenePos();
         mScreenStart = event->screenPos();
 
-        CornerHandle *clickedHandle = 0;
+        CornerHandle *clickedCornerHandle = 0;
+        ResizeHandle *clickedResizeHandle = 0;
 
         if (QGraphicsView *view = findView(event)) {
             QGraphicsItem *clickedItem = mapScene()->itemAt(event->scenePos(),
                                                             view->transform());
 
-            clickedHandle = dynamic_cast<CornerHandle*>(clickedItem);
+            clickedCornerHandle = dynamic_cast<CornerHandle*>(clickedItem);
+            clickedResizeHandle = dynamic_cast<ResizeHandle*>(clickedItem);
         }
 
-        mClickedCornerHandle = clickedHandle;
-        if (!clickedHandle)
+        mClickedCornerHandle = clickedCornerHandle;
+        mClickedResizeHandle = clickedResizeHandle;
+        if (!clickedCornerHandle && !clickedResizeHandle)
             mClickedObjectItem = topMostObjectItemAt(mStart);
 
         break;
@@ -401,6 +488,9 @@ void ObjectSelectionTool::mouseReleased(QGraphicsSceneMouseEvent *event)
     case Rotating:
         finishRotating(event->scenePos());
         break;
+    case Resizing:
+        finishResizing(event->scenePos());
+        break;
     }
 
     mMousePressed = false;
@@ -438,14 +528,55 @@ void ObjectSelectionTool::updateHandles()
             boundingRect |= item->mapToScene(item->boundingRect()).boundingRect();
         }
 
-        mCornerHandles[TopLeft]->setPos(boundingRect.topLeft());
-        mCornerHandles[TopRight]->setPos(boundingRect.topRight());
-        mCornerHandles[BottomLeft]->setPos(boundingRect.bottomLeft());
-        mCornerHandles[BottomRight]->setPos(boundingRect.bottomRight());
+        boundingRect = boundingRect.adjusted(1, 1, -1, -1);
+        
+        QPointF topLeft = boundingRect.topLeft();
+        QPointF topRight = boundingRect.topRight();
+        QPointF bottomLeft = boundingRect.bottomLeft();
+        QPointF bottomRight = boundingRect.bottomRight();
+        
+        mCornerHandles[TopLeft]->setPos(topLeft);
+        mCornerHandles[TopRight]->setPos(topRight);
+        mCornerHandles[BottomLeft]->setPos(bottomLeft);
+        mCornerHandles[BottomRight]->setPos(bottomRight);
 
         // TODO: Might be nice to make it configurable
         mRotationOrigin = boundingRect.center();
         mRotationOriginIndicator->setPos(mRotationOrigin);
+        
+        // Resizing handles.
+        // If there is only one object seleced, align to its orientation.
+        if (items.size() == 1) {
+            QRectF itemRect = item->boundingRect().adjusted(1, 1, -1, -1);
+            
+            topLeft = item->mapToScene(itemRect.topLeft());
+            topRight = item->mapToScene(itemRect.topRight());
+            bottomLeft = item->mapToScene(itemRect.bottomLeft());
+            bottomRight = item->mapToScene(itemRect.bottomRight());
+        }
+        
+        QPointF top = (topLeft + topRight) / 2;
+        QPointF left = (topLeft + bottomLeft) / 2;
+        QPointF right = (topRight + bottomRight) / 2;
+        QPointF bottom = (bottomLeft + bottomRight) / 2;
+        
+        mResizeHandles[TopMiddle]->setPos(top);
+        mResizeHandles[TopMiddle]->setResizingOrigin(bottom);
+        mResizeHandles[CenterLeft]->setPos(left);
+        mResizeHandles[CenterLeft]->setResizingOrigin(right);
+        mResizeHandles[CenterRight]->setPos(right);
+        mResizeHandles[CenterRight]->setResizingOrigin(left);
+        mResizeHandles[BottomMiddle]->setPos(bottom);
+        mResizeHandles[BottomMiddle]->setResizingOrigin(top);
+        
+        mResizeHandles[TopLeft]->setPos(topLeft);
+        mResizeHandles[TopLeft]->setResizingOrigin(bottomRight);
+        mResizeHandles[TopRight]->setPos(topRight);
+        mResizeHandles[TopRight]->setResizingOrigin(bottomLeft);
+        mResizeHandles[BottomLeft]->setPos(bottomLeft);
+        mResizeHandles[BottomLeft]->setResizingOrigin(topRight);
+        mResizeHandles[BottomRight]->setPos(bottomRight);
+        mResizeHandles[BottomRight]->setResizingOrigin(topLeft);
     }
 
     mSelectionBoundingRect = boundingRect;
@@ -457,6 +588,8 @@ void ObjectSelectionTool::setHandlesVisible(bool visible)
 {
     for (int i = 0; i < 4; ++i)
         mCornerHandles[i]->setVisible(visible);
+    for (int i = 0; i < 8; ++i)
+        mResizeHandles[i]->setVisible(visible);
 }
 
 void ObjectSelectionTool::objectsRemoved(const QList<MapObject *> &objects)
@@ -548,25 +681,7 @@ void ObjectSelectionTool::updateMovingItems(const QPointF &pos,
     MapRenderer *renderer = mapDocument()->renderer();
     QPointF diff = pos - mStart;
 
-    bool snapToGrid = Preferences::instance()->snapToGrid();
-    bool snapToFineGrid = Preferences::instance()->snapToFineGrid();
-    if (modifiers & Qt::ControlModifier) {
-        snapToGrid = !snapToGrid;
-        snapToFineGrid = false;
-    }
-
-    if (snapToGrid || snapToFineGrid) {
-        int scale = snapToFineGrid ? Preferences::instance()->gridFine() : 1;
-        const QPointF alignScreenPos =
-                renderer->pixelToScreenCoords(mAlignPosition);
-        const QPointF newAlignPixelPos = alignScreenPos + diff;
-
-        // Snap the position to the grid
-        QPointF newTileCoords =
-                (renderer->screenToTileCoords(newAlignPixelPos) * scale).toPoint();
-        newTileCoords /= scale;
-        diff = renderer->tileToScreenCoords(newTileCoords) - alignScreenPos;
-    }
+    diff = snapToGrid(diff, modifiers);
 
     int i = 0;
     foreach (MapObjectItem *objectItem, mMovingItems) {
@@ -690,4 +805,177 @@ void ObjectSelectionTool::finishRotating(const QPointF &pos)
     mOldObjectPositions.clear();
     mOldObjectRotations.clear();
     mMovingItems.clear();
+}
+
+
+void ObjectSelectionTool::startResizing()
+{
+    mMovingItems = mapScene()->selectedObjectItems();
+    mMode = Resizing;
+
+    mResizingOrigin = mClickedResizeHandle->getResizingOrigin();
+    mResizingLimitHorizontal = mClickedResizeHandle->getResizingLimitHorizontal();
+    mResizingLimitVertical = mClickedResizeHandle->getResizingLimitVertical();
+
+    mStart = mClickedResizeHandle->pos();
+
+    // Remember the current object positions and sizes.
+    mOldObjectItemPositions.clear();
+    mOldObjectPositions.clear();
+    mOldObjectSizes.clear();
+
+    foreach (MapObjectItem *objectItem, mMovingItems) {
+        MapObject *object = objectItem->mapObject();
+        mOldObjectItemPositions += objectItem->pos();
+        mOldObjectPositions += object->position();
+        mOldObjectSizes += object->size();
+    }
+
+    setHandlesVisible(false);
+}
+
+void ObjectSelectionTool::updateResizingItems(const QPointF &pos,
+                                              Qt::KeyboardModifiers modifiers)
+{
+    MapRenderer *renderer = mapDocument()->renderer();
+    QPointF diff = pos - mResizingOrigin;
+    QPointF startDiff = mStart - mResizingOrigin;
+
+    diff = snapToGrid(diff, modifiers);
+
+    // Calculate the scaling factor.
+    qreal scale;
+    if (mResizingLimitHorizontal)
+        scale = qMax((qreal)0, diff.y() / startDiff.y());
+    else if (mResizingLimitVertical)
+        scale = qMax((qreal)0, diff.x() / startDiff.x());
+    else
+        scale = (qMax((qreal)0, diff.x() / startDiff.x())
+                + qMax((qreal)0, diff.y() / startDiff.y())) / 2;
+
+    int i = 0;
+    foreach (MapObjectItem *objectItem, mMovingItems) {
+        if (objectItem->mapObject()->polygon().isEmpty() == true) {
+            const QPointF oldRelPos = mOldObjectItemPositions.at(i) - mResizingOrigin;
+            const QPointF scaledRelPos(oldRelPos.x() * scale,
+                                       oldRelPos.y() * scale);
+            const QPointF newScreenPos = mResizingOrigin + scaledRelPos;
+            const QPointF newPos = renderer->screenToPixelCoords(newScreenPos);
+            const QSizeF origSize = mOldObjectSizes.at(i);
+            const QSizeF newSize(origSize.width() * scale,
+                                 origSize.height() * scale);
+
+            objectItem->resizeObject(newSize);
+            objectItem->setPos(newScreenPos);
+            objectItem->mapObject()->setPosition(newPos);
+        }
+
+        ++i;
+    }
+}
+
+void ObjectSelectionTool::updateResizingSingleItem(const QPointF &pos,
+                                                   Qt::KeyboardModifiers modifiers)
+{
+    MapObjectItem *objectItem = *mMovingItems.begin();
+    MapRenderer *renderer = mapDocument()->renderer();
+    QPointF diff = pos - mResizingOrigin;
+    QPointF startDiff = mStart - mResizingOrigin;
+
+    diff = snapToGrid(diff, modifiers);
+
+    // Most calculations in this function occur in object space, so 
+    // we transform the scaling factors from world space.
+    qreal rotation = objectItem->rotation() * M_PI / -180;
+    const qreal sn = std::sin(rotation);
+    const qreal cs = std::cos(rotation);
+
+    diff = QPointF(diff.x() * cs - diff.y() * sn, diff.x() * sn + diff.y() * cs);
+    startDiff = QPointF(startDiff.x() * cs - startDiff.y() * sn, startDiff.x() * sn + startDiff.y() * cs);
+
+    // Calculate scaling factor.
+    QSizeF scalingFactor(qMax((qreal)0, diff.x() / startDiff.x()),
+                         qMax((qreal)0, diff.y() / startDiff.y()));
+
+    if (mResizingLimitHorizontal)
+        scalingFactor.setWidth(1);
+    if (mResizingLimitVertical)
+        scalingFactor.setHeight(1);
+
+    if (objectItem->mapObject()->polygon().isEmpty() == true) {
+        // Convert relative position into object space, scale,
+        // and then convert back to world space.
+        const QPointF oldRelPos = mOldObjectItemPositions.at(0) - mResizingOrigin;
+        const QPointF objectRelPos(oldRelPos.x() * cs - oldRelPos.y() * sn,
+                                   oldRelPos.x() * sn + oldRelPos.y() * cs);
+        const QPointF scaledRelPos(objectRelPos.x() * scalingFactor.width(),
+                                   objectRelPos.y() * scalingFactor.height());
+        const QPointF newRelPos(scaledRelPos.x() * cs + scaledRelPos.y() * sn,
+                                scaledRelPos.x() * -sn + scaledRelPos.y() * cs);
+        const QPointF newScreenPos = mResizingOrigin + newRelPos;
+        const QPointF newPos = renderer->screenToPixelCoords(newScreenPos);
+        const QSizeF origSize = mOldObjectSizes.at(0);
+        const QSizeF newSize(origSize.width() * scalingFactor.width(),
+                             origSize.height() * scalingFactor.height());
+        
+        objectItem->resizeObject(newSize);
+        objectItem->setPos(newScreenPos);
+        objectItem->mapObject()->setPosition(newPos);
+    }
+}
+
+void ObjectSelectionTool::finishResizing(const QPointF &pos)
+{
+    Q_ASSERT(mMode == Resizing);
+    mMode = NoMode;
+    updateHandles();
+
+    if (mStart == pos) // No scaling at all
+        return;
+
+    QUndoStack *undoStack = mapDocument()->undoStack();
+    undoStack->beginMacro(tr("Resize %n Object(s)", "", mMovingItems.size()));
+    int i = 0;
+    foreach (MapObjectItem *objectItem, mMovingItems) {
+        MapObject *object = objectItem->mapObject();
+        const QPointF oldPos = mOldObjectPositions.at(i);
+        const QSizeF oldSize = mOldObjectSizes.at(i);
+        undoStack->push(new MoveMapObject(mapDocument(), object, oldPos));
+        undoStack->push(new ResizeMapObject(mapDocument(), object, oldSize));
+        ++i;
+    }
+    undoStack->endMacro();
+
+    mOldObjectItemPositions.clear();
+    mOldObjectPositions.clear();
+    mOldObjectSizes.clear();
+    mMovingItems.clear();
+}
+
+const QPointF ObjectSelectionTool::snapToGrid(const QPointF &pos,
+                                              Qt::KeyboardModifiers modifiers)
+{
+    bool snapToGrid = Preferences::instance()->snapToGrid();
+    bool snapToFineGrid = Preferences::instance()->snapToFineGrid();
+    if (modifiers & Qt::ControlModifier) {
+        snapToGrid = !snapToGrid;
+        snapToFineGrid = false;
+    }
+
+    if (snapToGrid || snapToFineGrid) {
+        MapRenderer *renderer = mapDocument()->renderer();
+        int scale = snapToFineGrid ? Preferences::instance()->gridFine() : 1;
+        const QPointF alignPixelPos =
+                renderer->tileToPixelCoords(mAlignPosition);
+        const QPointF newAlignPixelPos = alignPixelPos + pos;
+
+        // Snap the position to the grid
+        QPointF newTileCoords =
+                (renderer->pixelToTileCoords(newAlignPixelPos) * scale).toPoint();
+        newTileCoords /= scale;
+        
+        return renderer->tileToPixelCoords(newTileCoords) - alignPixelPos;
+    }
+    
+    return pos;
 }

--- a/src/tiled/objectselectiontool.cpp
+++ b/src/tiled/objectselectiontool.cpp
@@ -989,7 +989,7 @@ void ObjectSelectionTool::finishResizing(const QPointF &pos)
     mMovingItems.clear();
 }
 
-const QPointF ObjectSelectionTool::snapToGrid(const QPointF &pos,
+const QPointF ObjectSelectionTool::snapToGrid(const QPointF &diff,
                                               Qt::KeyboardModifiers modifiers)
 {
     bool snapToGrid = Preferences::instance()->snapToGrid();
@@ -998,21 +998,21 @@ const QPointF ObjectSelectionTool::snapToGrid(const QPointF &pos,
         snapToGrid = !snapToGrid;
         snapToFineGrid = false;
     }
-
+    
     if (snapToGrid || snapToFineGrid) {
         MapRenderer *renderer = mapDocument()->renderer();
         int scale = snapToFineGrid ? Preferences::instance()->gridFine() : 1;
-        const QPointF alignPixelPos =
-                renderer->tileToPixelCoords(mAlignPosition);
-        const QPointF newAlignPixelPos = alignPixelPos + pos;
+        const QPointF alignScreenPos =
+                renderer->pixelToScreenCoords(mAlignPosition);
+        const QPointF newAlignScreenPos = alignScreenPos + diff;
 
         // Snap the position to the grid
         QPointF newTileCoords =
-                (renderer->pixelToTileCoords(newAlignPixelPos) * scale).toPoint();
+                (renderer->screenToTileCoords(newAlignScreenPos) * scale).toPoint();
         newTileCoords /= scale;
         
-        return renderer->tileToPixelCoords(newTileCoords) - alignPixelPos;
+        return renderer->tileToScreenCoords(newTileCoords) - alignScreenPos;
     }
     
-    return pos;
+    return diff;
 }

--- a/src/tiled/objectselectiontool.cpp
+++ b/src/tiled/objectselectiontool.cpp
@@ -944,7 +944,7 @@ void ObjectSelectionTool::updateResizingSingleItem(const QPointF &pos,
             const QPointF point(oldPolygon[n]);
             const QPointF newPoint(point.x() * scalingFactor.width(),
                                    point.y() * scalingFactor.height());
-            newPolygon += newPoint;
+            newPolygon[n] = newPoint;
         }
         objectItem->mapObject()->setPolygon(newPolygon);
     }

--- a/src/tiled/objectselectiontool.cpp
+++ b/src/tiled/objectselectiontool.cpp
@@ -867,12 +867,20 @@ void ObjectSelectionTool::updateResizingItems(const QPointF &pos,
                              origSize.height() * scale);
         
         if (objectItem->mapObject()->polygon().isEmpty() == false) {
-            const QPolygonF &oldPolygon = mOldObjectPolygons.at(0);
+            // For polygons, we have to scale in object space.
+            qreal rotation = objectItem->rotation() * M_PI / -180;
+            const qreal sn = std::sin(rotation);
+            const qreal cs = std::cos(rotation);
+            
+            const QPolygonF &oldPolygon = mOldObjectPolygons.at(i);
             QPolygonF newPolygon(oldPolygon.size());
             for (int n = 0; n < oldPolygon.size(); ++n) {
-                const QPointF point(oldPolygon[n]);
-                const QPointF newPoint(point.x() * scale,
-                                       point.y() * scale);
+                const QPointF oldPoint(oldPolygon[n]);
+                const QPointF rotPoint(oldPoint.x() * cs + oldPoint.y() * sn,
+                                       oldPoint.y() * cs - oldPoint.x() * sn);
+                const QPointF scaledPoint(rotPoint.x() * scale, rotPoint.y() * scale);
+                const QPointF newPoint(scaledPoint.x() * cs - scaledPoint.y() * sn,
+                                       scaledPoint.y() * cs + scaledPoint.x() * sn);
                 newPolygon += newPoint;
             }
             objectItem->mapObject()->setPolygon(newPolygon);

--- a/src/tiled/objectselectiontool.h
+++ b/src/tiled/objectselectiontool.h
@@ -108,6 +108,7 @@ private:
     QVector<QPointF> mOldObjectItemPositions;
     QVector<QPointF> mOldObjectPositions;
     QVector<QSizeF> mOldObjectSizes;
+    QVector<QPolygonF> mOldObjectPolygons;
     QVector<qreal> mOldObjectRotations;
     QPointF mAlignPosition;
     QRectF mSelectionBoundingRect;

--- a/src/tiled/objectselectiontool.h
+++ b/src/tiled/objectselectiontool.h
@@ -31,6 +31,7 @@ namespace Tiled {
 namespace Internal {
 
 class CornerHandle;
+class ResizeHandle;
 class MapObjectItem;
 class SelectionRectangle;
 
@@ -66,7 +67,8 @@ private:
         NoMode,
         Selecting,
         Moving,
-        Rotating
+        Rotating,
+        Resizing
     };
 
     void updateSelection(const QPointF &pos,
@@ -84,19 +86,35 @@ private:
                              Qt::KeyboardModifiers modifiers);
     void finishRotating(const QPointF &pos);
 
+    void startResizing();
+    void updateResizingSingleItem(const QPointF &pos,
+                                  Qt::KeyboardModifiers modifiers);
+    void updateResizingItems(const QPointF &pos,
+                             Qt::KeyboardModifiers modifiers);
+    void finishResizing(const QPointF &pos);
+    
+    const QPointF snapToGrid(const QPointF &pos,
+                             Qt::KeyboardModifiers modifiers);
+
     SelectionRectangle *mSelectionRectangle;
     QGraphicsItem *mRotationOriginIndicator;
     CornerHandle *mCornerHandles[4];
+    ResizeHandle *mResizeHandles[8];
     bool mMousePressed;
     MapObjectItem *mClickedObjectItem;
     CornerHandle *mClickedCornerHandle;
+    ResizeHandle *mClickedResizeHandle;
     QSet<MapObjectItem*> mMovingItems;
     QVector<QPointF> mOldObjectItemPositions;
     QVector<QPointF> mOldObjectPositions;
+    QVector<QSizeF> mOldObjectSizes;
     QVector<qreal> mOldObjectRotations;
     QPointF mAlignPosition;
     QRectF mSelectionBoundingRect;
     QPointF mRotationOrigin;
+    QPointF mResizingOrigin;
+    bool mResizingLimitHorizontal;
+    bool mResizingLimitVertical;
     Mode mMode;
     QPointF mStart;
     QPoint mScreenStart;


### PR DESCRIPTION
Depends on pull requests #591 and #592, so you might want to get through them first to make the comparison less unsightly. Replaces pull #485. Does the following:

- Map renderer supports scaling of cells.
- Map reader and object tile creation will initialize the size of the object to the tile's size.
- Removed handles from mapobjectitem.cpp.
- In objectselectiontool.cpp, added a set of 8 ResizeHandles, and changed the Corner enum to AnchorPosition, representing the edge centers as well.
- When a single object is selected, resizing is handled in object space.
- When multiple objects are selected, resizing is handled in world space.

Caveats:
- Negative scaling factors are not allowed.


<!---
@huboard:{"order":876.0,"milestone_order":593,"custom_state":""}
-->
