### PR TITLE
Some change to support custom data read/write in origin tmx file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,16 @@ tests/test_mapreader
 
 # Ronn html outputs
 docs/*.1.html
+
+#qmake some
+.qmake.stash
+.localized
+
+#visual studio
+debug
+release
+*.ilk
+*.pdb
+*_manifest.rc
+*_manifest.res
+*.embed.manifest

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -334,6 +334,9 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
         // TODO: Draw the object name
         // TODO: Do something sensible to make null-sized objects usable
 
+        /* a polygon to contain object, use to draw custom object content below. */
+        QPolygonF objPolygon;
+
         switch (object->shape()) {
         case MapObject::Ellipse: {
             QPointF topLeft(pixelToScreenCoords(object->bounds().topLeft()));
@@ -350,6 +353,7 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
                                          rect.width() + 2);
 
             QPolygonF polygon = pixelRectToScreenPolygon(object->bounds());
+            objPolygon = polygon;
 
             float tw = map()->tileWidth();
             float th = map()->tileHeight();
@@ -420,6 +424,8 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
                                          rect.width() + 2);
 
             QPolygonF polygon = pixelRectToScreenPolygon(object->bounds());
+            objPolygon = polygon;
+
             painter->drawPolygon(polygon);
             if (!name.isEmpty())
                 painter->drawText(QPointF(headerX, headerY - 5 + shadowOffset), name);
@@ -438,6 +444,7 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
             const QPointF &pos = object->position();
             const QPolygonF polygon = object->polygon().translated(pos);
             QPolygonF screenPolygon = pixelToScreenCoords(polygon);
+            objPolygon = screenPolygon;
 
             const QRectF polygonBoundingRect = screenPolygon.boundingRect();
 
@@ -466,6 +473,7 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
             const QPointF &pos = object->position();
             const QPolygonF polygon = object->polygon().translated(pos);
             QPolygonF screenPolygon = pixelToScreenCoords(polygon);
+            objPolygon = screenPolygon;
 
             painter->drawPolyline(screenPolygon);
 
@@ -477,6 +485,15 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
             break;
         }
         }
+
+        /* draw custom content for map object. */
+        painter->save();
+        const QPointF &pos = pixelToScreenCoords(object->position());
+        objPolygon.translate(-pos);
+        painter->translate(pos);
+        object->handlePaint(*painter, objPolygon);
+        painter->restore();
+
     }
 
     painter->restore();

--- a/src/libtiled/map.cpp
+++ b/src/libtiled/map.cpp
@@ -37,6 +37,15 @@
 #include "tileset.h"
 #include "mapobject.h"
 
+/* convenient macro to delete object with NULL check. */
+#define SAFE_DELETE(_obj)       \
+    do {                        \
+        if ((_obj) != NULL) {   \
+            delete (_obj);      \
+            (_obj) = NULL;      \
+        }                       \
+    } while (0);
+
 using namespace Tiled;
 
 Map::Map(Orientation orientation,
@@ -52,7 +61,8 @@ Map::Map(Orientation orientation,
     mStaggerAxis(StaggerY),
     mStaggerIndex(StaggerOdd),
     mLayerDataFormat(Base64Zlib),
-    mNextObjectId(1)
+    mNextObjectId(1),
+    m_pCustomDataMgr(NULL)
 {
 }
 
@@ -78,11 +88,16 @@ Map::Map(const Map &map):
         clone->setMap(this);
         mLayers.append(clone);
     }
+
+    if (map.m_pCustomDataMgr) {
+        m_pCustomDataMgr = map.m_pCustomDataMgr->clone();
+    }
 }
 
 Map::~Map()
 {
     qDeleteAll(mLayers);
+    SAFE_DELETE(m_pCustomDataMgr);
 }
 
 static QMargins maxMargins(const QMargins &a,
@@ -358,4 +373,13 @@ Map *Map::fromLayer(Layer *layer)
     Map *result = new Map(Unknown, layer->width(), layer->height(), 0, 0);
     result->addLayer(layer);
     return result;
+}
+
+void Map::SetCustomDataManager(CustomDataManager* mgr) {
+    SAFE_DELETE(m_pCustomDataMgr);
+    m_pCustomDataMgr = mgr;
+}
+
+CustomDataManager* Map::GetCustomDataManager() {
+    return m_pCustomDataMgr;
 }

--- a/src/libtiled/map.h
+++ b/src/libtiled/map.h
@@ -44,6 +44,7 @@ namespace Tiled {
 class Tile;
 class Tileset;
 class ObjectGroup;
+class CustomDataManager;
 
 /**
  * A tile map. Consists of a stack of layers, each can be either a TileLayer
@@ -406,6 +407,19 @@ private:
     QList<Tileset*> mTilesets;
     LayerDataFormat mLayerDataFormat;
     int mNextObjectId;
+
+public:
+    /**
+     * set an new CustomDataManager instance, if old instance will be delete.
+     */
+    void SetCustomDataManager(CustomDataManager* mgr);
+    /**
+     * get m_pCustomDataMgr.
+     */
+    CustomDataManager* GetCustomDataManager();
+
+private:
+    CustomDataManager* m_pCustomDataMgr;
 };
 
 
