### PR TITLE
AppVeyor: install NSIS using the Chocolatey package manager.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,7 @@ environment:
 configuration: Release
 
 install:
-  - appveyor DownloadFile "http://kent.dl.sourceforge.net/project/nsis/NSIS 2/2.46/nsis-2.46-setup.exe" -FileName nsissetup.exe
-  - nsissetup /S
+  - choco install -y nsis
   - set PATH=%PATH%;%QTDIR%\bin;%MINGW%\bin;C:\Qt\Tools\QtCreator\bin
 
 build_script:


### PR DESCRIPTION
Another small improvement to CI config. I'm working on getting Qbs available through Chocolatey as well so then you'll be able to easily use a newer version without relying on Qt Creator.