### PR TITLE
allow setting transparency color for tileset image collection

### DIFF
--- a/src/tiled/newtilesetdialog.ui
+++ b/src/tiled/newtilesetdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>387</width>
-    <height>314</height>
+    <height>345</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -114,34 +114,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QCheckBox" name="useTransparentColor">
-        <property name="text">
-         <string>Use transparent color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="Tiled::Internal::ColorButton" name="colorButton">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>0</width>
-          <height>13</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="2" column="0" colspan="5">
+      <item row="1" column="0" colspan="4">
        <layout class="QGridLayout" name="gridLayout_3">
         <item row="1" column="1">
          <widget class="QSpinBox" name="tileHeight">
@@ -279,6 +252,52 @@
        <widget class="QLineEdit" name="image"/>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="transparencyGroupBox">
+     <property name="title">
+      <string>Transparency</string>
+     </property>
+     <widget class="QWidget" name="horizontalLayoutWidget">
+      <property name="geometry">
+       <rect>
+        <x>19</x>
+        <y>20</y>
+        <width>451</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QCheckBox" name="useTransparentColor">
+         <property name="text">
+          <string>Use transparent color:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="Tiled::Internal::ColorButton" name="colorButton">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>17</width>
+           <height>17</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -48,10 +48,12 @@
 
 #include <QMimeData>
 #include <QAction>
+#include <QBitmap>
 #include <QDropEvent>
 #include <QComboBox>
 #include <QFileDialog>
 #include <QHBoxLayout>
+#include <QImage>
 #include <QInputDialog>
 #include <QMenu>
 #include <QMessageBox>
@@ -827,9 +829,16 @@ void TilesetDock::addTiles()
     int id = tileset->tileCount();
 
     foreach (const QString &file, files) {
-        const QPixmap image(file);
-        if (!image.isNull()) {
-            tiles.append(new Tile(image, file, id, tileset));
+        const QImage tileImage(file);
+        if (!tileImage.isNull()) {
+            QPixmap tilePixmap = QPixmap::fromImage(tileImage);
+            if (tileset->transparentColor().isValid())
+            {
+                const QBitmap mask =
+                        tilePixmap.createMaskFromColor(tileset->transparentColor().rgb());
+                tilePixmap.setMask(mask);
+            }
+            tiles.append(new Tile(tilePixmap, file, id, tileset));
             ++id;
         } else {
             QMessageBox warning(QMessageBox::Warning,


### PR DESCRIPTION
This patch moves the transparency related widgets out of the Image group-box so it can be set when creating a image collection tileset. It also applies the transparency color when you add an image from the tileset dock.

![screenshot](https://cloud.githubusercontent.com/assets/901271/8150193/974d96b0-12ad-11e5-83b6-7659cd4261c3.png)
![screenshot2](https://cloud.githubusercontent.com/assets/901271/8150192/974b1c0a-12ad-11e5-886d-a4c8f92f505d.png)
