### PR TITLE
Fixed possible memory leaks.

### DIFF
--- a/src/libtiled/logginginterface.h
+++ b/src/libtiled/logginginterface.h
@@ -46,6 +46,8 @@ class LoggingInterface
       INFO, ERROR
     };
 
+    virtual ~LoggingInterface() {}
+
     virtual void log(OutputType type, const QString) = 0;
 };
 

--- a/src/libtiled/mapreader.h
+++ b/src/libtiled/mapreader.h
@@ -54,7 +54,7 @@ class TILEDSHARED_EXPORT MapReader
 {
 public:
     MapReader();
-    ~MapReader();
+    virtual ~MapReader();
 
     /**
      * Reads a TMX map from the given \a device. Optionally a \a path can


### PR DESCRIPTION
There are some classes which used as base for other classes and haven't got virtual destructors. It could be the reason of memory leaks in some cases. This pull request fixes this situation.