### PR TITLE
Suggest transparent color for indexed image

### DIFF
--- a/src/tiled/newtilesetdialog.cpp
+++ b/src/tiled/newtilesetdialog.cpp
@@ -191,6 +191,10 @@ void NewTilesetDialog::browse()
 
         if (!mNameWasEdited)
             mUi->name->setText(QFileInfo(f).completeBaseName());
+            
+        QImage img(f);
+        if(!img.hasAlphaChannel() && img.colorTable().count() > 0)
+            mUi->colorButton->setColor(img.colorTable().first());
     }
 }
 


### PR DESCRIPTION
I think a lot of people still use indexed colors images for tilesets. The usual behavior for transparency is that the first color of the color table is the transparent. So this just sets the transparent color button in the "New tileset" dialog to the first color of color table (palette) when selecting an indexed colors images.

This is the first time I use git and github, and I wanted to start with a very small suggestion, so I hope this is alright...

Thanks !