### PR TITLE
Added an auto tile to layer function.

### DIFF
--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -99,6 +99,10 @@ Preferences::Preferences()
     mAutoMapDrawing = boolValue("WhileDrawing");
     mSettings->endGroup();
 
+    mSettings->beginGroup(QLatin1String("AutoLayer"));
+    mAutoLayerTiles = boolValue("AutoLayerTiles");
+    mSettings->endGroup();
+
     mSettings->beginGroup(QLatin1String("MapsDirectory"));
     mMapsDirectory = stringValue("Current");
     mSettings->endGroup();
@@ -121,6 +125,16 @@ void Preferences::setShowGrid(bool showGrid)
     mSettings->setValue(QLatin1String("Interface/ShowGrid"), mShowGrid);
     emit showGridChanged(mShowGrid);
 }
+
+void Preferences::setAutoLayerTiles(bool autoLayer)
+{
+    if (mAutoLayerTiles == autoLayer)
+        return;
+
+    mAutoLayerTiles = autoLayer;
+    mSettings->setValue(QLatin1String("AutoLayer/AutoLayerTiles"), mAutoLayerTiles);
+}
+
 
 void Preferences::setShowTileObjectOutlines(bool enabled)
 {

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -92,6 +92,9 @@ public:
     QString mapsDirectory() const;
     void setMapsDirectory(const QString &path);
 
+    bool autoLayerTiles() const { return mAutoLayerTiles; }
+    void setAutoLayerTiles(bool enabled);
+
     /**
      * Provides access to the QSettings instance to allow storing/retrieving
      * arbitrary values. The naming style for groups and keys is CamelCase.
@@ -160,6 +163,8 @@ private:
     ObjectTypes mObjectTypes;
 
     bool mAutoMapDrawing;
+
+    bool mAutoLayerTiles;
 
     QString mMapsDirectory;
 

--- a/src/tiled/preferencesdialog.cpp
+++ b/src/tiled/preferencesdialog.cpp
@@ -167,6 +167,9 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) :
 
     connect(mUi->autoMapWhileDrawing, SIGNAL(toggled(bool)),
             SLOT(useAutomappingDrawingToggled(bool)));
+
+    connect(mUi->autoLayerEnabled, SIGNAL(toggled(bool)),
+            SLOT(useAutoLayerToggled(bool)));
 }
 
 PreferencesDialog::~PreferencesDialog()
@@ -316,6 +319,7 @@ void PreferencesDialog::fromPreferences()
     mUi->gridFine->setValue(prefs->gridFine());
     mUi->objectLineWidth->setValue(prefs->objectLineWidth());
     mUi->autoMapWhileDrawing->setChecked(prefs->automappingDrawing());
+    mUi->autoLayerEnabled->setChecked(prefs->autoLayerTiles());
     mObjectTypesModel->setObjectTypes(prefs->objectTypes());
 }
 
@@ -326,9 +330,15 @@ void PreferencesDialog::toPreferences()
     prefs->setReloadTilesetsOnChanged(mUi->reloadTilesetImages->isChecked());
     prefs->setDtdEnabled(mUi->enableDtd->isChecked());
     prefs->setAutomappingDrawing(mUi->autoMapWhileDrawing->isChecked());
+    prefs->setAutoLayerTiles(mUi->autoLayerEnabled->isChecked());
 }
 
 void PreferencesDialog::useAutomappingDrawingToggled(bool enabled)
 {
     Preferences::instance()->setAutomappingDrawing(enabled);
+}
+
+void PreferencesDialog::useAutoLayerToggled(bool enabled)
+{
+    Preferences::instance()->setAutoLayerTiles(enabled);
 }

--- a/src/tiled/preferencesdialog.h
+++ b/src/tiled/preferencesdialog.h
@@ -54,6 +54,7 @@ private slots:
     void objectLineWidthChanged(double lineWidth);
     void useOpenGLToggled(bool useOpenGL);
     void useAutomappingDrawingToggled(bool enabled);
+    void useAutoLayerToggled(bool enabled);
 
     void addObjectType();
     void selectedObjectTypesChanged();

--- a/src/tiled/preferencesdialog.ui
+++ b/src/tiled/preferencesdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>421</width>
+    <width>423</width>
     <height>383</height>
    </rect>
   </property>
@@ -18,7 +18,7 @@
     <enum>QLayout::SetFixedSize</enum>
    </property>
    <item>
-    <widget class="QTabWidget" name="tabWidget">
+    <widget class="QTabWidget" name="tabAutoLayer">
      <property name="currentIndex">
       <number>0</number>
      </property>
@@ -305,6 +305,24 @@
        </property>
       </widget>
      </widget>
+     <widget class="QWidget" name="tab_4">
+      <attribute name="title">
+       <string>AutoLayer</string>
+      </attribute>
+      <widget class="QCheckBox" name="autoLayerEnabled">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>121</width>
+         <height>17</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Enable Auto Layer</string>
+       </property>
+      </widget>
+     </widget>
     </widget>
    </item>
    <item>
@@ -327,7 +345,7 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>tabWidget</tabstop>
+  <tabstop>tabAutoLayer</tabstop>
   <tabstop>enableDtd</tabstop>
   <tabstop>reloadTilesetImages</tabstop>
   <tabstop>languageCombo</tabstop>

--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -30,6 +30,7 @@
 #include "tilelayer.h"
 #include "tile.h"
 #include "utils.h"
+#include "tileset.h"
 #include "preferences.h"
 
 #include <math.h>

--- a/src/tiled/utils.cpp
+++ b/src/tiled/utils.cpp
@@ -85,5 +85,44 @@ void saveGeometry(QWidget *widget)
     settings->setValue(key, widget->saveGeometry());
 }
 
+/**
+ * Takes a tileset name and splits it based on the '.'
+ * We should have 2 or more '.' in the sentence to parse a valid name.
+ * basically if we have 2 items we return the last item from the results of the split.
+ * if it's greater than 2 we return (n-1) from the split result.
+ * Also note that it returns nothing if the split results in less than 2 items.
+ */
+QString parsePreExtension(QString input)
+{
+
+    if (input.isNull() || input.isEmpty() || input.size() == 0) {
+        return QString();
+    }
+
+
+    const QLatin1Char splitToken = QLatin1Char('.');
+    const QStringList stringList = input.split(splitToken);
+    const int itemCount = stringList.size();
+
+    int tokenCount = 0;
+
+    //count the number of tokens.
+    for (int i = 0; i < input.size(); i++) {
+
+        if (input.at(i) == splitToken) {
+            tokenCount++;
+        }
+    }
+
+    if (tokenCount < 1 || itemCount < 2) {
+        return QString();
+    }
+
+    if (itemCount == 2) {
+        return stringList.at(1);
+    }
+    return stringList.at(itemCount - 1);
+}
+
 } // namespace Utils
 } // namespace Tiled

