### PR TITLE
Usability improvement: double click on polygon.

### DIFF
--- a/src/tiled/documentmanager.cpp
+++ b/src/tiled/documentmanager.cpp
@@ -386,6 +386,9 @@ void DocumentManager::currentIndexChanged()
         mapScene->setSelectedTool(mSelectedTool);
         mapScene->enableSelectedTool();
         mSceneWithTool = mapScene;
+        connect(mSceneWithTool, SIGNAL(polygonDoubleClicked(QGraphicsSceneMouseEvent*)),
+            this, SIGNAL(polygonDoubleClicked(QGraphicsSceneMouseEvent*)),
+            Qt::UniqueConnection);
     }
 }
 

--- a/src/tiled/documentmanager.h
+++ b/src/tiled/documentmanager.h
@@ -28,6 +28,7 @@
 #include <QPointF>
 
 class QUndoGroup;
+class QGraphicsSceneMouseEvent;
 
 namespace Tiled {
 
@@ -176,6 +177,11 @@ signals:
      * Emitted when an error occurred while reloading the map.
      */
     void reloadError(const QString &error);
+
+    /**
+     * Emitted when polygon is double clicked.
+     */
+    void polygonDoubleClicked(QGraphicsSceneMouseEvent *event);
 
 public slots:
     void switchToLeftDocument();

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -144,6 +144,8 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
 {
     mUi->setupUi(this);
     setCentralWidget(mDocumentManager->widget());
+    connect (mDocumentManager, SIGNAL(polygonDoubleClicked(QGraphicsSceneMouseEvent*)),
+        this, SLOT(onPolygonDoubleClicked(QGraphicsSceneMouseEvent*)));
 
 #ifdef Q_OS_MAC
     MacSupport::addFullscreen(this);
@@ -383,6 +385,7 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     mStampBrush = new StampBrush(this);
     mTerrainBrush = new TerrainBrush(this);
     mBucketFillTool = new BucketFillTool(this);
+    mEditPolygonTool = new EditPolygonTool(this);
     CreateObjectTool *tileObjectsTool = new CreateTileObjectTool(this);
     CreateObjectTool *rectangleObjectsTool = new CreateRectangleObjectTool(this);
     CreateObjectTool *ellipseObjectsTool = new CreateEllipseObjectTool(this);
@@ -424,7 +427,7 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     toolBar->addAction(mToolManager->registerTool(new SelectSameTileTool(this)));
     toolBar->addSeparator();
     toolBar->addAction(mToolManager->registerTool(new ObjectSelectionTool(this)));
-    toolBar->addAction(mToolManager->registerTool(new EditPolygonTool(this)));
+    toolBar->addAction(mToolManager->registerTool(mEditPolygonTool));
     toolBar->addAction(mToolManager->registerTool(rectangleObjectsTool));
     toolBar->addAction(mToolManager->registerTool(ellipseObjectsTool));
     toolBar->addAction(mToolManager->registerTool(polygonObjectsTool));
@@ -1385,6 +1388,14 @@ void MainWindow::onAnimationEditorClosed()
 void MainWindow::onCollisionEditorClosed()
 {
     mShowTileCollisionEditor->setChecked(false);
+}
+
+void MainWindow::onPolygonDoubleClicked(QGraphicsSceneMouseEvent *event)
+{
+    if (mToolManager->selectedTool() != mEditPolygonTool)
+        mToolManager->selectTool(mEditPolygonTool);
+    // For more usability we select the shape when it was double clicked.
+    mEditPolygonTool->mousePressed(event);
 }
 
 void MainWindow::openRecentFile()

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -34,6 +34,7 @@
 class QComboBox;
 class QLabel;
 class QToolButton;
+class QGraphicsSceneMouseEvent;
 
 namespace Ui {
 class MainWindow;
@@ -51,6 +52,7 @@ class AutomappingManager;
 class BucketFillTool;
 class CommandButton;
 class DocumentManager;
+class EditPolygonTool;
 class LayerDock;
 class MapDocumentActionHandler;
 class MapScene;
@@ -176,6 +178,9 @@ public slots:
     void onAnimationEditorClosed();
     void onCollisionEditorClosed();
 
+private slots:
+    void onPolygonDoubleClicked(QGraphicsSceneMouseEvent *event);
+
 private:
     /**
       * Asks the user whether the given \a mapDocument should be saved, when
@@ -238,6 +243,7 @@ private:
     StampBrush *mStampBrush;
     BucketFillTool *mBucketFillTool;
     TerrainBrush *mTerrainBrush;
+    EditPolygonTool *mEditPolygonTool;
 
     enum { MaxRecentFiles = 8 };
     QAction *mRecentFiles[MaxRecentFiles];

--- a/src/tiled/mapscene.h
+++ b/src/tiled/mapscene.h
@@ -111,6 +111,7 @@ public:
 
 signals:
     void selectedObjectItemsChanged();
+    void polygonDoubleClicked(QGraphicsSceneMouseEvent *event);
 
 protected:
     /**
@@ -127,6 +128,7 @@ protected:
     void mouseMoveEvent(QGraphicsSceneMouseEvent *mouseEvent);
     void mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent);
     void mouseReleaseEvent(QGraphicsSceneMouseEvent *mouseEvent);
+    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *mouseEvent);
 
     void dragEnterEvent(QGraphicsSceneDragDropEvent *event);
 


### PR DESCRIPTION
**Implements**: Changing 'object selection tool' to 'polygon edit tool' when clicking on polygon.
**Implementation details**: When user makes double click on the polygon or the polyline the current tool is changed to '*polygon edit tool*'. Current tool could be only '*object selection tool*' as other tools are used to create objects and we shouldn't prevent user to create something. Also patch includes shape selection after double click for increasing the usability as the shape isn't selected after double click and user should manually select it to be able to change it with new tool.
**Testing**: A base test which could tell us that it **works**. Moreover tested some cases:
* Double click when current tool is not 'object selection tool';
* Double click on point with no shape;
* Double click on non-polygon & non-polyline shapes;
No bugs noticed in all these cases.