### PR TITLE
Automapping Tile Objects

### DIFF
--- a/src/libtiled/mapobject.cpp
+++ b/src/libtiled/mapobject.cpp
@@ -28,6 +28,7 @@
  */
 
 #include "mapobject.h"
+#include "tile.h"
 
 using namespace Tiled;
 
@@ -56,6 +57,23 @@ MapObject::MapObject(const QString &name, const QString &type,
     mRotation(0.0f),
     mVisible(true)
 {
+}
+
+QRectF MapObject::boundsUseTile() const
+{
+    if (mCell.isEmpty()) {
+        // No tile so just use regular bounds
+        return bounds();
+    }
+
+    // Using the tile for determing boundary
+    // Note the position given is the bottom-left corner so correct for that
+    QRectF rect;
+    rect.setLeft(mPos.x());
+    rect.setTop(mPos.y() - mCell.tile->height());
+    rect.setWidth(mCell.tile->width());
+    rect.setHeight(mCell.tile->height());
+    return rect;
 }
 
 void MapObject::flip(FlipDirection direction)

--- a/src/libtiled/mapobject.h
+++ b/src/libtiled/mapobject.h
@@ -201,6 +201,11 @@ public:
     QRectF bounds() const { return QRectF(mPos, mSize); }
 
     /**
+     * Shortcut to getting a QRectF from position() and size() that uses cell tile if present.
+     */
+    QRectF boundsUseTile() const;
+
+    /**
      * Sets the tile that is associated with this object. The object will
      * display as the tile image.
      *

--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -469,10 +469,22 @@ void AutoMapper::autoMap(QRegion *where)
                 TileLayer *dstTileLayer = dstLayer->asTileLayer();
                 if (dstTileLayer)
                     dstTileLayer->erase(region);
-                else
+                else {
+                    // Region has to be put into object space
+                    const int w = mMapDocument->map()->tileWidth();
+                    const int h = mMapDocument->map()->tileHeight();
+                    const QRect& tilesRect = region.boundingRect();
+                    QRect objRect;
+                    objRect.setTop(tilesRect.top() * h);
+                    objRect.setLeft(tilesRect.left() * w);
+                    objRect.setBottom((tilesRect.bottom() + 1) * h);
+                    objRect.setRight((tilesRect.right() + 1) * w);
+                    QRegion objRegion;
+                    objRegion += objRect;
                     eraseRegionObjectGroup(mMapDocument,
                                            dstLayer->asObjectGroup(),
-                                           region);
+                                           objRegion);
+                }
             }
         }
     }

--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -469,22 +469,10 @@ void AutoMapper::autoMap(QRegion *where)
                 TileLayer *dstTileLayer = dstLayer->asTileLayer();
                 if (dstTileLayer)
                     dstTileLayer->erase(region);
-                else {
-                    // Region has to be put into object space
-                    const int w = mMapDocument->map()->tileWidth();
-                    const int h = mMapDocument->map()->tileHeight();
-                    const QRect& tilesRect = region.boundingRect();
-                    QRect objRect;
-                    objRect.setTop(tilesRect.top() * h);
-                    objRect.setLeft(tilesRect.left() * w);
-                    objRect.setBottom((tilesRect.bottom() + 1) * h);
-                    objRect.setRight((tilesRect.right() + 1) * w);
-                    QRegion objRegion;
-                    objRegion += objRect;
+                else
                     eraseRegionObjectGroup(mMapDocument,
                                            dstLayer->asObjectGroup(),
-                                           objRegion);
-                }
+                                           region);
             }
         }
     }

--- a/src/tiled/automappingutils.cpp
+++ b/src/tiled/automappingutils.cpp
@@ -24,6 +24,7 @@
 #include "addremovemapobject.h"
 #include "mapdocument.h"
 #include "mapobject.h"
+#include "maprenderer.h"
 #include "objectgroup.h"
 
 #include <QUndoStack>
@@ -42,7 +43,22 @@ void eraseRegionObjectGroup(MapDocument *mapDocument,
         // tile objects. polygons and polylines are not covered correctly by this
         // erase method (we are in fact deleting too many objects)
         // TODO2: toAlignedRect may even break rects.
-        if (where.intersects(obj->bounds().toAlignedRect()))
+
+        // Convert the boundary of the object into tile space
+        const QRectF objBounds = obj->boundsUseTile();
+        QPointF tl = mapDocument->renderer()->pixelToTileCoords(objBounds.topLeft());
+        QPointF tr = mapDocument->renderer()->pixelToTileCoords(objBounds.topRight());
+        QPointF br = mapDocument->renderer()->pixelToTileCoords(objBounds.bottomRight());
+        QPointF bl = mapDocument->renderer()->pixelToTileCoords(objBounds.bottomLeft());
+
+        QRectF objInTileSpace;
+        objInTileSpace.setTopLeft(tl);
+        objInTileSpace.setTopRight(tr);
+        objInTileSpace.setBottomRight(br);
+        objInTileSpace.setBottomLeft(bl);
+
+        const QRect objAlignedRect = objInTileSpace.toAlignedRect();
+        if (where.intersects(objAlignedRect))
             undo->push(new RemoveMapObject(mapDocument, obj));
     }
 }
@@ -68,7 +84,7 @@ const QList<MapObject*> objectsInRegion(ObjectGroup *layer,
         // tile objects. polygons and polylines are not covered correctly by this
         // erase method (we are in fact deleting too many objects)
         // TODO2: toAlignedRect may even break rects.
-        const QRect rect = obj->bounds().toAlignedRect();
+        const QRect rect = obj->boundsUseTile().toAlignedRect();
 
         // QRegion::intersects() returns false for empty regions even if they are
         // contained within the region, so we also check for containment of the

--- a/src/tiled/automappingutils.cpp
+++ b/src/tiled/automappingutils.cpp
@@ -25,7 +25,6 @@
 #include "mapdocument.h"
 #include "mapobject.h"
 #include "objectgroup.h"
-#include "tile.h"
 
 #include <QUndoStack>
 
@@ -43,10 +42,7 @@ void eraseRegionObjectGroup(MapDocument *mapDocument,
         // tile objects. polygons and polylines are not covered correctly by this
         // erase method (we are in fact deleting too many objects)
         // TODO2: toAlignedRect may even break rects.
-		
-		// Note: intersects returns false in some conditions so check if corners are contained 
-        const QRect& objRect = obj->bounds().toAlignedRect();
-        if (where.intersects(objRect) || where.contains(objRect.topLeft()) || where.contains(objRect.bottomLeft()))
+        if (where.intersects(obj->bounds().toAlignedRect()))
             undo->push(new RemoveMapObject(mapDocument, obj));
     }
 }
@@ -77,8 +73,7 @@ const QList<MapObject*> objectsInRegion(ObjectGroup *layer,
         // QRegion::intersects() returns false for empty regions even if they are
         // contained within the region, so we also check for containment of the
         // top left to include the case of zero size objects.
-        // (Also, for Tile objects we need to check the bottom left)
-        if (where.intersects(rect) || where.contains(rect.topLeft()) || where.contains(rect.bottomLeft()))
+        if (where.intersects(rect) || where.contains(rect.topLeft()))
             ret += obj;
     }
     return ret;


### PR DESCRIPTION
Tile Objects can be added to Object Layers through the automapping
mechanism.
Also, fixed bug in "DeleteTiles" functionality with respect to Objects
(tiled or otherwise).

<!---
@huboard:{"order":871.0,"milestone_order":890,"custom_state":""}
-->
