### PR TITLE
Loading Objecttypes.xml with default properties

### DIFF
--- a/src/tiled/objecttypes.cpp
+++ b/src/tiled/objecttypes.cpp
@@ -90,27 +90,29 @@ ObjectTypes ObjectTypesReader::readObjectTypes(const QString &fileName)
         return objectTypes;
     }
 
-    while (reader.readNextStartElement()) {
-        if (reader.name() == QLatin1String("objecttype")) {
-            const QXmlStreamAttributes atts = reader.attributes();
+    while(!reader.atEnd()) {
+        while (reader.readNextStartElement()) {
+            if (reader.name() == QLatin1String("objecttype")) {
+                const QXmlStreamAttributes atts = reader.attributes();
 
-            const QString name(atts.value(QLatin1String("name")).toString());
-            const QColor color(atts.value(QLatin1String("color")).toString());
+                const QString name(atts.value(QLatin1String("name")).toString());
+                const QColor color(atts.value(QLatin1String("color")).toString());
 
-            // read the custom properties
-            Properties props;
+                //qDebug().nospace() << name;
 
-            while (reader.readNextStartElement()) {
-                if (reader.name() == QLatin1String("property"))
-                    readObjectTypeProperty(reader, props);
-                reader.skipCurrentElement();
+                // read the custom properties
+                Properties props;                                
+                while (reader.readNextStartElement()) {
+                    if (reader.name() == QLatin1String("property")){
+                        readObjectTypeProperty(reader, props);
+                    }
+                    reader.skipCurrentElement();
+                }
+                objectTypes.append(ObjectType(name, color, props));
             }
+        }    
+    }   
 
-            objectTypes.append(ObjectType(name, color, props));
-        }
-
-        reader.skipCurrentElement();
-    }
 
     // readNextStartElement() leaves the stream in
     // an invalid state at the end. A single readNext()

--- a/src/tiled/objecttypes.cpp
+++ b/src/tiled/objecttypes.cpp
@@ -130,7 +130,7 @@ ObjectTypes ObjectTypesReader::readObjectTypes(const QString &fileName)
     return objectTypes;
 }
 
-void ObjectTypesReader::readObjectTypeProperty(QXmlStreamReader& xml, const Properties& props) {
+void ObjectTypesReader::readObjectTypeProperty(QXmlStreamReader& xml, Properties& props) {
     
     Q_ASSERT(xml.isStartElement() && xml.name() == QLatin1String("property"));
 
@@ -143,7 +143,7 @@ void ObjectTypesReader::readObjectTypeProperty(QXmlStreamReader& xml, const Prop
 
     // TODO: allow for real typed properties. Only strings for now
 
-    properties->insert(name, defaultValue);
+    props.insert(name, defaultValue);
 }
 
 } // namespace Internal

--- a/src/tiled/objecttypes.cpp
+++ b/src/tiled/objecttypes.cpp
@@ -21,9 +21,12 @@
 #include "objecttypes.h"
 
 #include <QCoreApplication>
+#include <QDebug>
 #include <QFile>
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
+
+#include "properties.h"
 
 namespace Tiled {
 namespace Internal {
@@ -94,10 +97,26 @@ ObjectTypes ObjectTypesReader::readObjectTypes(const QString &fileName)
             const QString name(atts.value(QLatin1String("name")).toString());
             const QColor color(atts.value(QLatin1String("color")).toString());
 
-            objectTypes.append(ObjectType(name, color));
+            // read the custom properties
+            Properties props;
+
+            while (reader.readNextStartElement()) {
+                if (reader.name() == QLatin1String("property"))
+                    readObjectTypeProperty(reader, props);
+                reader.skipCurrentElement();
+            }
+
+            objectTypes.append(ObjectType(name, color, props));
         }
+
         reader.skipCurrentElement();
     }
+
+    // readNextStartElement() leaves the stream in
+    // an invalid state at the end. A single readNext()
+    // will advance us to EndDocument.
+    if (reader.tokenType() == QXmlStreamReader::Invalid)
+        reader.readNext();
 
     if (reader.hasError()) {
         mError = QCoreApplication::translate("ObjectTypes",
@@ -109,6 +128,22 @@ ObjectTypes ObjectTypesReader::readObjectTypes(const QString &fileName)
     }
 
     return objectTypes;
+}
+
+void ObjectTypesReader::readObjectTypeProperty(QXmlStreamReader& xml, const Properties& props) {
+    
+    Q_ASSERT(xml.isStartElement() && xml.name() == QLatin1String("property"));
+
+    const QXmlStreamAttributes atts = xml.attributes();
+    QString name(atts.value(QLatin1String("name")).toString());
+    QString type(atts.value(QLatin1String("type")).toString());
+    QString defaultValue(atts.value(QLatin1String("default")).toString());
+
+    //qDebug().nospace() << "Property: " << name << " " << type << " " << defaultValue;
+
+    // TODO: allow for real typed properties. Only strings for now
+
+    properties->insert(name, defaultValue);
 }
 
 } // namespace Internal

