### PR TITLE
Animation driver TODO solved.

### DIFF
--- a/src/tiled/tilesetmanager.cpp
+++ b/src/tiled/tilesetmanager.cpp
@@ -157,11 +157,23 @@ void TilesetManager::setReloadTilesetsOnChange(bool enabled)
 
 void TilesetManager::setAnimateTiles(bool enabled)
 {
-    // TODO: Avoid running the driver when there are no animated tiles
-    if (enabled)
-        mAnimationDriver->start();
-    else
+    if ((enabled && mAnimationDriver->state() == QAbstractAnimation::Running)
+        || (!enabled && mAnimationDriver->state() == QAbstractAnimation::Stopped))
+        return;
+
+    if (enabled) {
+        // At first check if we have animated tiles to avoid driver starting when we have no animated tiles
+        foreach (Tileset *t, mTilesets.keys()) {
+            foreach (Tile *tile, t->tiles()) {
+                if (tile->isAnimated()) {
+                    mAnimationDriver->start();
+                    return;
+                }
+            }
+        }
+    } else {
         mAnimationDriver->stop();
+    }
 }
 
 bool TilesetManager::animateTiles() const


### PR DESCRIPTION
Now animation driver isn't started when there are no animated tiles. There is also added a check that driver isn't running already to avoid extra searching of animated tiles each times user calls 'mAnimationDriver->start()' more than once without correspondend 'stop()'.
**Warning**: due to technical problems (Very old PC) the patch wasn't tested.