### PR TITLE
Added a single tilesheet per layer option

### DIFF
--- a/src/libtiled/map.h
+++ b/src/libtiled/map.h
@@ -194,6 +194,16 @@ public:
     void setTileHeight(int height) { mTileHeight = height; }
 
     /**
+     * Returns wether the single sheet option is activated or not
+     */
+    bool singleSheet() const { return mSingleSheet; }
+
+    /**
+     * Sets single sheet option
+     */
+    void setSingleSheet(int v) { mSingleSheet = v; }
+
+    /**
      * Returns the size of one tile. Provided for convenience.
      */
     QSize tileSize() const { return QSize(mTileWidth, mTileHeight); }
@@ -398,6 +408,7 @@ private:
     int mTileWidth;
     int mTileHeight;
     int mHexSideLength;
+    bool mSingleSheet;
     StaggerAxis mStaggerAxis;
     StaggerIndex mStaggerIndex;
     QColor mBackgroundColor;

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -94,6 +94,7 @@ private:
     QDir mMapDir;     // The directory in which the map is being saved
     GidMapper mGidMapper;
     bool mUseAbsolutePaths;
+    const Map *mMap;
 };
 
 } // namespace Internal
@@ -213,6 +214,7 @@ void MapWriterPrivate::writeMap(QXmlStreamWriter &w, const Map *map)
         firstGid += tileset->tileCount();
     }
 