--- a/src/tiled/objecttypes.h
+++ b/src/tiled/objecttypes.h
@@ -24,6 +24,9 @@
 #include <QString>
 #include <QColor>
 #include <QVector>
+#include <QXmlStreamReader>
+
+#include "properties.h"
 
 namespace Tiled {
 namespace Internal {
@@ -36,13 +39,17 @@ struct ObjectType
     ObjectType() : color(Qt::gray) {}
 
     ObjectType(const QString &name,
-               const QColor &color)
+               const QColor &color,
+               const Properties& properties)
         : name(name)
         , color(color)
+        , defaultProperties(properties)
     {}
 
     QString name;
     QColor color;
+
+    Properties defaultProperties;
 };
 
 typedef QVector<ObjectType> ObjectTypes;
@@ -65,6 +72,8 @@ class ObjectTypesReader
 {
 public:
     ObjectTypes readObjectTypes(const QString &fileName);
+
+    void readObjectTypeProperty(QXmlStreamReader& xml, const Properties& props);
 
     QString errorString() const { return mError; }
 

--- a/src/tiled/objecttypes.h
+++ b/src/tiled/objecttypes.h
@@ -73,7 +73,7 @@ class ObjectTypesReader
 public:
     ObjectTypes readObjectTypes(const QString &fileName);
 
-    void readObjectTypeProperty(QXmlStreamReader& xml, const Properties& props);
+    void readObjectTypeProperty(QXmlStreamReader& xml, Properties& props);
 
     QString errorString() const { return mError; }
 

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -31,6 +31,7 @@
 #include <QDesktopServices>
 #endif
 
+#include <QDebug>
 #include <QFileInfo>
 #include <QSettings>
 
@@ -84,17 +85,36 @@ Preferences::Preferences()
     mSettings->endGroup();
 
     // Retrieve defined object types
+    const QString objDefFile = mSettings->value(QLatin1String("ObjectTypesDefinition")).toString();
+
+    if (!objDefFile.isEmpty()) { // we have a file reference
+        
+        ObjectTypesReader reader;
+        ObjectTypes objectTypes = reader.readObjectTypes(objDefFile);
+
+        mObjectTypes = objectTypes;
+
+        qDebug().nospace() << "ObjectTypes found: " << objDefFile;
+
+        emit objectTypesChanged();
+
+    } else
+        qDebug().nospace() << "No ObjectTypes specified.";
+
+    /*
     mSettings->beginGroup(QLatin1String("ObjectTypes"));
     const QStringList names =
             mSettings->value(QLatin1String("Names")).toStringList();
     const QStringList colors =
             mSettings->value(QLatin1String("Colors")).toStringList();
     mSettings->endGroup();
+    
 
     const int count = qMin(names.size(), colors.size());
     Properties props;
     for (int i = 0; i < count; ++i)
         mObjectTypes.append(ObjectType(names.at(i), QColor(colors.at(i)), props));
+    */
 
     mSettings->beginGroup(QLatin1String("Automapping"));
     mAutoMapDrawing = boolValue("WhileDrawing");
@@ -308,10 +328,11 @@ void Preferences::setUseOpenGL(bool useOpenGL)
     emit useOpenGLChanged(mUseOpenGL);
 }
 
