### PR TITLE
Extend CSV plugin to export all tile layers.

### DIFF
--- a/src/libtiled/mapwriterinterface.h
+++ b/src/libtiled/mapwriterinterface.h
@@ -73,7 +73,7 @@ public:
      * Returns the absolute paths for the files that will be written by
      * the map writer.
      */
-    virtual QStringList outputFiles(const Map * /*map*/, const QString &/*fileName*/) const { return QStringList(); }
+    virtual QStringList outputFiles(const Map * /*map*/, const QString &fileName) const { return QStringList(fileName); }
 
 protected:
     /**

--- a/src/libtiled/mapwriterinterface.h
+++ b/src/libtiled/mapwriterinterface.h
@@ -69,6 +69,12 @@ public:
      */
     virtual QString errorString() const = 0;
 
+    /**
+     * Returns the absolute paths for the files that will be written by
+     * the map writer.
+     */
+    virtual QStringList outputFiles(const Map * /*map*/, const QString &/*fileName*/) const { return QStringList(); }
+
 protected:
     /**
      * Returns the name filter of this map writer.

--- a/src/plugins/csv/csvplugin.h
+++ b/src/plugins/csv/csvplugin.h
@@ -40,12 +40,12 @@ public:
     CsvPlugin();
 
     // MapWriterInterface
-    virtual bool write(const Tiled::Map *map, const QString &fileName) override;
-    virtual QString errorString() const override;
-    virtual QStringList outputFiles(const Tiled::Map *map, const QString &fileName) const override;
+    virtual bool write(const Tiled::Map *map, const QString &fileName);
+    virtual QString errorString() const;
+    virtual QStringList outputFiles(const Tiled::Map *map, const QString &fileName) const;
 
 protected:
-    virtual QString nameFilter() const override;
+    virtual QString nameFilter() const;
 
 private:
     QString mError;

--- a/src/plugins/csv/csvplugin.h
+++ b/src/plugins/csv/csvplugin.h
@@ -40,9 +40,12 @@ public:
     CsvPlugin();
 
     // MapWriterInterface
-    bool write(const Tiled::Map *map, const QString &fileName);
-    QString nameFilter() const;
-    QString errorString() const;
+    virtual bool write(const Tiled::Map *map, const QString &fileName) override;
+    virtual QString errorString() const override;
+    virtual QStringList outputFiles(const Tiled::Map *map, const QString &fileName) const override;
+
+protected:
+    virtual QString nameFilter() const override;
 
 private:
     QString mError;

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -929,9 +929,11 @@ void MainWindow::exportAs()
                 + QLatin1Char('.') + extension;
     }
 
+    // No need to confirm overwrite here since it'll be prompted below
     QString fileName = QFileDialog::getSaveFileName(this, tr("Export As..."),
                                                     suggestedFilename,
-                                                    filter, &selectedFilter);
+                                                    filter, &selectedFilter,
+                                                    QFileDialog::DontConfirmOverwrite);
     if (fileName.isEmpty())
         return;
 
@@ -978,13 +980,13 @@ void MainWindow::exportAs()
         return;
     }
 
-    // Some writers could save to multiple files at the same time.
-    // For example CSV saves each layer into a separate file.
-    // Warn user if we overwrite existing files.
+    // Check if writer will overwrite existing files here because some writers could save to multiple
+    // files at the same time. For example CSV saves each layer into a separate file.
     QStringList outputFiles = chosenWriter->outputFiles(mMapDocument->map(), fileName);
     if (outputFiles.size() > 0)
     {
         // Check if any output file already exists
+        QString message = tr("Some export files already exist:\n");
         bool overwriteHappens = false;
         QStringList::ConstIterator filesIt = outputFiles.cbegin();
         const QStringList::ConstIterator filesEnd = outputFiles.cend();
@@ -994,9 +996,10 @@ void MainWindow::exportAs()
             if (file.exists())
             {
                 overwriteHappens = true;
-                break;
+                message += QLatin1String("\t") + *filesIt + QLatin1String("\n");
             }
         }
+        message += tr("\nDo you want to replace them?");
 
         // If overwrite happens, warn the user and get confirmation before executing the writer
         if (overwriteHappens)
@@ -1004,7 +1007,7 @@ void MainWindow::exportAs()
             const QMessageBox::StandardButton reply = QMessageBox::warning(
                 this,
                 tr("Overwrite files"),
-                tr("Some export files already exist.\nDo you want to replace them?"),
+                message,
                 QMessageBox::Yes | QMessageBox::No,
                 QMessageBox::No);
 

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -983,27 +983,22 @@ void MainWindow::exportAs()
     // Check if writer will overwrite existing files here because some writers could save to multiple
     // files at the same time. For example CSV saves each layer into a separate file.
     QStringList outputFiles = chosenWriter->outputFiles(mMapDocument->map(), fileName);
-    if (outputFiles.size() > 0)
-    {
+    if (outputFiles.size() > 0) {
         // Check if any output file already exists
         QString message = tr("Some export files already exist:\n");
         bool overwriteHappens = false;
-        QStringList::ConstIterator filesIt = outputFiles.cbegin();
-        const QStringList::ConstIterator filesEnd = outputFiles.cend();
-        for (; filesIt != filesEnd; ++filesIt)
-        {
-            QFile file(*filesIt);
-            if (file.exists())
-            {
+
+        foreach (const QString &outputFile, outputFiles) {
+            QFile file(outputFile);
+            if (file.exists()) {
                 overwriteHappens = true;
-                message += QLatin1String("\t") + *filesIt + QLatin1String("\n");
+                message += QLatin1String("\t") + outputFile + QLatin1String("\n");
             }
         }
         message += tr("\nDo you want to replace them?");
 
         // If overwrite happens, warn the user and get confirmation before executing the writer
-        if (overwriteHappens)
-        {
+        if (overwriteHappens) {
             const QMessageBox::StandardButton reply = QMessageBox::warning(
                 this,
                 tr("Overwrite files"),
@@ -1012,9 +1007,7 @@ void MainWindow::exportAs()
                 QMessageBox::No);
 
             if (QMessageBox::Yes != reply)
-            {
                 return;
-            }
         }
     }
 


### PR DESCRIPTION
- Layers get exported in different files.
- Filenames are constructed as
    #base_#layer.csv
  where #base is the name chosen in the
  save-file dialog (without extension), and
  #layer is the name for the layer.

Related to #277 

<!---
@huboard:{"order":869.0,"milestone_order":869,"custom_state":""}
-->