@@ -465,6 +479,23 @@ TILEDSHARED_EXPORT Map::Orientation orientationFromString(const QString &);
 
 TILEDSHARED_EXPORT QString renderOrderToString(Map::RenderOrder renderOrder);
 TILEDSHARED_EXPORT Map::RenderOrder renderOrderFromString(const QString &);
+
+/**
+ * CustomDataManager is a interface class, in a plugin, can inherit CustomDataManager to hold custom data from MapReader, and write back by MapWriter.
+ * get/set CustomDataManager instance with Map::SetCustomDataManager()/GetCustomDataManager().
+ * the instance in map instance is NULL as default.
+ */
+class CustomDataManager {
+protected:
+    CustomDataManager() {}
+    virtual ~CustomDataManager() {}
+
+protected:
+    /*! clone interface, impl it to support map copy. */
+    virtual CustomDataManager* clone() const = 0;
+
+    friend class Map;
+};
 
 } // namespace Tiled
 

--- a/src/libtiled/mapobject.h
+++ b/src/libtiled/mapobject.h
@@ -40,6 +40,16 @@
 #include <QString>
 #include <QRectF>
 
+class QPainter;
+
+namespace Tiled {
+    class MapObject;
+}
+/**
+ * Define a factory for Tiled::MapObject.
+ */
+typedef Tiled::MapObject* (*MapObjectFactory)(void);
+
 namespace Tiled {
 
 class ObjectGroup;
@@ -247,8 +257,24 @@ public:
     /**
      * Returns a duplicate of this object. The caller is responsible for the
      * ownership of this newly created object.
+     *
+     * if this is an instance of sub-class from MapObject(eg. created with CreateByType()),
+     * must inherit and return new object as a sub-class instance,
+     * and call cloneInternal(MapObject*) at end of clone(), to clone base MapObject data.
      */
-    MapObject *clone() const;
+    virtual MapObject *clone() const;
+
+protected:
+    /**
+     * clone base data to newObj, default called in clone(), if sub-class inherited clone(), should call this method at end of clone.
+     */
+    void cloneInternal(MapObject* newObj) const;
+
+    /**
+     * Paint custom in map object. default do nothing, overwrite if need.
+     */
+    virtual void handlePaint(QPainter& painter, const QPolygonF& defaultPolygon = QPolygonF()) const;
+
 
 private:
     int mId;
@@ -262,6 +288,17 @@ private:
     ObjectGroup *mObjectGroup;
     qreal mRotation;
     bool mVisible;
+
+public:
+    /**
+     * Register a custom factory of MapObject (or sub-class), with type.
+     */
+    static void RegisterCreateFunc(const QString& type, MapObjectFactory factoryFunc);
+    /**
+     * Create a MapObject (or sub-class) with given type, name, pos, and size.
+     * Return the new object instance.
+     */
+    static MapObject* CreateByType(const QString& name, const QString& type, const QPointF& pos, const QSizeF& size);
 };
 
 } // namespace Tiled

--- a/src/libtiled/mapobject.h
+++ b/src/libtiled/mapobject.h
@@ -270,6 +270,7 @@ protected:
      */
     void cloneInternal(MapObject* newObj) const;
 
+public:
     /**
      * Paint custom in map object. default do nothing, overwrite if need.
      */

--- a/src/libtiled/mapreader.h
+++ b/src/libtiled/mapreader.h
@@ -34,6 +34,7 @@
 #include <QImage>
 
 class QFile;
+class QXmlStreamReader;
 
 namespace Tiled {
 
@@ -43,6 +44,13 @@ class Tileset;
 namespace Internal {
 class MapReaderPrivate;
 }
+
+/**
+ * Define a callback func type, useful to handle read custom data (eg. resource ref) from origin tmx file.
+ * these custom data can hold and write with CustomXmlElementWriteCallback.
+ * Return true if element read success, otherwise false.
+ */
+typedef bool (*CustomXmlElementReadCallback)(QXmlStreamReader& xml, const QString& xmlFilePath, const Tiled::Map* map);
 
 /**
  * A fast QXmlStreamReader based reader for the TMX and TSX formats.
@@ -122,6 +130,13 @@ protected:
 private:
     friend class Internal::MapReaderPrivate;
     Internal::MapReaderPrivate *d;
+
+public:
+    /**
+     *  Set a CustomXmlElementReadCallback to write custom data.
+     */
+    void SetCustomXmlElementReadCallback(CustomXmlElementReadCallback callback);
+
 };
 
 } // namespace Tiled

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -78,6 +78,7 @@ public:
     QString mError;
     Map::LayerDataFormat mLayerDataFormat;
     bool mDtdEnabled;
+    CustomXmlElementWriteCallback mWriteCallback;
 
 private:
     void writeMap(QXmlStreamWriter &w, const Map *map);
@@ -104,6 +105,7 @@ MapWriterPrivate::MapWriterPrivate()
     : mLayerDataFormat(Map::Base64Zlib)
     , mDtdEnabled(false)
     , mUseAbsolutePaths(false)