--- a/src/tiled/utils.h
+++ b/src/tiled/utils.h
@@ -65,6 +65,14 @@ void setThemeIcon(T *t, const char *name)
 void restoreGeometry(QWidget *widget);
 void saveGeometry(QWidget *widget);
 
+/**
+ * @brief parsePreExtention parses a pre-extention from a file name. Expected to be in the format of Foo.bar.png
+ * which makes the extention of the file .png but the pre-extention would be 'bar'.
+ * @param input = string to parse the pre-extention from.
+ * @return the pre extention or an empty string if none was able to be parsed.
+ */
+QString parsePreExtension(QString input);
+
 } // namespace Utils
 } // namespace Tiled
 


### PR DESCRIPTION
Added an auto tile to layer function.
Say you have two tile sets defined in the editor named (the name in the editor):
Grassland.ground
Grassland.object
And two layers named:
Object
Ground
What this will do is is look at the tile set in which the tile comes from and try to place it in the correct layer based on the extension in the name (not the image actual file). So say I have the Object layer selected but I am using a tile from the Grassland.ground what this would do is place the tile into the ground layer instead since it would look at the .ground and try to find the layer it needs to go to. It's not case sensitive and it currently used the '.' character to split the name. If the layer is not found it will default to the currently selected layer.

It could probably be named better but AutoLayer is what I thought of.