-void Preferences::setObjectTypes(const ObjectTypes &objectTypes)
+void Preferences::setObjectTypes(const QString& fileName, const ObjectTypes &objectTypes)
 {
     mObjectTypes = objectTypes;
 
+    /*
     QStringList names;
     QStringList colors;
     foreach (const ObjectType &objectType, objectTypes) {
@@ -323,6 +344,9 @@ void Preferences::setObjectTypes(const ObjectTypes &objectTypes)
     mSettings->setValue(QLatin1String("Names"), names);
     mSettings->setValue(QLatin1String("Colors"), colors);
     mSettings->endGroup();
+    */
+    
+    mSettings->setValue(QLatin1String("ObjectTypesDefinition"), fileName);
 
     emit objectTypesChanged();
 }

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -92,8 +92,9 @@ Preferences::Preferences()
     mSettings->endGroup();
 
     const int count = qMin(names.size(), colors.size());
+    Properties props;
     for (int i = 0; i < count; ++i)
-        mObjectTypes.append(ObjectType(names.at(i), QColor(colors.at(i))));
+        mObjectTypes.append(ObjectType(names.at(i), QColor(colors.at(i)), props));
 
     mSettings->beginGroup(QLatin1String("Automapping"));
     mAutoMapDrawing = boolValue("WhileDrawing");

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -75,7 +75,7 @@ public:
     void setUseOpenGL(bool useOpenGL);
 
     const ObjectTypes &objectTypes() const { return mObjectTypes; }
-    void setObjectTypes(const ObjectTypes &objectTypes);
+    void setObjectTypes(const QString& fileName, const ObjectTypes &objectTypes);
 
     enum FileType {
         ObjectTypesFile,

--- a/src/tiled/preferencesdialog.cpp
+++ b/src/tiled/preferencesdialog.cpp
@@ -160,10 +160,12 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) :
     connect(mUi->exportObjectTypesButton, SIGNAL(clicked()),
             SLOT(exportObjectTypes()));
 
+    /*
     connect(mObjectTypesModel, SIGNAL(dataChanged(QModelIndex,QModelIndex)),
             SLOT(applyObjectTypes()));
     connect(mObjectTypesModel, SIGNAL(rowsRemoved(QModelIndex,int,int)),
             SLOT(applyObjectTypes()));
+    */
 
     connect(mUi->autoMapWhileDrawing, SIGNAL(toggled(bool)),
             SLOT(useAutomappingDrawingToggled(bool)));
@@ -244,11 +246,13 @@ void PreferencesDialog::objectTypeIndexClicked(const QModelIndex &index)
     }
 }
 