+    , mWriteCallback(NULL)
 {
 }
 
@@ -211,6 +213,11 @@ void MapWriterPrivate::writeMap(QXmlStreamWriter &w, const Map *map)
         writeTileset(w, tileset, firstGid);
         mGidMapper.insert(firstGid, tileset);
         firstGid += tileset->tileCount();
+    }
+
+    /* here callback for writing custom data, ignore if mWriteCallback is NULL as default. */
+    if (mWriteCallback) {
+        mWriteCallback(w, map);
     }
 
     foreach (const Layer *layer, map->layers()) {
@@ -719,4 +726,9 @@ void MapWriter::setDtdEnabled(bool enabled)
 bool MapWriter::isDtdEnabled() const
 {
     return d->mDtdEnabled;
+}
+
+void MapWriter::SetCustomXmlElementWriteCallback(CustomXmlElementWriteCallback callback)
+{
+    d->mWriteCallback = callback;
 }

--- a/src/libtiled/mapwriter.h
+++ b/src/libtiled/mapwriter.h
@@ -36,6 +36,7 @@
 #include <QString>
 
 class QIODevice;
+class QXmlStreamWriter;
 
 namespace Tiled {
 
@@ -45,6 +46,12 @@ class Tileset;
 namespace Internal {
 class MapWriterPrivate;
 }
+
+/**
+ * Define a callback func type, useful to handle write(save) custom data (eg. resource ref) to origin tmx file.
+ * all the custom data will be write after <tileset> and before all <layer>.
+ */
+typedef void (*CustomXmlElementWriteCallback)(QXmlStreamWriter& writer, const Tiled::Map* map);
 
 /**
  * A QXmlStreamWriter based writer for the TMX and TSX formats.
@@ -106,6 +113,12 @@ public:
 
 private:
     Internal::MapWriterPrivate *d;
+
+public:
+    /**
+     *  Set a CustomXmlElementWriteCallback to write custom data.
+     */
+    void SetCustomXmlElementWriteCallback(CustomXmlElementWriteCallback callback);
 };
 
 } // namespace Tiled

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -353,6 +353,9 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
             shape = MapObject::Rectangle;
         }
 
+        /* a polygon to contain object, use to draw custom object content below. */
+        QPolygonF objPolygon;
+
         switch (shape) {
         case MapObject::Rectangle: {
             if (rect.isNull())
@@ -374,11 +377,13 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
             if (!name.isEmpty())
                 painter->drawText(QPointF(0, -4 - lineWidth / 2), name);
 
+            objPolygon = rect;
             break;
         }
 
         case MapObject::Polyline: {
             QPolygonF screenPolygon = pixelToScreenCoords(object->polygon());
+            objPolygon = screenPolygon;
 
             painter->setPen(shadowPen);
             painter->drawPolyline(screenPolygon.translated(shadowOffset));
@@ -391,6 +396,7 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
 
         case MapObject::Polygon: {
             QPolygonF screenPolygon = pixelToScreenCoords(object->polygon());
+            objPolygon = screenPolygon;
 
             painter->setPen(shadowPen);
             painter->drawPolygon(screenPolygon.translated(shadowOffset));
@@ -421,10 +427,20 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
             if (!name.isEmpty())
                 painter->drawText(QPoint(0, -5), name);
 
+            objPolygon = rect;
             break;
         }
         }
+
+        /* draw custom content for map object. */
+        painter->save();
+        const QPointF &pos = pixelToScreenCoords(object->position());
+        objPolygon.translate(-pos);
+        painter->translate(pos);
+        object->handlePaint(*painter, objPolygon);
+        painter->restore();
     }
+
 
     painter->restore();
 }


### PR DESCRIPTION
Hi, here are some change to support custom data read/write in origin tmx file. detail:
1. a CustomXmlElementWriteCallback member in MapWriter, and a CustomXmlElementReaderCallback member in MapReader, to read/write custom data;
2. a new interface class CustomDataManager in Map, to store custom data read in CustomXmlElementReadCallback and write back by CustomXmlElementWriteCallback.
3. plugin developer can implement CustomXmlElementWriteCallback/CustomXmlElementReaderCallback/CustomDataManager in the plugin project.
4. I build tiled in win32 with qmake -spec win32-msvc2012, and found the temp file not ignore, so I add to .gitignore.

example:
1. define a custom node to ref to custom resource
![20150118122620](https://cloud.githubusercontent.com/assets/1829278/5791377/e79f1e9a-9f0d-11e4-9ec5-b6903128b101.jpg)
2. add object with custom properties
![20150118122725](https://cloud.githubusercontent.com/assets/1829278/5791379/022496d2-9f0e-11e4-980f-37db88807adc.jpg)
3. finally show like this, with a custom plugin
![20150118122105](https://cloud.githubusercontent.com/assets/1829278/5791380/0cf0d1de-9f0e-11e4-8d75-a5c90fd39714.png)

I'm a game developer in china, and this is my first pull request in github, hope it's useful for others.