### PR TITLE
Added Qt.gui to Export{} of libtiled.qbs

### DIFF
--- a/src/libtiled/libtiled.qbs
+++ b/src/libtiled/libtiled.qbs
@@ -59,6 +59,11 @@ DynamicLibrary {
 
     Export {
         Depends { name: "cpp" }
+        Depends {
+            name: "Qt"
+            submodules: ["gui"]
+        }
+
         cpp.includePaths: "."
     }
 


### PR DESCRIPTION
libtiled uses QPixmap in its headers, which requires that any project
that uses libtiled also depends on Qt Gui.

This makes the qbs file more reusable for 3rd party programs/libraries.