+/*
 void PreferencesDialog::applyObjectTypes()
 {
     Preferences *prefs = Preferences::instance();
     prefs->setObjectTypes(mObjectTypesModel->objectTypes());
 }
+*/
 
 void PreferencesDialog::importObjectTypes()
 {
@@ -267,7 +271,7 @@ void PreferencesDialog::importObjectTypes()
     ObjectTypes objectTypes = reader.readObjectTypes(fileName);
 
     if (reader.errorString().isEmpty()) {
-        prefs->setObjectTypes(objectTypes);
+        prefs->setObjectTypes(fileName, objectTypes);
         mObjectTypesModel->setObjectTypes(objectTypes);
     } else {
         QMessageBox::critical(this, tr("Error Reading Object Types"),

--- a/src/tiled/preferencesdialog.h
+++ b/src/tiled/preferencesdialog.h
@@ -59,7 +59,7 @@ private slots:
     void selectedObjectTypesChanged();
     void removeSelectedObjectTypes();
     void objectTypeIndexClicked(const QModelIndex &index);
-    void applyObjectTypes();
+    //void applyObjectTypes();
     void importObjectTypes();
     void exportObjectTypes();
 

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -964,7 +964,11 @@ void PropertyBrowser::updateCustomProperties()
         while (it.hasNext()) {
             it.next();
             if (!mCombinedProperties.contains(it.key())) {
-                mObject->setProperty(it.key(), it.value()); // set the actual property
+                /*
+                    TODO: set the actual property on the object. Does this makes sense? What is the usecase that makes the most sense?
+                    mObject->setProperty(it.key(), it.value()); 
+                */
+                
                 mCombinedProperties.insert(it.key(), it.value()); // add to view
             }
         }

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -947,11 +947,6 @@ void PropertyBrowser::updateCustomProperties()
     }
 
     // Add Default properties
-    /*
-    foreach(const QString& key, mCombinedProperties.keys()) {
-        qDebug().nospace() << key;
-    }
-    */
     const ObjectType *curType = NULL;
     ObjectTypes defObjTypes = Preferences::instance()->objectTypes();
     foreach (const ObjectType &type, defObjTypes) {
@@ -969,8 +964,8 @@ void PropertyBrowser::updateCustomProperties()
         while (it.hasNext()) {
             it.next();
             if (!mCombinedProperties.contains(it.key())) {
-                mObject->setProperty(it.key(), it.value());
-                mCombinedProperties.insert(it.key(), it.value());
+                mObject->setProperty(it.key(), it.value()); // set the actual property
+                mCombinedProperties.insert(it.key(), it.value()); // add to view
             }
         }
     }

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -969,6 +969,7 @@ void PropertyBrowser::updateCustomProperties()
         while (it.hasNext()) {
             it.next();
             if (!mCombinedProperties.contains(it.key())) {
+                mObject->setProperty(it.key(), it.value());
                 mCombinedProperties.insert(it.key(), it.value());
             }
         }

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -964,11 +964,6 @@ void PropertyBrowser::updateCustomProperties()
         while (it.hasNext()) {
             it.next();
             if (!mCombinedProperties.contains(it.key())) {
-                /*
-                    TODO: set the actual property on the object. Does this makes sense? What is the usecase that makes the most sense?
-                    mObject->setProperty(it.key(), it.value()); 
-                */
-                
                 mCombinedProperties.insert(it.key(), it.value()); // add to view
             }
         }

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -51,6 +51,7 @@
 #include <QtGroupPropertyManager>
 
 #include <QCoreApplication>
+#include <QDebug>
 
 namespace Tiled {
 namespace Internal {
@@ -310,6 +311,7 @@ void PropertyBrowser::propertyRemoved(Object *object, const QString &name)
 void PropertyBrowser::propertyChanged(Object *object, const QString &name)
 {
     if (mObject == object) {
+
         mUpdating = true;
         mNameToProperty[name]->setValue(object->property(name));
         mUpdating = false;
@@ -923,6 +925,8 @@ void PropertyBrowser::updateCustomProperties()
 
     mUpdating = true;
 
+    //qDebug().nospace() << "updateCustomProperties";
+
     qDeleteAll(mNameToProperty);
     mNameToProperty.clear();
 
@@ -938,6 +942,34 @@ void PropertyBrowser::updateCustomProperties()
             it.next();
             if (!mCombinedProperties.contains(it.key())) {
                 mCombinedProperties.insert(it.key(), tr(""));
+            }
+        }
+    }
+
+    // Add Default properties
+    /*
+    foreach(const QString& key, mCombinedProperties.keys()) {
+        qDebug().nospace() << key;
+    }
+    */
+    const ObjectType *curType = NULL;
+    ObjectTypes defObjTypes = Preferences::instance()->objectTypes();
+    foreach (const ObjectType &type, defObjTypes) {
+        if (mIdToProperty.contains(TypeProperty)) {
+            QString typeName = mIdToProperty[TypeProperty]->value().toString();            
+            if (type.name == typeName) { // match
+                curType = &type;
+                break;
+            }
+            //qDebug().nospace() << "FOOO: " << type.name << " == " << typeName;
+        }        
+    }
+    if (curType != NULL) {
+        QMapIterator<QString,QString> it(curType->defaultProperties);
+        while (it.hasNext()) {
+            it.next();
+            if (!mCombinedProperties.contains(it.key())) {
+                mCombinedProperties.insert(it.key(), it.value());
             }
         }
     }


### PR DESCRIPTION
Related to the following issues, maybe even more: #365 #392 #367

Allows loading of objecttypes with default properties from xml.

Test-data: [objecttypes.xml for Stendhal entities](http://arianne.cvs.sourceforge.net/viewvc/arianne/stendhal/tiled/objecttypes.xml?content-type=text%2Fplain) by @nhnb 

<!---
@huboard:{"order":870.0,"milestone_order":877,"custom_state":""}
-->
