### PR TITLE
Build fixes

### DIFF
--- a/dist/win/dist.qbs
+++ b/dist/win/dist.qbs
@@ -1,0 +1,36 @@
+import qbs
+import qbs.FileInfo
+
+NSISSetup {
+    builtByDefault: false
+    condition: qbs.toolchain.contains("mingw")
+
+    Depends { productTypes: ["application", "dynamiclibrary"] }
+    type: base.concat(["installable"])
+
+    Depends { name: "cpp" }
+    Depends { name: "Qt.core" }
+
+    property int bits: {
+        if (qbs.architecture === "x86_64")
+            return 64;
+        if (qbs.architecture === "x86")
+            return 32;
+    }
+
+    targetName: "tiled-" + version + "-win" + bits + "-setup"
+    version: project.version
+
+    nsis.defines: [
+        "QT_DIR=" + FileInfo.joinPaths(Qt.core.binPath, ".."),
+        "MINGW_DIR=" + FileInfo.joinPaths(cpp.toolchainInstallPath, ".."),
+        "V=" + version,
+        "ARCH=" + qbs.architecture,
+        "ROOT_DIR=" + project.sourceDirectory,
+        "BUILD_DIR=" + qbs.installRoot
+    ]
+
+    files: [
+        "*"
+    ]
+}

--- a/dist/win/tiled.nsi
+++ b/dist/win/tiled.nsi
@@ -8,15 +8,33 @@ CRCCheck force
 XPStyle on
 SetCompressor /FINAL /SOLID lzma
 
+!ifndef QT_DIR
 !define QT_DIR $%QTDIR%                       ; Qt Installation directory
+!endif
+
+!ifndef MINGW_DIR
 !define MINGW_DIR $%MINGW%                    ; MinGW Installation directory
+!endif
+
+!ifndef V
 !define V $%VERSION%                          ; Program version
+!endif
+
+!ifndef ARCH
 !define ARCH $%ARCH%                          ; Architecture 32 or 64
+!endif
 
 !define P "Tiled"                             ; Program name
 !define P_NORM "tiled"                        ; Program name (normalized)
+
+!ifndef ROOT_DIR
 !define ROOT_DIR "..\.."                      ; Program root directory
+!endif
+
+!ifndef BUILD_DIR
 !define BUILD_DIR $%TILED_BUILD_DIR%          ; Build dir
+!endif
+
 !define SYSTEM_DIR "C:\windows\system32"
 !define ADD_REMOVE "Software\Microsoft\Windows\CurrentVersion\Uninstall\Tiled"
 !define PRODUCT_REG_KEY "Tiled Map Editor"

--- a/src/plugins/python/python.qbs
+++ b/src/plugins/python/python.qbs
@@ -25,8 +25,8 @@ TiledPlugin {
 
     Properties {
         condition: qbs.targetOS.contains("windows")
-        cpp.cxxFlags: "-IC:/Python27/include"
-        cpp.linkerFlags: "-LC:/Python27/libs"
+        cpp.includePaths: ["C:/Python27/include"]
+        cpp.libraryPaths: ["C:/Python27/libs"]
         cpp.dynamicLibraries: ["python27"]
     }
 

--- a/tiled.qbs
+++ b/tiled.qbs
@@ -3,7 +3,10 @@ import qbs 1.0
 Project {
     qbsSearchPaths: "qbs"
 
+    property string version: qbs.getEnv("BUILD_INFO_VERSION")
+
     references: [
+        "dist/win",
         "src/automappingconverter",
         "src/libtiled",
         "src/plugins",


### PR DESCRIPTION
You can now build the NSIS installer using `qbs -p dist` or `qbs --all-products`

It will not be built during a default invocation of Qbs (think `make dist` vs `make`/`make all`)