### PR TITLE
Added 'File => Save All' functionality.

### DIFF
--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -293,6 +293,7 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
             SLOT(clearRecentFiles()));
     connect(mUi->actionSave, SIGNAL(triggered()), SLOT(saveFile()));
     connect(mUi->actionSaveAs, SIGNAL(triggered()), SLOT(saveFileAs()));
+    connect(mUi->actionSaveAll, SIGNAL(triggered()), SLOT(saveAll()));
     connect(mUi->actionExportAsImage, SIGNAL(triggered()), SLOT(exportAsImage()));
     connect(mUi->actionExport, SIGNAL(triggered()), SLOT(export_()));
     connect(mUi->actionExportAs, SIGNAL(triggered()), SLOT(exportAs()));
@@ -814,6 +815,29 @@ bool MainWindow::saveFileAs()
     mMapDocument->setWriterPluginFileName(writerPluginFilename);
 
     return saveFile(fileName);
+}
+
+void MainWindow::saveAll()
+{
+    foreach (MapDocument *mapDoc, mDocumentManager->documents()) {
+        if (!mapDoc->isModified())
+            continue;
+
+        QString fileName(mapDoc->fileName());
+        QString error;
+
+        if (fileName.isEmpty()) {
+            mDocumentManager->switchToDocument(mapDoc);
+            if (!saveFileAs())
+                return;
+        } else if (!mapDoc->save(fileName, &error)) {
+            mDocumentManager->switchToDocument(mapDoc);
+            QMessageBox::critical(this, tr("Error Saving Map"), error);
+            return;
+        }
+
+        setRecentFile(fileName);
+    }
 }
 
 bool MainWindow::confirmSave(MapDocument *mapDocument)
@@ -1446,6 +1470,7 @@ void MainWindow::updateActions()
 
     mUi->actionSave->setEnabled(map);
     mUi->actionSaveAs->setEnabled(map);
+    mUi->actionSaveAll->setEnabled(map);
     mUi->actionExportAsImage->setEnabled(map);
     mUi->actionExport->setEnabled(map);
     mUi->actionExportAs->setEnabled(map);

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -119,6 +119,7 @@ public slots:
     void openFile();
     bool saveFile();
     bool saveFileAs();
+    void saveAll();
     void export_(); // 'export' is a reserved word
     void exportAs();
     void exportAsImage();

--- a/src/tiled/mainwindow.ui
+++ b/src/tiled/mainwindow.ui
@@ -21,16 +21,7 @@
   </property>
   <widget class="QWidget" name="centralWidget">
    <layout class="QVBoxLayout" name="verticalLayout">
-    <property name="leftMargin">
-     <number>0</number>
-    </property>
-    <property name="topMargin">
-     <number>0</number>
-    </property>
-    <property name="rightMargin">
-     <number>0</number>
-    </property>
-    <property name="bottomMargin">
+    <property name="margin">
      <number>0</number>
     </property>
    </layout>
@@ -41,7 +32,7 @@
      <x>0</x>
      <y>0</y>
      <width>553</width>
-     <height>27</height>
+     <height>23</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -64,6 +55,7 @@
     <addaction name="separator"/>
     <addaction name="actionSave"/>
     <addaction name="actionSaveAs"/>
+    <addaction name="actionSaveAll"/>
     <addaction name="actionExport"/>
     <addaction name="actionExportAs"/>
     <addaction name="actionExportAsImage"/>
@@ -473,6 +465,11 @@
   <action name="actionBecomePatron">
    <property name="text">
     <string>Become a Patron</string>
+   </property>
+  </action>
+  <action name="actionSaveAll">
+   <property name="text">
+    <string>Save All</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Useful feature to save all opened documents at once. Useful when game developer opens all his game's levels in an editor then edit them in similar way and wants to save them with one click.