+    mMap = map;
     foreach (const Layer *layer, map->layers()) {
         const Layer::TypeFlag type = layer->layerType();
         if (type == Layer::TileLayerType)
@@ -426,11 +428,34 @@ void MapWriterPrivate::writeTileLayer(QXmlStreamWriter &w,
     if (!compression.isEmpty())
         w.writeAttribute(QLatin1String("compression"), compression);
 
+    if (mMap->singleSheet())
+    {
+        bool tSetFound = false;
+        QString tname;
+        for (int y = 0; y < tileLayer->height(); ++y) {
+            for (int x = 0; x < tileLayer->width(); ++x) {
+                const Cell c = tileLayer->cellAt(x, y);
+                if (!c.isEmpty()) {
+                    tname = c.tile->tileset()->name();
+                    tSetFound = true;
+                }
+            }
+        }
+        if (tSetFound)
+            w.writeAttribute(QLatin1String("tileset"), QLatin1String(tname.toLatin1()));
+    }
+
     if (mLayerDataFormat == Map::XML) {
         for (int y = 0; y < tileLayer->height(); ++y) {
             for (int x = 0; x < tileLayer->width(); ++x) {
-                const unsigned gid = mGidMapper.cellToGid(tileLayer->cellAt(x, y));
+                const Cell c = tileLayer->cellAt(x, y);
+                unsigned gid = mGidMapper.cellToGid(c);
                 w.writeStartElement(QLatin1String("tile"));
+                if (mMap->singleSheet())
+                    if (c.isEmpty())
+                        gid = 0;
+                    else
+                        gid = c.tile->id();
                 w.writeAttribute(QLatin1String("gid"), QString::number(gid));
                 w.writeEndElement();
             }
@@ -440,7 +465,13 @@ void MapWriterPrivate::writeTileLayer(QXmlStreamWriter &w,
 
         for (int y = 0; y < tileLayer->height(); ++y) {
             for (int x = 0; x < tileLayer->width(); ++x) {
-                const unsigned gid = mGidMapper.cellToGid(tileLayer->cellAt(x, y));
+                const Cell c = tileLayer->cellAt(x, y);
+                unsigned gid = mGidMapper.cellToGid(c);
+                if (mMap->singleSheet())
+                    if (c.isEmpty())
+                        gid = 0;
+                    else
+                        gid = c.tile->id();
                 tileData.append(QString::number(gid));
                 if (x != tileLayer->width() - 1
                     || y != tileLayer->height() - 1)
@@ -457,7 +488,13 @@ void MapWriterPrivate::writeTileLayer(QXmlStreamWriter &w,
 
         for (int y = 0; y < tileLayer->height(); ++y) {
             for (int x = 0; x < tileLayer->width(); ++x) {
-                const unsigned gid = mGidMapper.cellToGid(tileLayer->cellAt(x, y));
+                const Cell c = tileLayer->cellAt(x, y);
+                unsigned gid = mGidMapper.cellToGid(c);
+                if (mMap->singleSheet())
+                    if (c.isEmpty())
+                        gid = 0;
+                    else
+                        gid = c.tile->id();
                 tileData.append((char) (gid));
                 tileData.append((char) (gid >> 8));
                 tileData.append((char) (gid >> 16));

--- a/src/tiled/changemapproperty.cpp
+++ b/src/tiled/changemapproperty.cpp
@@ -172,6 +172,12 @@ void ChangeMapProperty::swap()
         mRenderOrder = renderOrder;
         break;
     }
+    case SingleSheet: {
+        const bool singleSheet = map->singleSheet();
+        map->setSingleSheet(mSingleSheet);
+        mSingleSheet = singleSheet;
+        break;
+    }
     case BackgroundColor: {
         const QColor backgroundColor = map->backgroundColor();
         map->setBackgroundColor(mBackgroundColor);

--- a/src/tiled/changemapproperty.h
+++ b/src/tiled/changemapproperty.h
@@ -43,7 +43,8 @@ public:
         Orientation,
         RenderOrder,
         BackgroundColor,
-        LayerDataFormat
+        LayerDataFormat,
+        SingleSheet
     };
 
     /**
@@ -113,6 +114,7 @@ private:
     MapDocument *mMapDocument;
     Property mProperty;
     QColor mBackgroundColor;
+    bool mSingleSheet;
     union {
         int mIntValue;
         Map::StaggerAxis mStaggerAxis;

--- a/src/tiled/newmapdialog.cpp
+++ b/src/tiled/newmapdialog.cpp
@@ -38,6 +38,7 @@ static const char * const MAP_WIDTH_KEY = "Map/Width";
 static const char * const MAP_HEIGHT_KEY = "Map/Height";
 static const char * const TILE_WIDTH_KEY = "Map/TileWidth";
 static const char * const TILE_HEIGHT_KEY = "Map/TileHeight";
+static const char * const SINGLE_SHEET_KEY = "Map/SingleSheet";
 
 using namespace Tiled;
 using namespace Tiled::Internal;
@@ -58,6 +59,7 @@ NewMapDialog::NewMapDialog(QWidget *parent) :
     const int tileWidth = s->value(QLatin1String(TILE_WIDTH_KEY), 32).toInt();
     const int tileHeight = s->value(QLatin1String(TILE_HEIGHT_KEY),
                                     32).toInt();
+    const bool singleSheet = s->value(QLatin1String(SINGLE_SHEET_KEY), false).toBool();
 
     mUi->layerFormat->addItem(QCoreApplication::translate("PreferencesDialog", "XML"));
     mUi->layerFormat->addItem(QCoreApplication::translate("PreferencesDialog", "Base64 (uncompressed)"));
@@ -82,6 +84,7 @@ NewMapDialog::NewMapDialog(QWidget *parent) :
     mUi->mapHeight->setValue(mapHeight);
     mUi->tileWidth->setValue(tileWidth);
     mUi->tileHeight->setValue(tileHeight);
+    mUi->singleSheet->setChecked(singleSheet);
 
     // Make the font of the pixel size label smaller
     QFont font = mUi->pixelSizeLabel->font();
@@ -111,6 +114,7 @@ MapDocument *NewMapDialog::createMap()
     const int mapHeight = mUi->mapHeight->value();
     const int tileWidth = mUi->tileWidth->value();
     const int tileHeight = mUi->tileHeight->value();
+    const bool singleSheet = mUi->singleSheet->isChecked();
 
     const int orientationIndex = mUi->orientation->currentIndex();
     const QVariant orientationData = mUi->orientation->itemData(orientationIndex);
@@ -127,6 +131,7 @@ MapDocument *NewMapDialog::createMap()
 
     map->setLayerDataFormat(layerFormat);
     map->setRenderOrder(renderOrder);
+    map->setSingleSheet(singleSheet);
 
     const size_t gigabyte = 1073741824;
     const size_t memory = size_t(mapWidth) * size_t(mapHeight) * sizeof(Cell);
@@ -153,6 +158,7 @@ MapDocument *NewMapDialog::createMap()
     s->setValue(QLatin1String(MAP_HEIGHT_KEY), mapHeight);
     s->setValue(QLatin1String(TILE_WIDTH_KEY), tileWidth);
     s->setValue(QLatin1String(TILE_HEIGHT_KEY), tileHeight);
+    s->setValue(QLatin1String(SINGLE_SHEET_KEY), singleSheet);
 
     return new MapDocument(map);
 }

--- a/src/tiled/newmapdialog.ui
+++ b/src/tiled/newmapdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>371</width>
-    <height>323</height>
+    <width>388</width>
+    <height>353</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -188,7 +188,7 @@
       <string>Map</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="label_5">
         <property name="text">
          <string>Orientation:</string>
@@ -198,7 +198,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="1" column="1">
        <widget class="QComboBox" name="orientation">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -208,7 +208,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="layerFormatLabel">
         <property name="text">
          <string>Tile layer format:</string>
@@ -218,10 +218,10 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="QComboBox" name="layerFormat"/>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="renderOrderLabel">
         <property name="text">
          <string>Tile render order:</string>
@@ -231,8 +231,15 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QComboBox" name="renderOrder"/>
+      </item>
+      <item row="4" column="0">
+       <widget class="QCheckBox" name="singleSheet">
+        <property name="text">
+         <string>Single tilesheet per layer</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -423,6 +423,11 @@ void PropertyBrowser::addMapProperties()
 
     renderOrderProperty->setAttribute(QLatin1String("enumNames"), mRenderOrderNames);
 
+    createProperty(SingleSheetProperty,
+                           QVariant::Bool,
+                           tr("Single tilesheet per layer"),
+                           groupProperty);
+
     createProperty(ColorProperty, QVariant::Color, tr("Background Color"), groupProperty);
     addProperty(groupProperty);
 }
@@ -595,6 +600,10 @@ void PropertyBrowser::applyMapValue(PropertyId id, const QVariant &val)
         Map::RenderOrder renderOrder = static_cast<Map::RenderOrder>(val.toInt());
         command = new ChangeMapProperty(mMapDocument, renderOrder);
         break;
+    }
+    case SingleSheetProperty: {
+        command = new ChangeMapProperty(mMapDocument, ChangeMapProperty::SingleSheet,
+                                        val.toBool());
     }
     case ColorProperty:
         command = new ChangeMapProperty(mMapDocument, val.value<QColor>());
@@ -871,6 +880,7 @@ void PropertyBrowser::updateProperties()
         mIdToProperty[StaggerIndexProperty]->setValue(map->staggerIndex());
         mIdToProperty[LayerFormatProperty]->setValue(map->layerDataFormat());
         mIdToProperty[RenderOrderProperty]->setValue(map->renderOrder());
+        mIdToProperty[SingleSheetProperty]->setValue(map->singleSheet());
         QColor backgroundColor = map->backgroundColor();
         if (!backgroundColor.isValid())
             backgroundColor = Qt::darkGray;

--- a/src/tiled/propertybrowser.h
+++ b/src/tiled/propertybrowser.h
@@ -122,7 +122,8 @@ private:
         TileOffsetProperty,
         TileProbabilityProperty,
         IdProperty,
-        CustomProperty
+        CustomProperty,
+        SingleSheetProperty
     };
 
     void addMapProperties();


### PR DESCRIPTION
Now allows to optionally save a .tmx file in which:
* Layer elements have a tileset property (if it's not a totally empty layer) which identify the tileset used for the layer. It doesn't refrain you from using various tilesets in a single layer, but if you do that then you don't need this option anyways:
 ```
 <data encoding="csv" tileset="test_tiles">
 ```
* Tiles' ids are saved, not the gids

There is an option (defaults to false) to enable this saving mode. It can be toggled in the new map creation dialog, as well as the map properties pane.