### PR TITLE
#975 Fixed crash while changing different properties at once.

### DIFF
--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -676,7 +676,10 @@ void PropertyBrowser::applyMapObjectValue(PropertyId id, const QVariant &val)
     if (selectedObjects.size() > 1) {
         foreach (MapObject *obj, selectedObjects) {
             if (obj != mapObject) {
-                mMapDocument->undoStack()->push(applyMapObjectValueTo(id, val, obj));
+                QUndoCommand *cmd = applyMapObjectValueTo(id, val, obj);
+                if (cmd != 0) {
+                    mMapDocument->undoStack()->push(cmd);
+                }
             }
         }
     }


### PR DESCRIPTION
applyMapObjectValue(...) returns command only if flipping state is different from the user set. In sutuations when user selects multiply objects and try to set an option for them applyMapObjectValue(...) returns 0 for some already checked/unchecked flipping options (the state is same as user set). This '0' is the reason of crash and now was fixed.