### PR TITLE
Adjustable tilelayer horizontal and vertical pixel offset

### DIFF
--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -192,7 +192,7 @@ void IsometricRenderer::drawTileLayer(QPainter *painter,
     QPointF tilePos = screenToTileCoords(rect.x(), rect.y());
     QPoint rowItr = QPoint((int) std::floor(tilePos.x()),
                            (int) std::floor(tilePos.y()));
-    QPointF startPos = tileToScreenCoords(rowItr);
+    QPointF startPos = tileToScreenCoords(rowItr, layer);
     startPos.rx() -= tileWidth / 2;
     startPos.ry() += tileHeight;
 

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -42,12 +42,22 @@ QSize IsometricRenderer::mapSize() const
 {
     // Map width and height contribute equally in both directions
     const int side = map()->height() + map()->width();
+    const int tileWidth = map()->tileWidth();
+    const int tileHeight = map()->tileHeight();
     const QMargins offset = map()->offset();
-    const QSize padding = QSize(offset.left() + offset.right(),
-                                offset.top() + offset.bottom());
+    const QMargins margins = map()->drawMargins();
 
-    return padding + QSize(side * map()->tileWidth() / 2,
-                           side * map()->tileHeight() / 2);
+    const QSize padding = QSize(offset.left() + offset.right() +
+                                qMax(0,
+                                     margins.left() + margins.right() -
+                                     tileWidth / 2),
+                                offset.top() + offset.bottom() +
+                                qMax(0,
+                                     margins.top() + margins.bottom() -
+                                     tileHeight / 2));
+
+    return padding + QSize(side * tileWidth / 2,
+                           side * tileHeight / 2);
 }
 
 QRect IsometricRenderer::boundingRect(const QRect &rect) const

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -42,7 +42,7 @@ QSize IsometricRenderer::mapSize() const
 {
     // Map width and height contribute equally in both directions
     const int side = map()->height() + map()->width();
-    const QMargins offset = tileLayersOffset();
+    const QMargins offset = map()->offset();
     const QSize padding = QSize(offset.left() + offset.right(),
                                 offset.top() + offset.bottom());
 

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -42,8 +42,12 @@ QSize IsometricRenderer::mapSize() const
 {
     // Map width and height contribute equally in both directions
     const int side = map()->height() + map()->width();
-    return QSize(side * map()->tileWidth() / 2,
-                 side * map()->tileHeight() / 2);
+    const QMargins offset = tileLayersOffset();
+    const QSize padding = QSize(offset.left() + offset.right(),
+                                offset.top() + offset.bottom());
+
+    return padding + QSize(side * map()->tileWidth() / 2,
+                           side * map()->tileHeight() / 2);
 }
 
 QRect IsometricRenderer::boundingRect(const QRect &rect) const

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -193,7 +193,7 @@ void IsometricRenderer::drawTileLayer(QPainter *painter,
 
     QRect rect = exposed.toAlignedRect();
     if (rect.isNull())
-        rect = boundingRect(layer->bounds());
+        rect = boundingRect(layer);
 
     QMargins drawMargins = layer->drawMargins();
     drawMargins.setTop(drawMargins.top() - tileHeight);

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -175,6 +175,7 @@ void IsometricRenderer::drawTileLayer(QPainter *painter,
 {
     const int tileWidth = map()->tileWidth();
     const int tileHeight = map()->tileHeight();
+    const QMargins mapOffset = map()->offset();
 
     if (tileWidth <= 0 || tileHeight <= 1)
         return;
@@ -184,16 +185,14 @@ void IsometricRenderer::drawTileLayer(QPainter *painter,
         rect = boundingRect(layer->bounds());
 
     QMargins drawMargins = layer->drawMargins();
-    drawMargins.setTop(drawMargins.top() - tileHeight);
-    drawMargins.setRight(drawMargins.right() - tileWidth);
 
     rect.adjust(-drawMargins.right(),
                 -drawMargins.bottom(),
-                drawMargins.left(),
-                drawMargins.top());
+                drawMargins.left() + mapOffset.left() + mapOffset.right(),
+                drawMargins.top() + mapOffset.top() + mapOffset.bottom());
 
     // Determine the tile and pixel coordinates to start at
-    QPointF tilePos = screenToTileCoords(rect.x(), rect.y());
+    QPointF tilePos = screenToTileCoords(rect.x(), rect.y(), layer);
     QPoint rowItr = QPoint((int) std::floor(tilePos.x()),
                            (int) std::floor(tilePos.y()));
     QPointF startPos = tileToScreenCoords(rowItr, layer);

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -134,14 +134,23 @@ QPainterPath IsometricRenderer::shape(const MapObject *object) const
 }
 
 void IsometricRenderer::drawGrid(QPainter *painter, const QRectF &rect,
-                                 QColor gridColor) const
+                                 const Layer* layer, QColor gridColor) const
 {
     const int tileWidth = map()->tileWidth();
     const int tileHeight = map()->tileHeight();
+    const QMargins mapOffset = map()->offset();
+    QMargins layerOffset;
+
+    if (layer->isTileLayer())
+        layerOffset = static_cast<const TileLayer*>(layer)->layerOffset();
+    else
+        layerOffset = QMargins();
 
     QRect r = rect.toAlignedRect();
-    r.adjust(-tileWidth / 2, -tileHeight / 2,
-             tileWidth / 2, tileHeight / 2);
+    r.adjust(-tileWidth / 2 - mapOffset.right() + layerOffset.right(),
+             -tileHeight / 2 - mapOffset.bottom() + layerOffset.bottom(),
+             tileWidth / 2 + mapOffset.left() + layerOffset.left(),
+             tileHeight / 2 + mapOffset.top() + layerOffset.top());
 
     const int startX = qMax(qreal(0), screenToTileCoords(r.topLeft()).x());
     const int startY = qMax(qreal(0), screenToTileCoords(r.topRight()).y());
@@ -158,13 +167,13 @@ void IsometricRenderer::drawGrid(QPainter *painter, const QRectF &rect,
     painter->setPen(gridPen);
 
     for (int y = startY; y <= endY; ++y) {
-        const QPointF start = tileToScreenCoords(startX, y);
-        const QPointF end = tileToScreenCoords(endX, y);
+        const QPointF start = tileToScreenCoords(startX, y, layer);
+        const QPointF end = tileToScreenCoords(endX, y, layer);
         painter->drawLine(start, end);
     }
     for (int x = startX; x <= endX; ++x) {
-        const QPointF start = tileToScreenCoords(x, startY);
-        const QPointF end = tileToScreenCoords(x, endY);
+        const QPointF start = tileToScreenCoords(x, startY, layer);
+        const QPointF end = tileToScreenCoords(x, endY, layer);
         painter->drawLine(start, end);
     }
 }

--- a/src/libtiled/isometricrenderer.h
+++ b/src/libtiled/isometricrenderer.h
@@ -49,6 +49,7 @@ public:
 
     QRect boundingRect(const QRect &rect) const;
 
+    using MapRenderer::boundingRect;
     QRectF boundingRect(const MapObject *object) const;
     QPainterPath shape(const MapObject *object) const;
 

--- a/src/libtiled/isometricrenderer.h
+++ b/src/libtiled/isometricrenderer.h
@@ -61,7 +61,8 @@ public:
     void drawTileSelection(QPainter *painter,
                            const QRegion &region,
                            const QColor &color,
-                           const QRectF &exposed) const;
+                           const QRectF &exposed,
+                           const TileLayer* layer) const;
 
     void drawMapObject(QPainter *painter,
                        const MapObject *object,
@@ -87,7 +88,8 @@ public:
 
 private:
     QPolygonF pixelRectToScreenPolygon(const QRectF &rect) const;
-    QPolygonF tileRectToScreenPolygon(const QRect &rect) const;
+    QPolygonF tileRectToScreenPolygon(const QRect &rect,
+                                      const TileLayer* layer) const;
 };
 
 } // namespace Tiled

--- a/src/libtiled/isometricrenderer.h
+++ b/src/libtiled/isometricrenderer.h
@@ -52,7 +52,8 @@ public:
     QRectF boundingRect(const MapObject *object) const;
     QPainterPath shape(const MapObject *object) const;
 
-    void drawGrid(QPainter *painter, const QRectF &rect, QColor grid) const;
+    void drawGrid(QPainter *painter, const QRectF &rect, const Layer* layer, 
+                  QColor grid) const;
 
     void drawTileLayer(QPainter *painter, const TileLayer *layer,
                        const QRectF &exposed = QRectF()) const;

--- a/src/libtiled/map.cpp
+++ b/src/libtiled/map.cpp
@@ -110,6 +110,20 @@ void Map::recomputeDrawMargins()
             tileLayer->recomputeDrawMargins();
 }
 
+void Map::adjustOffset(const QMargins &offset)
+{
+    mOffset = maxMargins(offset, mOffset);
+}
+
+void Map::recomputeOffset()
+{
+    mOffset = QMargins();
+
+    foreach (Layer *layer, mLayers)
+        if (TileLayer *tileLayer = layer->asTileLayer())
+            adjustOffset(tileLayer->layerOffset());
+}
+
 int Map::layerCount(Layer::TypeFlag type) const
 {
     int count = 0;
@@ -172,8 +186,10 @@ void Map::adoptLayer(Layer *layer)
 {
     layer->setMap(this);
 
-    if (TileLayer *tileLayer = layer->asTileLayer())
+    if (TileLayer *tileLayer = layer->asTileLayer()) {
         adjustDrawMargins(tileLayer->drawMargins());
+        adjustOffset(tileLayer->layerOffset());
+    }
 }
 
 Layer *Map::takeLayerAt(int index)

--- a/src/libtiled/map.h
+++ b/src/libtiled/map.h
@@ -172,6 +172,24 @@ public:
     void recomputeDrawMargins();
 
     /**
+     * Adjusts the map offset to be at least as big as the given offset.
+     * Called when a new layer is added to the map.
+     */
+    void adjustOffset(const QMargins &offset);
+
+    /**
+     * Returns the offset of the map which is calculated in base at all the
+     * offsets aplied to each tile layer.
+     */
+    QMargins offset() const { return mOffset; }
+
+    /**
+     * Recomputes the offset of the map. Needed when a layer offset gets 
+     * changed.
+     */
+    void recomputeOffset();
+
+    /**
      * Returns the number of layers of this map.
      */
     int layerCount() const
@@ -327,6 +345,7 @@ private:
     int mTileHeight;
     QColor mBackgroundColor;
     QMargins mDrawMargins;
+    QMargins mOffset;
     QList<Layer*> mLayers;
     QList<Tileset*> mTilesets;
     LayerDataFormat mLayerDataFormat;

--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -541,8 +541,8 @@ TileLayer *MapReaderPrivate::readLayer()
     TileLayer *tileLayer = new TileLayer(name, x, y, width, height);
     readLayerAttributes(tileLayer, atts);
 
-    const QStringRef horizontalOffsetRef = atts.value(QLatin1String("horizontalOffset"));
-    const QStringRef verticalOffsetRef = atts.value(QLatin1String("verticalOffset"));
+    const QStringRef horizontalOffsetRef = atts.value(QLatin1String("horizontaloffset"));
+    const QStringRef verticalOffsetRef = atts.value(QLatin1String("verticaloffset"));
 
     bool ok;
     const int horizontalOffset = horizontalOffsetRef.toString().toInt(&ok);

--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -541,6 +541,18 @@ TileLayer *MapReaderPrivate::readLayer()
     TileLayer *tileLayer = new TileLayer(name, x, y, width, height);
     readLayerAttributes(tileLayer, atts);
 
+    const QStringRef horizontalOffsetRef = atts.value(QLatin1String("horizontalOffset"));
+    const QStringRef verticalOffsetRef = atts.value(QLatin1String("verticalOffset"));
+
+    bool ok;
+    const int horizontalOffset = horizontalOffsetRef.toString().toInt(&ok);
+    if (ok)
+        tileLayer->setHorizontalOffset(horizontalOffset);
+
+    const int verticalOffset = verticalOffsetRef.toString().toInt(&ok);
+    if (ok)
+        tileLayer->setVerticalOffset(verticalOffset);
+
     while (xml.readNextStartElement()) {
         if (xml.name() == QLatin1String("properties"))
             tileLayer->mergeProperties(readProperties());

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -55,10 +55,21 @@ void MapRenderer::drawImageLayer(QPainter *painter,
                         imageLayer->image());
 }
 
+QPointF MapRenderer::screenToTileCoords(qreal x, qreal y, const TileLayer* layer) const 
+{
+    QMargins mapOffset = mMap->offset();
+
+    return screenToTileCoords(x + layer->horizontalOffset() - mapOffset.right(),
+                              y + layer->verticalOffset() - mapOffset.top());
+}
+
 QPointF MapRenderer::tileToScreenCoords(qreal x, qreal y, const TileLayer* layer) const 
 {
+    QMargins mapOffset = mMap->offset();
     QPointF base = tileToScreenCoords(x, y);
-    return base - QPointF(layer->horizontalOffset(), layer->verticalOffset());
+
+    return base + QPointF(mapOffset.right(), mapOffset.top()) - 
+                  QPointF(layer->horizontalOffset(), layer->verticalOffset());
 }
 
 

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -39,10 +39,34 @@
 
 using namespace Tiled;
 
+QRectF MapRenderer::boundingRect(const QRect &rect, const Layer *layer) const
+{
+    const QMargins mapOffset = map()->offset();
+    int horizontalOffset = mapOffset.left();
+    int verticalOffset = mapOffset.top();
+
+    if (layer->isTileLayer()) {
+        const TileLayer* tileLayer = static_cast<const TileLayer*>(layer);
+        horizontalOffset +=  tileLayer->horizontalOffset();
+        verticalOffset -= tileLayer->verticalOffset();
+    }
+
+    QRect bounds = boundingRect(rect);
+    bounds.adjust(horizontalOffset, verticalOffset,
+                  horizontalOffset, verticalOffset);
+
+    return bounds;
+}
+
 QRectF MapRenderer::boundingRect(const ImageLayer *imageLayer) const
 {
     return QRectF(imageLayer->position(),
                   imageLayer->image().size());
+}
+
+QRectF MapRenderer::boundingRect(const TileLayer *tileLayer) const
+{
+    return boundingRect(tileLayer->bounds(), tileLayer);
 }
 
 void MapRenderer::drawImageLayer(QPainter *painter,

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -39,28 +39,6 @@
 
 using namespace Tiled;
 
-QMargins MapRenderer::tileLayersOffset() const {
-    int maxVerticalOffset = 0;
-    int maxHorizontalOffset = 0;
-    int minHorizontalOffset = 0;
-    int minVerticalOffset = 0;
-
-    foreach (TileLayer* layer, mMap->tileLayers()) {
-        if (layer->horizontalOffset() > maxHorizontalOffset)
-            maxHorizontalOffset = layer->horizontalOffset();
-        else if (layer->horizontalOffset() < minHorizontalOffset)
-            minHorizontalOffset = layer->horizontalOffset();
-
-        if (layer->verticalOffset() > maxVerticalOffset)
-            maxVerticalOffset = layer->verticalOffset();
-        else if (layer->verticalOffset() < minVerticalOffset)
-            minVerticalOffset = layer->verticalOffset();
-    }
-
-    return QMargins(-minHorizontalOffset, maxVerticalOffset,
-                    maxHorizontalOffset, -minVerticalOffset);
-}
-
 QRectF MapRenderer::boundingRect(const ImageLayer *imageLayer) const
 {
     return QRectF(imageLayer->position(),

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -57,26 +57,29 @@ void MapRenderer::drawImageLayer(QPainter *painter,
 
 QPointF MapRenderer::screenToTileCoords(qreal x, qreal y, const Layer* layer) const 
 {
+    QMargins mapOffset = mMap->offset();
+    x -= mapOffset.right();
+    y -= mapOffset.top();
+
     if (layer->isTileLayer()) {
         const TileLayer* tileLayer = static_cast<const TileLayer*>(layer);
-        QMargins mapOffset = mMap->offset();
+        x += tileLayer->horizontalOffset();
+        y += tileLayer->verticalOffset();
+    } 
 
-        return screenToTileCoords(x + tileLayer->horizontalOffset() - mapOffset.right(),
-                                  y + tileLayer->verticalOffset() - mapOffset.top());
-    } else
-        return screenToTileCoords(x, y);
+    return screenToTileCoords(x, y);
 }
 
 QPointF MapRenderer::tileToScreenCoords(qreal x, qreal y, const Layer* layer) const 
 {
-    QPointF position = tileToScreenCoords(x, y);
+    QMargins mapOffset = mMap->offset();
+    QPointF position = tileToScreenCoords(x, y) +
+                       QPointF(mapOffset.right(), mapOffset.top());
 
     if (layer->isTileLayer()) {
         const TileLayer* tileLayer = static_cast<const TileLayer*>(layer);
-        QMargins mapOffset = mMap->offset();
 
-        position = position + QPointF(mapOffset.right(), mapOffset.top()) - 
-                              QPointF(tileLayer->horizontalOffset(),
+        position = position - QPointF(tileLayer->horizontalOffset(),
                                       tileLayer->verticalOffset());
     }
 

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -54,6 +54,13 @@ void MapRenderer::drawImageLayer(QPainter *painter,
                         imageLayer->image());
 }
 
+QPointF MapRenderer::tileToScreenCoords(qreal x, qreal y, const TileLayer* layer) const 
+{
+    QPointF base = tileToScreenCoords(x, y);
+    return base - QPointF(layer->horizontalOffset(), layer->verticalOffset());
+}
+
+
 void MapRenderer::setFlag(RenderFlag flag, bool enabled)
 {
     if (enabled)

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -55,23 +55,33 @@ void MapRenderer::drawImageLayer(QPainter *painter,
                         imageLayer->image());
 }
 
-QPointF MapRenderer::screenToTileCoords(qreal x, qreal y, const TileLayer* layer) const 
+QPointF MapRenderer::screenToTileCoords(qreal x, qreal y, const Layer* layer) const 
 {
-    QMargins mapOffset = mMap->offset();
+    if (layer->isTileLayer()) {
+        const TileLayer* tileLayer = static_cast<const TileLayer*>(layer);
+        QMargins mapOffset = mMap->offset();
 
-    return screenToTileCoords(x + layer->horizontalOffset() - mapOffset.right(),
-                              y + layer->verticalOffset() - mapOffset.top());
+        return screenToTileCoords(x + tileLayer->horizontalOffset() - mapOffset.right(),
+                                  y + tileLayer->verticalOffset() - mapOffset.top());
+    } else
+        return screenToTileCoords(x, y);
 }
 
-QPointF MapRenderer::tileToScreenCoords(qreal x, qreal y, const TileLayer* layer) const 
+QPointF MapRenderer::tileToScreenCoords(qreal x, qreal y, const Layer* layer) const 
 {
-    QMargins mapOffset = mMap->offset();
-    QPointF base = tileToScreenCoords(x, y);
+    QPointF position = tileToScreenCoords(x, y);
 
-    return base + QPointF(mapOffset.right(), mapOffset.top()) - 
-                  QPointF(layer->horizontalOffset(), layer->verticalOffset());
+    if (layer->isTileLayer()) {
+        const TileLayer* tileLayer = static_cast<const TileLayer*>(layer);
+        QMargins mapOffset = mMap->offset();
+
+        position = position + QPointF(mapOffset.right(), mapOffset.top()) - 
+                              QPointF(tileLayer->horizontalOffset(),
+                                      tileLayer->verticalOffset());
+    }
+
+    return position;
 }
-
 
 void MapRenderer::setFlag(RenderFlag flag, bool enabled)
 {

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -39,7 +39,7 @@
 
 using namespace Tiled;
 
-QRectF MapRenderer::boundingRect(const QRect &rect, const Layer *layer) const
+QRect MapRenderer::boundingRect(const QRect &rect, const Layer *layer) const
 {
     const QMargins mapOffset = map()->offset();
     int horizontalOffset = mapOffset.left();
@@ -64,7 +64,7 @@ QRectF MapRenderer::boundingRect(const ImageLayer *imageLayer) const
                   imageLayer->image().size());
 }
 
-QRectF MapRenderer::boundingRect(const TileLayer *tileLayer) const
+QRect MapRenderer::boundingRect(const TileLayer *tileLayer) const
 {
     return boundingRect(tileLayer->bounds(), tileLayer);
 }

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -28,6 +28,7 @@
 
 #include "maprenderer.h"
 
+#include "map.h"
 #include "imagelayer.h"
 #include "tile.h"
 #include "tilelayer.h"
@@ -37,6 +38,28 @@
 #include <QVector2D>
 
 using namespace Tiled;
+
+QMargins MapRenderer::tileLayersOffset() const {
+    int maxVerticalOffset = 0;
+    int maxHorizontalOffset = 0;
+    int minHorizontalOffset = 0;
+    int minVerticalOffset = 0;
+
+    foreach (TileLayer* layer, mMap->tileLayers()) {
+        if (layer->horizontalOffset() > maxHorizontalOffset)
+            maxHorizontalOffset = layer->horizontalOffset();
+        else if (layer->horizontalOffset() < minHorizontalOffset)
+            minHorizontalOffset = layer->horizontalOffset();
+
+        if (layer->verticalOffset() > maxVerticalOffset)
+            maxVerticalOffset = layer->verticalOffset();
+        else if (layer->verticalOffset() < minVerticalOffset)
+            minVerticalOffset = layer->verticalOffset();
+    }
+
+    return QMargins(-minHorizontalOffset, maxVerticalOffset,
+                    maxHorizontalOffset, -minVerticalOffset);
+}
 
 QRectF MapRenderer::boundingRect(const ImageLayer *imageLayer) const
 {

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -58,12 +58,12 @@ void MapRenderer::drawImageLayer(QPainter *painter,
 QPointF MapRenderer::screenToTileCoords(qreal x, qreal y, const Layer* layer) const 
 {
     QMargins mapOffset = mMap->offset();
-    x -= mapOffset.right();
+    x -= mapOffset.left();
     y -= mapOffset.top();
 
     if (layer->isTileLayer()) {
         const TileLayer* tileLayer = static_cast<const TileLayer*>(layer);
-        x += tileLayer->horizontalOffset();
+        x -= tileLayer->horizontalOffset();
         y += tileLayer->verticalOffset();
     } 
 
@@ -74,12 +74,12 @@ QPointF MapRenderer::tileToScreenCoords(qreal x, qreal y, const Layer* layer) co
 {
     QMargins mapOffset = mMap->offset();
     QPointF position = tileToScreenCoords(x, y) +
-                       QPointF(mapOffset.right(), mapOffset.top());
+                       QPointF(mapOffset.left(), mapOffset.top());
 
     if (layer->isTileLayer()) {
         const TileLayer* tileLayer = static_cast<const TileLayer*>(layer);
 
-        position = position - QPointF(tileLayer->horizontalOffset(),
+        position = position - QPointF(-tileLayer->horizontalOffset(),
                                       tileLayer->verticalOffset());
     }
 

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -84,7 +84,7 @@ public:
      * Returns the bounding rectangle in pixels of the given \a rect, taking
      * into account the possible offset applied to the \a layer.
      */
-    QRectF boundingRect(const QRect &rect, const Layer *layer) const;
+    QRect boundingRect(const QRect &rect, const Layer *layer) const;
 
     /**
      * Returns the bounding rectangle in pixels of the given \a object, as it
@@ -102,7 +102,7 @@ public:
      * Returns the bounding rectangle in pixels of the given \a tileLayer, as
      * it would be drawn by drawTileLayer().
      */
-    QRectF boundingRect(const TileLayer *tileLayer) const;
+    QRect boundingRect(const TileLayer *tileLayer) const;
 
     /**
      * Returns the shape in pixels of the given \a object. This is used for

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -67,12 +67,6 @@ public:
     virtual ~MapRenderer() {}
 
     /**
-     * Returns the size in pixels of the max offset within all the tile layers
-     * defined on this renderer map.
-     */
-    QMargins tileLayersOffset() const;
-
-    /**
      * Returns the size in pixels of the map associated with this renderer.
      */
     virtual QSize mapSize() const = 0;

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -81,6 +81,12 @@ public:
     virtual QRect boundingRect(const QRect &rect) const = 0;
 
     /**
+     * Returns the bounding rectangle in pixels of the given \a rect, taking
+     * into account the possible offset applied to the \a layer.
+     */
+    QRectF boundingRect(const QRect &rect, const Layer *layer) const;
+
+    /**
      * Returns the bounding rectangle in pixels of the given \a object, as it
      * would be drawn by drawMapObject().
      */
@@ -91,6 +97,12 @@ public:
      * it would be drawn by drawImageLayer().
      */
     QRectF boundingRect(const ImageLayer *imageLayer) const;
+
+    /**
+     * Returns the bounding rectangle in pixels of the given \a tileLayer, as
+     * it would be drawn by drawTileLayer().
+     */
+    QRectF boundingRect(const TileLayer *tileLayer) const;
 
     /**
      * Returns the shape in pixels of the given \a object. This is used for

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -174,9 +174,9 @@ public:
      * Returns the tile coordinates matching the given screen position for the
      * given layer (which may be offeseted).
      */
-    QPointF screenToTileCoords(qreal x, qreal y, const TileLayer* layer) const;
+    QPointF screenToTileCoords(qreal x, qreal y, const Layer* layer) const;
 
-    inline QPointF screenToTileCoords(const QPointF &point, const TileLayer* layer) const
+    inline QPointF screenToTileCoords(const QPointF &point, const Layer* layer) const
     { return tileToScreenCoords(point.x(), point.y(), layer); }
 
     /**
@@ -191,9 +191,9 @@ public:
      * Returns the screen position matching the given tile coordinates for the
      * given layer (which may be offeseted).
      */
-    QPointF tileToScreenCoords(qreal x, qreal y, const TileLayer* layer) const;
+    QPointF tileToScreenCoords(qreal x, qreal y, const Layer* layer) const;
 
-    inline QPointF tileToScreenCoords(const QPointF &point, const TileLayer* layer) const
+    inline QPointF tileToScreenCoords(const QPointF &point, const Layer* layer) const
     { return tileToScreenCoords(point.x(), point.y(), layer); }
 
     /**

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -67,6 +67,12 @@ public:
     virtual ~MapRenderer() {}
 
     /**
+     * Returns the size in pixels of the max offset within all the tile layers
+     * defined on this renderer map.
+     */
+    QMargins tileLayersOffset() const;
+
+    /**
      * Returns the size in pixels of the map associated with this renderer.
      */
     virtual QSize mapSize() const = 0;
@@ -178,6 +184,10 @@ public:
     inline QPointF screenToTileCoords(const QPointF &point) const
     { return screenToTileCoords(point.x(), point.y()); }
 
+    /**
+     * Returns the tile coordinates matching the given screen position for the
+     * given layer (which may be offeseted).
+     */
     QPointF tileToScreenCoords(qreal x, qreal y, const TileLayer* layer) const;
 
     inline QPointF tileToScreenCoords(const QPointF &point, const TileLayer* layer) const

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -171,6 +171,15 @@ public:
     }
 
     /**
+     * Returns the tile coordinates matching the given screen position for the
+     * given layer (which may be offeseted).
+     */
+    QPointF screenToTileCoords(qreal x, qreal y, const TileLayer* layer) const;
+
+    inline QPointF screenToTileCoords(const QPointF &point, const TileLayer* layer) const
+    { return tileToScreenCoords(point.x(), point.y(), layer); }
+
+    /**
      * Returns the tile coordinates matching the given screen position.
      */
     virtual QPointF screenToTileCoords(qreal x, qreal y) const = 0;
@@ -179,7 +188,7 @@ public:
     { return screenToTileCoords(point.x(), point.y()); }
 
     /**
-     * Returns the tile coordinates matching the given screen position for the
+     * Returns the screen position matching the given tile coordinates for the
      * given layer (which may be offeseted).
      */
     QPointF tileToScreenCoords(qreal x, qreal y, const TileLayer* layer) const;

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -124,7 +124,8 @@ public:
     virtual void drawTileSelection(QPainter *painter,
                                    const QRegion &region,
                                    const QColor &color,
-                                   const QRectF &exposed) const = 0;
+                                   const QRectF &exposed,
+                                   const TileLayer* layer) const = 0;
 
     /**
      * Draws the \a object in the given \a color using the \a painter.
@@ -177,7 +178,7 @@ public:
     QPointF screenToTileCoords(qreal x, qreal y, const Layer* layer) const;
 
     inline QPointF screenToTileCoords(const QPointF &point, const Layer* layer) const
-    { return tileToScreenCoords(point.x(), point.y(), layer); }
+    { return screenToTileCoords(point.x(), point.y(), layer); }
 
     /**
      * Returns the tile coordinates matching the given screen position.

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -178,6 +178,11 @@ public:
     inline QPointF screenToTileCoords(const QPointF &point) const
     { return screenToTileCoords(point.x(), point.y()); }
 
+    QPointF tileToScreenCoords(qreal x, qreal y, const TileLayer* layer) const;
+
+    inline QPointF tileToScreenCoords(const QPointF &point, const TileLayer* layer) const
+    { return tileToScreenCoords(point.x(), point.y(), layer); }
+
     /**
      * Returns the screen position matching the given tile coordinates.
      */

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -104,7 +104,7 @@ public:
      * \a painter.
      */
     virtual void drawGrid(QPainter *painter, const QRectF &rect,
-                          QColor gridColor = Qt::black) const = 0;
+                          const Layer* layer, QColor gridColor = Qt::black) const = 0;
 
     /**
      * Draws the given \a layer using the given \a painter.

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -461,6 +461,17 @@ void MapWriterPrivate::writeLayerAttributes(QXmlStreamWriter &w,
                          QString::number(layer->width()));
         w.writeAttribute(QLatin1String("height"),
                          QString::number(layer->height()));
+
+        const TileLayer* tiledLayer = static_cast<const TileLayer*>(layer);
+        const int horizontalOffset = tiledLayer->horizontalOffset();
+        const int verticalOffset = tiledLayer->verticalOffset();
+
+        if (horizontalOffset != 0)
+            w.writeAttribute(QLatin1String("horizontalOffset"),
+                    QString::number(horizontalOffset));
+        if (verticalOffset != 0)
+            w.writeAttribute(QLatin1String("verticalOffset"),
+                    QString::number(verticalOffset));
     }
 
     const int x = layer->x();

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -467,10 +467,10 @@ void MapWriterPrivate::writeLayerAttributes(QXmlStreamWriter &w,
         const int verticalOffset = tiledLayer->verticalOffset();
 
         if (horizontalOffset != 0)
-            w.writeAttribute(QLatin1String("horizontalOffset"),
+            w.writeAttribute(QLatin1String("horizontaloffset"),
                     QString::number(horizontalOffset));
         if (verticalOffset != 0)
-            w.writeAttribute(QLatin1String("verticalOffset"),
+            w.writeAttribute(QLatin1String("verticaloffset"),
                     QString::number(verticalOffset));
     }
 

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -252,7 +252,8 @@ void OrthogonalRenderer::drawTileLayer(QPainter *painter,
 void OrthogonalRenderer::drawTileSelection(QPainter *painter,
                                            const QRegion &region,
                                            const QColor &color,
-                                           const QRectF &exposed) const
+                                           const QRectF &exposed,
+                                           const TileLayer* layer) const
 {
     foreach (const QRect &r, region.rects()) {
         const QRectF toFill = QRectF(boundingRect(r)).intersected(exposed);

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -158,7 +158,7 @@ QPainterPath OrthogonalRenderer::shape(const MapObject *object) const
 }
 
 void OrthogonalRenderer::drawGrid(QPainter *painter, const QRectF &rect,
-                                  QColor gridColor) const
+                                  const Layer* layer, QColor gridColor) const
 {
     const int tileWidth = map()->tileWidth();
     const int tileHeight = map()->tileHeight();

--- a/src/libtiled/orthogonalrenderer.h
+++ b/src/libtiled/orthogonalrenderer.h
@@ -58,7 +58,8 @@ public:
     void drawTileSelection(QPainter *painter,
                            const QRegion &region,
                            const QColor &color,
-                           const QRectF &exposed) const;
+                           const QRectF &exposed,
+                           const TileLayer* layer) const;
 
     void drawMapObject(QPainter *painter,
                        const MapObject *object,

--- a/src/libtiled/orthogonalrenderer.h
+++ b/src/libtiled/orthogonalrenderer.h
@@ -50,7 +50,7 @@ public:
     QPainterPath shape(const MapObject *object) const;
 
     void drawGrid(QPainter *painter, const QRectF &rect,
-                  QColor gridColor) const;
+                  const Layer* layer, QColor gridColor) const;
 
     void drawTileLayer(QPainter *painter, const TileLayer *layer,
                        const QRectF &exposed = QRectF()) const;

--- a/src/libtiled/staggeredrenderer.cpp
+++ b/src/libtiled/staggeredrenderer.cpp
@@ -203,7 +203,8 @@ void StaggeredRenderer::drawTileLayer(QPainter *painter,
 void StaggeredRenderer::drawTileSelection(QPainter *painter,
                                           const QRegion &region,
                                           const QColor &color,
-                                          const QRectF &exposed) const
+                                          const QRectF &exposed,
+                                          const TileLayer* layer) const
 {
     painter->setBrush(color);
     painter->setPen(Qt::NoPen);

--- a/src/libtiled/staggeredrenderer.cpp
+++ b/src/libtiled/staggeredrenderer.cpp
@@ -83,7 +83,7 @@ QPainterPath StaggeredRenderer::shape(const MapObject *object) const
 }
 
 void StaggeredRenderer::drawGrid(QPainter *painter, const QRectF &rect,
-                                 QColor gridColor) const
+                                 const Layer* layer, QColor gridColor) const
 {
     const int tileWidth = map()->tileWidth();
     const int tileHeight = map()->tileHeight();

--- a/src/libtiled/staggeredrenderer.h
+++ b/src/libtiled/staggeredrenderer.h
@@ -94,7 +94,8 @@ public:
     void drawTileSelection(QPainter *painter,
                            const QRegion &region,
                            const QColor &color,
-                           const QRectF &exposed) const;
+                           const QRectF &exposed,
+                           const TileLayer* layer) const;
 
     void drawMapObject(QPainter *painter,
                        const MapObject *object,

--- a/src/libtiled/staggeredrenderer.h
+++ b/src/libtiled/staggeredrenderer.h
@@ -86,7 +86,7 @@ public:
     QPainterPath shape(const MapObject *object) const;
 
     void drawGrid(QPainter *painter, const QRectF &rect,
-                  QColor gridColor) const;
+                  const Layer* layer, QColor gridColor) const;
 
     void drawTileLayer(QPainter *painter, const TileLayer *layer,
                        const QRectF &exposed = QRectF()) const;

--- a/src/libtiled/tilelayer.cpp
+++ b/src/libtiled/tilelayer.cpp
@@ -69,12 +69,12 @@ QMargins TileLayer::layerOffset() const
     if (mHorizontalOffset > 0)
         offset.setRight(mHorizontalOffset);
     else
-        offset.setLeft(mHorizontalOffset);
+        offset.setLeft(-mHorizontalOffset);
 
     if (mVerticalOffset > 0)
         offset.setTop(mVerticalOffset);
     else
-        offset.setBottom(mVerticalOffset);
+        offset.setBottom(-mVerticalOffset);
 
     return offset;
 }

--- a/src/libtiled/tilelayer.cpp
+++ b/src/libtiled/tilelayer.cpp
@@ -37,6 +37,8 @@ using namespace Tiled;
 
 TileLayer::TileLayer(const QString &name, int x, int y, int width, int height):
     Layer(TileLayerType, name, x, y, width, height),
+    mHorizontalOffset(0),
+    mVerticalOffset(0),
     mMaxTileSize(0, 0),
     mGrid(width * height)
 {
@@ -430,6 +432,8 @@ Layer *TileLayer::clone() const
 TileLayer *TileLayer::initializeClone(TileLayer *clone) const
 {
     Layer::initializeClone(clone);
+    clone->mHorizontalOffset = mHorizontalOffset;
+    clone->mVerticalOffset = mVerticalOffset;
     clone->mGrid = mGrid;
     clone->mMaxTileSize = mMaxTileSize;
     clone->mOffsetMargins = mOffsetMargins;

--- a/src/libtiled/tilelayer.cpp
+++ b/src/libtiled/tilelayer.cpp
@@ -62,6 +62,23 @@ static QMargins maxMargins(const QMargins &a,
                     qMax(a.bottom(), b.bottom()));
 }
 
+QMargins TileLayer::layerOffset() const
+{
+    QMargins offset = QMargins();
+
+    if (mHorizontalOffset > 0)
+        offset.setRight(mHorizontalOffset);
+    else
+        offset.setLeft(mHorizontalOffset);
+
+    if (mVerticalOffset > 0)
+        offset.setTop(mVerticalOffset);
+    else
+        offset.setBottom(mVerticalOffset);
+
+    return offset;
+}
+
 /**
  * Recomputes the draw margins. Needed after the tile offset of a tileset
  * has changed for example.

--- a/src/libtiled/tilelayer.h
+++ b/src/libtiled/tilelayer.h
@@ -104,6 +104,26 @@ public:
     TileLayer(const QString &name, int x, int y, int width, int height);
 
     /**
+     * Returns the horizontal offset of this layer.
+     */
+    int horizontalOffset() const { return mHorizontalOffset; }
+
+    /**
+     * Sets the vertical offset of this layer.
+     */
+    void setHorizontalOffset(int offset) { mHorizontalOffset = offset ; }
+
+    /**
+     * Returns the vertical offset of this layer.
+     */
+    int verticalOffset() const { return mVerticalOffset; }
+
+    /**
+     * Sets the vertical offset of this layer.
+     */
+    void setVerticalOffset(int offset) { mVerticalOffset = offset ; }
+
+    /**
      * Returns the maximum tile size of this layer.
      */
     QSize maxTileSize() const { return mMaxTileSize; }
@@ -270,6 +290,8 @@ protected:
     TileLayer *initializeClone(TileLayer *clone) const;
 
 private:
+    int mHorizontalOffset;
+    int mVerticalOffset;
     QSize mMaxTileSize;
     QMargins mOffsetMargins;
     QVector<Cell> mGrid;

--- a/src/libtiled/tilelayer.h
+++ b/src/libtiled/tilelayer.h
@@ -124,6 +124,11 @@ public:
     void setVerticalOffset(int offset) { mVerticalOffset = offset ; }
 
     /**
+     * Returns the offsets determined by the horizontal and vertical offsets.
+     */
+    QMargins layerOffset() const; 
+
+    /**
      * Returns the maximum tile size of this layer.
      */
     QSize maxTileSize() const { return mMaxTileSize; }

--- a/src/tiled/abstracttiletool.cpp
+++ b/src/tiled/abstracttiletool.cpp
@@ -74,7 +74,8 @@ void AbstractTileTool::mouseLeft()
 void AbstractTileTool::mouseMoved(const QPointF &pos, Qt::KeyboardModifiers)
 {
     const MapRenderer *renderer = mapDocument()->renderer();
-    const QPointF tilePosF = renderer->screenToTileCoords(pos);
+    const QPointF tilePosF = renderer->screenToTileCoords(
+        pos, mapDocument()->currentLayer());
     QPoint tilePos;
 
     if (mTilePositionMethod == BetweenTiles)

--- a/src/tiled/brushitem.cpp
+++ b/src/tiled/brushitem.cpp
@@ -102,6 +102,7 @@ void BrushItem::paint(QPainter *painter,
                       const QStyleOptionGraphicsItem *option,
                       QWidget *)
 {
+    const TileLayer* currentLayer = mMapDocument->currentLayer()->asTileLayer();
     QColor insideMapHighlight = QApplication::palette().highlight().color();
     insideMapHighlight.setAlpha(64);
     QColor outsideMapHighlight = QColor(255, 0, 0, 64);
@@ -114,6 +115,8 @@ void BrushItem::paint(QPainter *painter,
 
     const MapRenderer *renderer = mMapDocument->renderer();
     if (mTileLayer) {
+        mTileLayer->setHorizontalOffset(currentLayer->horizontalOffset());
+        mTileLayer->setVerticalOffset(currentLayer->verticalOffset());
         const qreal opacity = painter->opacity();
         painter->setOpacity(0.75);
         renderer->drawTileLayer(painter, mTileLayer, option->exposedRect);
@@ -123,11 +126,11 @@ void BrushItem::paint(QPainter *painter,
     renderer->drawTileSelection(painter, insideMapRegion,
                                 insideMapHighlight,
                                 option->exposedRect,
-                                mMapDocument->currentLayer()->asTileLayer());
+                                currentLayer);
     renderer->drawTileSelection(painter, outsideMapRegion,
                                 outsideMapHighlight,
                                 option->exposedRect,
-                                mMapDocument->currentLayer()->asTileLayer());
+                                currentLayer);
 }
 
 void BrushItem::updateBoundingRect()

--- a/src/tiled/brushitem.cpp
+++ b/src/tiled/brushitem.cpp
@@ -122,10 +122,12 @@ void BrushItem::paint(QPainter *painter,
 
     renderer->drawTileSelection(painter, insideMapRegion,
                                 insideMapHighlight,
-                                option->exposedRect);
+                                option->exposedRect,
+                                mMapDocument->currentLayer()->asTileLayer());
     renderer->drawTileSelection(painter, outsideMapRegion,
                                 outsideMapHighlight,
-                                option->exposedRect);
+                                option->exposedRect,
+                                mMapDocument->currentLayer()->asTileLayer());
 }
 
 void BrushItem::updateBoundingRect()

--- a/src/tiled/brushitem.cpp
+++ b/src/tiled/brushitem.cpp
@@ -140,7 +140,8 @@ void BrushItem::updateBoundingRect()
     }
 
     const QRect bounds = mRegion.boundingRect();
-    mBoundingRect = mMapDocument->renderer()->boundingRect(bounds);
+    const Layer* layer = mMapDocument->currentLayer();
+    mBoundingRect = mMapDocument->renderer()->boundingRect(bounds, layer);
 
     // Adjust for amount of pixels tiles extend at the top and to the right
     if (mTileLayer) {

--- a/src/tiled/changetilelayer.cpp
+++ b/src/tiled/changetilelayer.cpp
@@ -20,8 +20,10 @@
 
 #include "changetilelayer.h"
 
-#include "mapdocument.h"
+#include "map.h"
 #include "tilelayer.h"
+#include "mapdocument.h"
+#include "layermodel.h"
 
 #include <QCoreApplication>
 
@@ -29,11 +31,12 @@ using namespace Tiled;
 using namespace Tiled::Internal;
 
 SetLayerHorizontalOffset::SetLayerHorizontalOffset(MapDocument* mapDocument,
-                                                   TileLayer* layer,
+                                                   int layerIndex,
                                                    int offset)
     : mMapDocument(mapDocument)
-    , mLayer(layer)
-    , mOldHorizontalOffset(layer->horizontalOffset())
+    , mLayerIndex(layerIndex)
+    , mOldHorizontalOffset(
+        mMapDocument->map()->layerAt(layerIndex)->asTileLayer()->horizontalOffset())
     , mNewHorizontalOffset(offset)
 {
     setText(QCoreApplication::translate("Undo Commands",
@@ -42,16 +45,16 @@ SetLayerHorizontalOffset::SetLayerHorizontalOffset(MapDocument* mapDocument,
 
 void SetLayerHorizontalOffset::setOffset(int offset)
 {
-    mLayer->setHorizontalOffset(offset);
-    mMapDocument->emitMapChanged();
+    mMapDocument->layerModel()->setLayerOffset(mLayerIndex, offset, 0);
 }
 
 SetLayerVerticalOffset::SetLayerVerticalOffset(MapDocument* mapDocument,
-                                               TileLayer* layer,
+                                               int layerIndex,
                                                int offset)
     : mMapDocument(mapDocument)
-    , mLayer(layer)
-    , mOldVerticalOffset(layer->verticalOffset())
+    , mLayerIndex(layerIndex)
+    , mOldVerticalOffset(
+        mMapDocument->map()->layerAt(layerIndex)->asTileLayer()->horizontalOffset())
     , mNewVerticalOffset(offset)
 {
     setText(QCoreApplication::translate("Undo Commands",
@@ -60,7 +63,6 @@ SetLayerVerticalOffset::SetLayerVerticalOffset(MapDocument* mapDocument,
 
 void SetLayerVerticalOffset::setOffset(int offset)
 {
-    mLayer->setVerticalOffset(offset);
-    mMapDocument->emitMapChanged();
+    mMapDocument->layerModel()->setLayerOffset(mLayerIndex, 0, offset);
 }
 

--- a/src/tiled/changetilelayer.cpp
+++ b/src/tiled/changetilelayer.cpp
@@ -47,6 +47,6 @@ SetLayerOffset::SetLayerOffset(MapDocument* mapDocument, int layerIndex,
 
 void SetLayerOffset::setOffset(int horizontalOffset, int verticalOffset)
 {
-    mMapDocument->layerModel()->setLayerOffset(mLayerIndex, horizontalOffset,
-                                               verticalOffset);
+    mMapDocument->setTileLayerOffset(mLayerIndex, horizontalOffset,
+                                     verticalOffset);
 }

--- a/src/tiled/changetilelayer.cpp
+++ b/src/tiled/changetilelayer.cpp
@@ -37,7 +37,7 @@ SetLayerOffset::SetLayerOffset(MapDocument* mapDocument, int layerIndex,
     , mOldHorizontalOffset(
         mMapDocument->map()->layerAt(layerIndex)->asTileLayer()->horizontalOffset())
     , mOldVerticalOffset(
-        mMapDocument->map()->layerAt(layerIndex)->asTileLayer()->horizontalOffset())
+        mMapDocument->map()->layerAt(layerIndex)->asTileLayer()->verticalOffset())
     , mNewHorizontalOffset(horizontalOffset)
     , mNewVerticalOffset(verticalOffset)
 {

--- a/src/tiled/changetilelayer.cpp
+++ b/src/tiled/changetilelayer.cpp
@@ -30,39 +30,23 @@
 using namespace Tiled;
 using namespace Tiled::Internal;
 
-SetLayerHorizontalOffset::SetLayerHorizontalOffset(MapDocument* mapDocument,
-                                                   int layerIndex,
-                                                   int offset)
+SetLayerOffset::SetLayerOffset(MapDocument* mapDocument, int layerIndex, 
+                               int horizontalOffset, int verticalOffset)
     : mMapDocument(mapDocument)
     , mLayerIndex(layerIndex)
     , mOldHorizontalOffset(
         mMapDocument->map()->layerAt(layerIndex)->asTileLayer()->horizontalOffset())
-    , mNewHorizontalOffset(offset)
-{
-    setText(QCoreApplication::translate("Undo Commands",
-                                        "Change Tile Layer Horizontal Offset"));
-}
-
-void SetLayerHorizontalOffset::setOffset(int offset)
-{
-    mMapDocument->layerModel()->setLayerOffset(mLayerIndex, offset, 0);
-}
-
-SetLayerVerticalOffset::SetLayerVerticalOffset(MapDocument* mapDocument,
-                                               int layerIndex,
-                                               int offset)
-    : mMapDocument(mapDocument)
-    , mLayerIndex(layerIndex)
     , mOldVerticalOffset(
         mMapDocument->map()->layerAt(layerIndex)->asTileLayer()->horizontalOffset())
-    , mNewVerticalOffset(offset)
+    , mNewHorizontalOffset(horizontalOffset)
+    , mNewVerticalOffset(verticalOffset)
 {
     setText(QCoreApplication::translate("Undo Commands",
-                                        "Change Tile Layer Vertical Offset"));
+                                        "Change Tile Layer Offset"));
 }
 
-void SetLayerVerticalOffset::setOffset(int offset)
+void SetLayerOffset::setOffset(int horizontalOffset, int verticalOffset)
 {
-    mMapDocument->layerModel()->setLayerOffset(mLayerIndex, 0, offset);
+    mMapDocument->layerModel()->setLayerOffset(mLayerIndex, horizontalOffset,
+                                               verticalOffset);
 }
-

--- a/src/tiled/changetilelayer.cpp
+++ b/src/tiled/changetilelayer.cpp
@@ -1,0 +1,66 @@
+/*
+ * changetilelayer.cpp
+ * Copyright 2012-2013, Thorbjørn Lindeijer <thorbjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "changetilelayer.h"
+
+#include "mapdocument.h"
+#include "tilelayer.h"
+
+#include <QCoreApplication>
+
+using namespace Tiled;
+using namespace Tiled::Internal;
+
+SetLayerHorizontalOffset::SetLayerHorizontalOffset(MapDocument* mapDocument,
+                                                   TileLayer* layer,
+                                                   int offset)
+    : mMapDocument(mapDocument)
+    , mLayer(layer)
+    , mOldHorizontalOffset(layer->horizontalOffset())
+    , mNewHorizontalOffset(offset)
+{
+    setText(QCoreApplication::translate("Undo Commands",
+                                        "Change Tile Layer Horizontal Offset"));
+}
+
+void SetLayerHorizontalOffset::setOffset(int offset)
+{
+    mLayer->setHorizontalOffset(offset);
+    mMapDocument->emitMapChanged();
+}
+
+SetLayerVerticalOffset::SetLayerVerticalOffset(MapDocument* mapDocument,
+                                               TileLayer* layer,
+                                               int offset)
+    : mMapDocument(mapDocument)
+    , mLayer(layer)
+    , mOldVerticalOffset(layer->verticalOffset())
+    , mNewVerticalOffset(offset)
+{
+    setText(QCoreApplication::translate("Undo Commands",
+                                        "Change Tile Layer Vertical Offset"));
+}
+
+void SetLayerVerticalOffset::setOffset(int offset)
+{
+    mLayer->setVerticalOffset(offset);
+    mMapDocument->emitMapChanged();
+}
+

--- a/src/tiled/changetilelayer.h
+++ b/src/tiled/changetilelayer.h
@@ -1,0 +1,80 @@
+/*
+ * changetilelayer.h
+ * Copyright 2012-2013, Thorbjørn Lindeijer <thorbjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef CHANGETILELAYER_H
+#define CHANGETILELAYER_H
+
+#endif // CHANGETILELAYER_H
+
+#include <QUndoCommand>
+
+namespace Tiled {
+
+class TileLayer;
+
+namespace Internal {
+
+class MapDocument;
+
+/**
+ * Used for changing layer horizontal offset.
+ */
+class SetLayerHorizontalOffset : public QUndoCommand
+{
+public:
+    SetLayerHorizontalOffset(MapDocument *mapDocument,
+                             TileLayer* layer,
+                             int offset);
+
+    void undo() { setOffset(mOldHorizontalOffset); }
+    void redo() { setOffset(mNewHorizontalOffset); }
+
+private:
+    void setOffset(int offset);
+
+    MapDocument *mMapDocument;
+    TileLayer* mLayer;
+    int mOldHorizontalOffset;
+    int mNewHorizontalOffset;
+};
+
+/**
+ * Used for changing layer vertical offset.
+ */
+class SetLayerVerticalOffset : public QUndoCommand
+{
+public:
+    SetLayerVerticalOffset(MapDocument *mapDocument,
+                           TileLayer* layer,
+                           int offset);
+
+    void undo() { setOffset(mOldVerticalOffset); }
+    void redo() { setOffset(mNewVerticalOffset); }
+
+private:
+    void setOffset(int offset);
+
+    MapDocument *mMapDocument;
+    TileLayer* mLayer;
+    int mOldVerticalOffset;
+    int mNewVerticalOffset;
+};
+
+} // namespace Internal
+} // namespace Tiled

--- a/src/tiled/changetilelayer.h
+++ b/src/tiled/changetilelayer.h
@@ -35,46 +35,26 @@ class MapDocument;
 /**
  * Used for changing layer horizontal offset.
  */
-class SetLayerHorizontalOffset : public QUndoCommand
+class SetLayerOffset : public QUndoCommand
 {
 public:
-    SetLayerHorizontalOffset(MapDocument *mapDocument,
-                             int layerIndex,
-                             int offset);
+    SetLayerOffset(MapDocument *mapDocument, int layerIndex, 
+                   int horizontalOffset, int verticalOffset);
 
-    void undo() { setOffset(mOldHorizontalOffset); }
-    void redo() { setOffset(mNewHorizontalOffset); }
+    void undo() { setOffset(mOldHorizontalOffset, mOldVerticalOffset); }
+    void redo() { setOffset(mNewHorizontalOffset, mNewVerticalOffset); }
 
 private:
-    void setOffset(int offset);
+    void setOffset(int horizontalOffset, int verticalOffset);
 
     MapDocument *mMapDocument;
     int mLayerIndex;
     int mOldHorizontalOffset;
-    int mNewHorizontalOffset;
-};
-
-/**
- * Used for changing layer vertical offset.
- */
-class SetLayerVerticalOffset : public QUndoCommand
-{
-public:
-    SetLayerVerticalOffset(MapDocument *mapDocument,
-                           int layerIndex,
-                           int offset);
-
-    void undo() { setOffset(mOldVerticalOffset); }
-    void redo() { setOffset(mNewVerticalOffset); }
-
-private:
-    void setOffset(int offset);
-
-    MapDocument *mMapDocument;
-    int mLayerIndex;
     int mOldVerticalOffset;
+    int mNewHorizontalOffset;
     int mNewVerticalOffset;
 };
+;
 
 } // namespace Internal
 } // namespace Tiled

--- a/src/tiled/changetilelayer.h
+++ b/src/tiled/changetilelayer.h
@@ -39,7 +39,7 @@ class SetLayerHorizontalOffset : public QUndoCommand
 {
 public:
     SetLayerHorizontalOffset(MapDocument *mapDocument,
-                             TileLayer* layer,
+                             int layerIndex,
                              int offset);
 
     void undo() { setOffset(mOldHorizontalOffset); }
@@ -49,7 +49,7 @@ private:
     void setOffset(int offset);
 
     MapDocument *mMapDocument;
-    TileLayer* mLayer;
+    int mLayerIndex;
     int mOldHorizontalOffset;
     int mNewHorizontalOffset;
 };
@@ -61,7 +61,7 @@ class SetLayerVerticalOffset : public QUndoCommand
 {
 public:
     SetLayerVerticalOffset(MapDocument *mapDocument,
-                           TileLayer* layer,
+                           int layerIndex,
                            int offset);
 
     void undo() { setOffset(mOldVerticalOffset); }
@@ -71,7 +71,7 @@ private:
     void setOffset(int offset);
 
     MapDocument *mMapDocument;
-    TileLayer* mLayer;
+    int mLayerIndex;
     int mOldVerticalOffset;
     int mNewVerticalOffset;
 };

--- a/src/tiled/layermodel.cpp
+++ b/src/tiled/layermodel.cpp
@@ -210,6 +210,16 @@ void LayerModel::renameLayer(int layerIndex, const QString &name)
     emit layerChanged(layerIndex);
 }
 
+void LayerModel::setLayerOffset(int layerIndex, int horizontalOffset,
+                                int verticalOffset)
+{
+    TileLayer *layer = mMap->layerAt(layerIndex)->asTileLayer();
+    layer->setHorizontalOffset(horizontalOffset);
+    layer->setVerticalOffset(verticalOffset);
+    mMap->recomputeOffset();
+    mMapDocument->emitMapChanged();
+}
+
 void LayerModel::toggleOtherLayers(int layerIndex)
 {
     if (mMap->layerCount() <= 1) // No other layers

--- a/src/tiled/layermodel.cpp
+++ b/src/tiled/layermodel.cpp
@@ -210,16 +210,6 @@ void LayerModel::renameLayer(int layerIndex, const QString &name)
     emit layerChanged(layerIndex);
 }
 
-void LayerModel::setLayerOffset(int layerIndex, int horizontalOffset,
-                                int verticalOffset)
-{
-    TileLayer *layer = mMap->layerAt(layerIndex)->asTileLayer();
-    layer->setHorizontalOffset(horizontalOffset);
-    layer->setVerticalOffset(verticalOffset);
-    mMap->recomputeOffset();
-    mMapDocument->emitMapChanged();
-}
-
 void LayerModel::toggleOtherLayers(int layerIndex)
 {
     if (mMap->layerCount() <= 1) // No other layers

--- a/src/tiled/layermodel.h
+++ b/src/tiled/layermodel.h
@@ -128,6 +128,12 @@ public:
     void setLayerOpacity(int layerIndex, float opacity);
 
     /**
+     * Sets the horizontal and vertical offset of the tile layer at the given 
+     * index.
+     */
+    void setLayerOffset(int layerIndex, int horizontalOffset, int verticalOffset);
+
+    /**
      * Renames the layer at the given index.
      */
     void renameLayer(int index, const QString &name);

--- a/src/tiled/layermodel.h
+++ b/src/tiled/layermodel.h
@@ -128,12 +128,6 @@ public:
     void setLayerOpacity(int layerIndex, float opacity);
 
     /**
-     * Sets the horizontal and vertical offset of the tile layer at the given 
-     * index.
-     */
-    void setLayerOffset(int layerIndex, int horizontalOffset, int verticalOffset);
-
-    /**
      * Renames the layer at the given index.
      */
     void renameLayer(int index, const QString &name);

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -486,6 +486,21 @@ void MapDocument::toggleOtherLayers(int index)
     mLayerModel->toggleOtherLayers(index);
 }
 
+
+/**
+ * Set the offset of the tile layer at \a layerIndex and recomputes the map's
+ * global offset. Emits the appropriate signal.
+ */
+void MapDocument::setTileLayerOffset(int layerIndex, int horizontalOffset,
+                                     int verticalOffset)
+{
+    TileLayer *layer = mMap->layerAt(layerIndex)->asTileLayer();
+    layer->setHorizontalOffset(horizontalOffset);
+    layer->setVerticalOffset(verticalOffset);
+    mMap->recomputeOffset();
+    emitTileLayerChanged(layer);
+}
+
 /**
  * Adds a tileset to this map at the given \a index. Emits the appropriate
  * signal.

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -156,6 +156,9 @@ public:
     void removeLayer(int index);
     void toggleOtherLayers(int index);
 
+    void setTileLayerOffset(int layerIndex, int horizontalOffset,
+                            int verticalOffset);
+
     void insertTileset(int index, Tileset *tileset);
     void removeTilesetAt(int index);
     void moveTileset(int from, int to);
@@ -238,6 +241,7 @@ public:
     void emitTileTerrainChanged(const QList<Tile*> &tiles);
     void emitTileObjectGroupChanged(Tile *tile);
     void emitTileAnimationChanged(Tile *tile);
+    void emitTileLayerChanged(TileLayer *tileLayer);
     void emitObjectGroupChanged(ObjectGroup *objectGroup);
     void emitImageLayerChanged(ImageLayer *imageLayer);
     void emitEditLayerNameRequested();
@@ -318,6 +322,11 @@ signals:
      * Emitted after the color of an object group has changed.
      */
     void objectGroupChanged(ObjectGroup *objectGroup);
+
+    /**
+     * Emitted after the offset of a tile layer have changed.
+     */
+    void tileLayerChanged(TileLayer *tileLayer);
 
     /**
      * Emitted after the image and/or the transparent color of an image layer
@@ -448,6 +457,15 @@ inline void MapDocument::emitTileAnimationChanged(Tile *tile)
 inline void MapDocument::emitObjectGroupChanged(ObjectGroup *objectGroup)
 {
     emit objectGroupChanged(objectGroup);
+}
+
+/**
+ * Emits the tileLayerChanged signal, should be called when changing the
+ * offset of a tile layer.
+ */
+inline void MapDocument::emitTileLayerChanged(TileLayer *tileLayer)
+{
+    emit tileLayerChanged(tileLayer);
 }
 
 /**

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -321,6 +321,7 @@ void MapScene::disableSelectedTool()
 void MapScene::currentLayerIndexChanged()
 {
     updateCurrentLayerHighlight();
+    invalidate(sceneRect(), ForegroundLayer);
 }
 
 /**
@@ -599,7 +600,8 @@ void MapScene::drawForeground(QPainter *painter, const QRectF &rect)
         return;
 
     Preferences *prefs = Preferences::instance();
-    mMapDocument->renderer()->drawGrid(painter, rect, prefs->gridColor());
+    Layer* layer = mMapDocument->currentLayer();
+    mMapDocument->renderer()->drawGrid(painter, rect, layer, prefs->gridColor());
 }
 
 bool MapScene::event(QEvent *event)

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -131,6 +131,8 @@ void MapScene::setMapDocument(MapDocument *mapDocument)
                 this, SLOT(layerRemoved(int)));
         connect(mMapDocument, SIGNAL(layerChanged(int)),
                 this, SLOT(layerChanged(int)));
+        connect(mMapDocument, SIGNAL(tileLayerChanged(TileLayer*)),
+                this, SLOT(tileLayerChanged(TileLayer*)));
         connect(mMapDocument, SIGNAL(objectGroupChanged(ObjectGroup*)),
                 this, SLOT(objectGroupChanged(ObjectGroup*)));
         connect(mMapDocument, SIGNAL(imageLayerChanged(ImageLayer*)),
@@ -388,6 +390,15 @@ void MapScene::layerChanged(int index)
         multiplier = opacityFactor;
 
     layerItem->setOpacity(layer->opacity() * multiplier);
+}
+
+/**
+ * When an tile layer has changed, the global offsets may have changed, causing
+ * the map's size to change, so basically is af if the mapChanged signal was
+ * emitted. 
+ */
+void MapScene::tileLayerChanged(TileLayer *tileLayer) {
+    mapChanged();
 }
 
 /**

--- a/src/tiled/mapscene.h
+++ b/src/tiled/mapscene.h
@@ -33,6 +33,7 @@ namespace Tiled {
 
 class ImageLayer;
 class Layer;
+class TileLayer;
 class MapObject;
 class ObjectGroup;
 class Tileset;
@@ -158,6 +159,7 @@ private slots:
     void layerRemoved(int index);
     void layerChanged(int index);
 
+    void tileLayerChanged(TileLayer *tileLayer);
     void objectGroupChanged(ObjectGroup *objectGroup);
     void imageLayerChanged(ImageLayer *imageLayer);
 

--- a/src/tiled/minimap.cpp
+++ b/src/tiled/minimap.cpp
@@ -228,6 +228,13 @@ void MiniMap::renderMapToImage()
 
         if (tileLayer && drawTiles) {
             renderer->drawTileLayer(&painter, tileLayer);
+
+            if (drawTileGrid) {
+                Preferences *prefs = Preferences::instance();
+                renderer->drawGrid(&painter, QRectF(QPointF(), renderer->mapSize()),
+                                   layer, prefs->gridColor());
+            }
+
         } else if (objGroup && drawObjects) {
             QList<MapObject*> objects = objGroup->objects();
 
@@ -243,12 +250,6 @@ void MiniMap::renderMapToImage()
         } else if (imageLayer && drawImages) {
             renderer->drawImageLayer(&painter, imageLayer);
         }
-    }
-
-    if (drawTileGrid) {
-        Preferences *prefs = Preferences::instance();
-        renderer->drawGrid(&painter, QRectF(QPointF(), renderer->mapSize()),
-                           prefs->gridColor());
     }
 
     renderer->setFlags(renderFlags);

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -548,14 +548,17 @@ void PropertyBrowser::applyLayerValue(PropertyId id, const QVariant &val)
 void PropertyBrowser::applyTileLayerValue(PropertyId id, const QVariant &val)
 {
     TileLayer* layer = static_cast<TileLayer*>(mObject);
+    const int layerIndex = mMapDocument->map()->layers().indexOf(layer);
     QUndoCommand *command = 0;
 
     switch (id) {
         case HorizontalOffsetProperty:
-            command = new SetLayerHorizontalOffset(mMapDocument, layer, val.toInt());
+            command = new SetLayerHorizontalOffset(mMapDocument, layerIndex,
+                                                   val.toInt());
             break;
         case VerticalOffsetProperty:
-            command = new SetLayerVerticalOffset(mMapDocument, layer, val.toInt());
+            command = new SetLayerVerticalOffset(mMapDocument, layerIndex,
+                                                 val.toInt());
             break;
         default:
             break;

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -151,6 +151,8 @@ void PropertyBrowser::setMapDocument(MapDocument *mapDocument)
                 SLOT(objectsChanged(QList<MapObject*>)));
         connect(mapDocument, SIGNAL(layerChanged(int)),
                 SLOT(layerChanged(int)));
+        connect(mapDocument, SIGNAL(tileLayerChanged(TileLayer*)),
+                SLOT(tileLayerChanged(TileLayer*)));
         connect(mapDocument, SIGNAL(objectGroupChanged(ObjectGroup*)),
                 SLOT(objectGroupChanged(ObjectGroup*)));
         connect(mapDocument, SIGNAL(imageLayerChanged(ImageLayer*)),
@@ -209,6 +211,12 @@ void PropertyBrowser::objectsChanged(const QList<MapObject *> &objects)
 void PropertyBrowser::layerChanged(int index)
 {
     if (mObject == mMapDocument->map()->layerAt(index))
+        updateProperties();
+}
+
+void PropertyBrowser::tileLayerChanged(TileLayer *tileLayer)
+{
+    if (mObject == tileLayer)
         updateProperties();
 }
 

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -553,12 +553,12 @@ void PropertyBrowser::applyTileLayerValue(PropertyId id, const QVariant &val)
 
     switch (id) {
         case HorizontalOffsetProperty:
-            command = new SetLayerHorizontalOffset(mMapDocument, layerIndex,
-                                                   val.toInt());
+            command = new SetLayerOffset(mMapDocument, layerIndex,
+                                         val.toInt(), layer->verticalOffset());
             break;
         case VerticalOffsetProperty:
-            command = new SetLayerVerticalOffset(mMapDocument, layerIndex,
-                                                 val.toInt());
+            command = new SetLayerOffset(mMapDocument, layerIndex,
+                                         layer->horizontalOffset(), val.toInt());
             break;
         default:
             break;

--- a/src/tiled/propertybrowser.h
+++ b/src/tiled/propertybrowser.h
@@ -102,6 +102,8 @@ private:
         RotationProperty,
         VisibleProperty,
         OpacityProperty,
+        HorizontalOffsetProperty,
+        VerticalOffsetProperty,
         ColorProperty,
         LayerFormatProperty,
         ImageSourceProperty,

--- a/src/tiled/propertybrowser.h
+++ b/src/tiled/propertybrowser.h
@@ -81,6 +81,7 @@ private slots:
     void mapChanged();
     void objectsChanged(const QList<MapObject*> &objects);
     void layerChanged(int index);
+    void tileLayerChanged(TileLayer *tileLayer);
     void objectGroupChanged(ObjectGroup *objectGroup);
     void imageLayerChanged(ImageLayer *imageLayer);
     void tilesetChanged(Tileset *tileset);

--- a/src/tiled/saveasimagedialog.cpp
+++ b/src/tiled/saveasimagedialog.cpp
@@ -185,6 +185,13 @@ void SaveAsImageDialog::accept()
 
         if (tileLayer) {
             renderer->drawTileLayer(&painter, tileLayer);
+
+            if (drawTileGrid) {
+                Preferences *prefs = Preferences::instance();
+                renderer->drawGrid(&painter, QRectF(QPointF(), renderer->mapSize()),
+                                   layer, prefs->gridColor());
+            }
+
         } else if (objGroup) {
             QList<MapObject*> objects = objGroup->objects();
 
@@ -200,12 +207,6 @@ void SaveAsImageDialog::accept()
         } else if (imageLayer) {
             renderer->drawImageLayer(&painter, imageLayer);
         }
-    }
-
-    if (drawTileGrid) {
-        Preferences *prefs = Preferences::instance();
-        renderer->drawGrid(&painter, QRectF(QPointF(), renderer->mapSize()),
-                           prefs->gridColor());
     }
 
     // Restore the previous render flags

--- a/src/tiled/tiled.pro
+++ b/src/tiled/tiled.pro
@@ -63,6 +63,7 @@ SOURCES += aboutdialog.cpp \
     changepolygon.cpp \
     changeproperties.cpp \
     changetileanimation.cpp \
+    changetilelayer.cpp \
     changetileobjectgroup.cpp \
     changetileselection.cpp \
     changetileterrain.cpp \

--- a/src/tiled/tilelayeritem.cpp
+++ b/src/tiled/tilelayeritem.cpp
@@ -44,7 +44,7 @@ TileLayerItem::TileLayerItem(TileLayer *layer, MapRenderer *renderer)
 void TileLayerItem::syncWithTileLayer()
 {
     prepareGeometryChange();
-    mBoundingRect = mRenderer->boundingRect(mLayer->bounds());
+    mBoundingRect = mRenderer->boundingRect(mLayer);
 }
 
 QRectF TileLayerItem::boundingRect() const

--- a/src/tiled/tileselectionitem.cpp
+++ b/src/tiled/tileselectionitem.cpp
@@ -58,7 +58,8 @@ void TileSelectionItem::paint(QPainter *painter,
 
     MapRenderer *renderer = mMapDocument->renderer();
     renderer->drawTileSelection(painter, selection, highlight,
-                                option->exposedRect);
+                                option->exposedRect,
+                                mMapDocument->currentLayer()->asTileLayer());
 }
 
 void TileSelectionItem::selectionChanged(const QRegion &newSelection,

--- a/src/tiled/tileselectionitem.cpp
+++ b/src/tiled/tileselectionitem.cpp
@@ -76,5 +76,6 @@ void TileSelectionItem::selectionChanged(const QRegion &newSelection,
 void TileSelectionItem::updateBoundingRect()
 {
     const QRect b = mMapDocument->tileSelection().boundingRect();
-    mBoundingRect = mMapDocument->renderer()->boundingRect(b);
+    const Layer *layer = mMapDocument->currentLayer();
+    mBoundingRect = mMapDocument->renderer()->boundingRect(b, layer);
 }

--- a/src/tmxviewer/tmxviewer.cpp
+++ b/src/tmxviewer/tmxviewer.cpp
@@ -91,7 +91,7 @@ public:
 
     QRectF boundingRect() const
     {
-        return mRenderer->boundingRect(mTileLayer->bounds());
+        return mRenderer->boundingRect(mTileLayer);
     }
 
     void paint(QPainter *p, const QStyleOptionGraphicsItem *option, QWidget *)


### PR DESCRIPTION
This is an initial implementation of the feature described on the title. The only renderer that currently renders the map with the offseted layers is the isometric one.
The intention was to cover the feature described in #4, but adding the flexibility to use an arbitrary offset instead of only a positive vertical one.

Some caveats:

* For **positive vertical** and **negative horizontal** offsets, the current behavior when drawing is to *push* the rest of the tile layers on the opossite direction. Object layers are independent of the offsets since they use pixel positions, which will cause the objects to "fall out of place" on those cases (they are actually staying in place while everything else moves).
* I tried to adpt the bounding and exposed rects to the offsets in a given map and the current layer, but I'm not completely sure I did a good work, so that may hit on performance (maybe?).

There's no hurry, check the changes whenever you've got some time!