### PR TITLE
Fixed issue #1005.

### DIFF
--- a/src/tiled/mapdocumentactionhandler.cpp
+++ b/src/tiled/mapdocumentactionhandler.cpp
@@ -175,6 +175,8 @@ void MapDocumentActionHandler::setMapDocument(MapDocument *mapDocument)
     updateActions();
 
     if (mMapDocument) {
+        connect(mapDocument, SIGNAL(layerRemoved(int)),
+                SLOT(updateActions()));
         connect(mapDocument, SIGNAL(currentLayerIndexChanged(int)),
                 SLOT(updateActions()));
         connect(mapDocument, SIGNAL(selectedAreaChanged(QRegion,QRegion)),


### PR DESCRIPTION
Fortunately, I found time to look into #1005. Not sure is it a correct fix. In updateActions() at the moment of deleting mapDocument still returns 2 layers (when should be one), so the guaranteed deletion would be after layerRemoved signal as I think.