### PR TITLE
Added a Tile reference for MapObjects

### DIFF
--- a/util/java/libtiled-java/src/tiled/core/MapObject.java
+++ b/util/java/libtiled-java/src/tiled/core/MapObject.java
@@ -45,10 +45,10 @@ public class MapObject implements Cloneable
     private Shape shape = new Rectangle();
     private String name = "Object";
     private String type = "";
-    private int gid = -1;
     private String imageSource = "";
     private Image image;
     private Image scaledImage;
+    private Tile tile;
 
     public MapObject(int x, int y, int width, int height) {
         bounds = new Rectangle(x, y, width, height);
@@ -119,12 +119,12 @@ public class MapObject implements Cloneable
         scaledImage = null;
     }
 
-    public int getGid(){
-        return gid;
+    public Tile getTile(){
+        return tile;
     }
 
-    public void setGid(int gid){
-        this.gid = gid;
+    public void setTile(Tile tile){
+        this.tile = tile;
     }
 
     /**

--- a/util/java/libtiled-java/src/tiled/core/MapObject.java
+++ b/util/java/libtiled-java/src/tiled/core/MapObject.java
@@ -45,6 +45,7 @@ public class MapObject implements Cloneable
     private Shape shape = new Rectangle();
     private String name = "Object";
     private String type = "";
+    private int gid = -1;
     private String imageSource = "";
     private Image image;
     private Image scaledImage;
@@ -116,6 +117,14 @@ public class MapObject implements Cloneable
         }
 
         scaledImage = null;
+    }
+
+    public int getGid(){
+        return gid;
+    }
+
+    public void setGid(int gid){
+        this.gid = gid;
     }
 
     /**

--- a/util/java/libtiled-java/src/tiled/io/TMXMapReader.java
+++ b/util/java/libtiled-java/src/tiled/io/TMXMapReader.java
@@ -420,19 +420,22 @@ public class TMXMapReader
     private MapObject readMapObject(Node t) throws Exception {
         final String name = getAttributeValue(t, "name");
         final String type = getAttributeValue(t, "type");
+        final String gid = getAttributeValue(t, "gid");
         final int x = getAttribute(t, "x", 0);
         final int y = getAttribute(t, "y", 0);
         final int width = getAttribute(t, "width", 0);
         final int height = getAttribute(t, "height", 0);
-        final int gid = getAttribute(t, "gid", -1);
 
         MapObject obj = new MapObject(x, y, width, height);
-        obj.setGid(gid);
         obj.setShape(obj.getBounds());
         if (name != null)
             obj.setName(name);
         if (type != null)
             obj.setType(type);
+        if (gid != null){
+            Tile tile = getTileForTileGID(Integer.parseInt(gid));
+            obj.setTile(tile);
+        }
 
         NodeList children = t.getChildNodes();
         for (int i = 0; i < children.getLength(); i++) {

--- a/util/java/libtiled-java/src/tiled/io/TMXMapReader.java
+++ b/util/java/libtiled-java/src/tiled/io/TMXMapReader.java
@@ -424,8 +424,10 @@ public class TMXMapReader
         final int y = getAttribute(t, "y", 0);
         final int width = getAttribute(t, "width", 0);
         final int height = getAttribute(t, "height", 0);
+        final int gid = getAttribute(t, "gid", -1);
 
         MapObject obj = new MapObject(x, y, width, height);
+        obj.setGid(gid);
         obj.setShape(obj.getBounds());
         if (name != null)
             obj.setName(name);


### PR DESCRIPTION
TMXMapReader looks for the "gid" attribute when reading map objects. If it finds one it gives the MapObject a reference to the relevant Tile. If the gid value can't be parsed to an integer it will crash.