### PR TITLE
Add "Split into tiles" option to Export As Image dialog

### DIFF
--- a/src/tiled/exportasimagedialog.cpp
+++ b/src/tiled/exportasimagedialog.cpp
@@ -41,6 +41,7 @@ static const char * const VISIBLE_ONLY_KEY = "SaveAsImage/VisibleLayersOnly";
 static const char * const CURRENT_SCALE_KEY = "SaveAsImage/CurrentScale";
 static const char * const DRAW_GRID_KEY = "SaveAsImage/DrawGrid";
 static const char * const INCLUDE_BACKGROUND_COLOR = "SaveAsImage/IncludeBackgroundColor";
+static const char * const SPLIT_INTO_TILES_KEY = "SaveAsImage/SplitIntoTiles";
 
 using namespace Tiled;
 using namespace Tiled::Internal;
@@ -84,6 +85,11 @@ ExportAsImageDialog::ExportAsImageDialog(MapDocument *mapDocument,
 
     mUi->fileNameEdit->setText(suggestion);
 
+    // Constrain tile width/height to map size
+    const QSize mapSize = mMapDocument->renderer()->mapSize();
+    mUi->tileWidthSpinBox->setMaximum(mapSize.width());
+    mUi->tileHeightSpinBox->setMaximum(mapSize.height());
+
     // Restore previously used settings
     QSettings *s = Preferences::instance()->settings();
     const bool visibleLayersOnly =
@@ -94,16 +100,24 @@ ExportAsImageDialog::ExportAsImageDialog(MapDocument *mapDocument,
             s->value(QLatin1String(DRAW_GRID_KEY), false).toBool();
     const bool includeBackgroundColor =
             s->value(QLatin1String(INCLUDE_BACKGROUND_COLOR), false).toBool();
+    const bool splitIntoTiles =
+            s->value(QLatin1String(SPLIT_INTO_TILES_KEY), false).toBool();
 
     mUi->visibleLayersOnly->setChecked(visibleLayersOnly);
     mUi->currentZoomLevel->setChecked(useCurrentScale);
     mUi->drawTileGrid->setChecked(drawTileGrid);
     mUi->includeBackgroundColor->setChecked(includeBackgroundColor);
+    mUi->splitIntoTiles->setChecked(splitIntoTiles);
+    mUi->tileWidthSpinBox->setEnabled(splitIntoTiles);
+    mUi->tileHeightSpinBox->setEnabled(splitIntoTiles);
 
     connect(mUi->browseButton, SIGNAL(clicked()), SLOT(browse()));
     connect(mUi->fileNameEdit, SIGNAL(textChanged(QString)),
             this, SLOT(updateAcceptEnabled()));
-
+    connect(mUi->splitIntoTiles, SIGNAL(clicked(bool)),
+            mUi->tileWidthSpinBox, SLOT(setEnabled(bool)));
+    connect(mUi->splitIntoTiles, SIGNAL(clicked(bool)),
+            mUi->tileHeightSpinBox, SLOT(setEnabled(bool)));
 
     Utils::restoreGeometry(this);
 }
@@ -124,13 +138,33 @@ static bool smoothTransform(qreal scale)
     return scale != qreal(1) && scale < qreal(2);
 }
 
+/*!
+    Returns a rectangular portion of \a image specified by \a rect,
+    without copying. \a image must exist as long as the returned
+    image does.
+
+    http://stackoverflow.com/a/12682022/904422
+*/
+static QImage createSubImage(QImage* image, const QRect &rect) {
+    const size_t offset = rect.x() * image->depth() / 8
+            + rect.y() * image->bytesPerLine();
+    return QImage(image->bits() + offset, rect.width(), rect.height(),
+                  image->bytesPerLine(), image->format());
+}
+
 void ExportAsImageDialog::accept()
 {
     const QString fileName = mUi->fileNameEdit->text();
     if (fileName.isEmpty())
         return;
 
-    if (QFile::exists(fileName)) {
+    const bool visibleLayersOnly = mUi->visibleLayersOnly->isChecked();
+    const bool useCurrentScale = mUi->currentZoomLevel->isChecked();
+    const bool drawTileGrid = mUi->drawTileGrid->isChecked();
+    const bool includeBackgroundColor = mUi->includeBackgroundColor->isChecked();
+    const bool splitIntoTiles = mUi->splitIntoTiles->isChecked();
+
+    if (QFile::exists(fileName) && !splitIntoTiles) {
         const QMessageBox::StandardButton button =
                 QMessageBox::warning(this,
                                      tr("Export as Image"),
@@ -143,11 +177,6 @@ void ExportAsImageDialog::accept()
         if (button != QMessageBox::Yes)
             return;
     }
-
-    const bool visibleLayersOnly = mUi->visibleLayersOnly->isChecked();
-    const bool useCurrentScale = mUi->currentZoomLevel->isChecked();
-    const bool drawTileGrid = mUi->drawTileGrid->isChecked();
-    const bool includeBackgroundColor = mUi->includeBackgroundColor->isChecked();
 
     MapRenderer *renderer = mMapDocument->renderer();
 
@@ -268,8 +297,38 @@ void ExportAsImageDialog::accept()
     // Restore the previous render flags
     renderer->setFlags(renderFlags);
 
-    image.save(fileName);
-    mPath = QFileInfo(fileName).path();
+    if (splitIntoTiles) {
+        const int extensionIndex = fileName.lastIndexOf(QLatin1Char('.'));
+        if (extensionIndex == -1) {
+            QMessageBox::information(this,
+                                     tr("Export as Image"),
+                                     tr("Couldn't find filel extension for %1.\n"
+                                        "Unable to export tiled image.")
+                                     .arg(QFileInfo(fileName).fileName()),
+                                     QMessageBox::Ok);
+        } else {
+            const int tileWidth = mUi->tileWidthSpinBox->value();
+            const int tileHeight = mUi->tileHeightSpinBox->value();
+            const int rows = mapSize.height() / tileHeight;
+            const int columns = mapSize.width() / tileWidth;
+
+            for (int row = 0; row < rows; ++row) {
+                for (int column = 0; column < columns; ++column) {
+                    const int index = row * columns + column;
+                    const QString tileFileName = QString::fromLatin1("%1-%2%3")
+                            .arg(fileName.left(extensionIndex))
+                            .arg(index)
+                            .arg(fileName.right(fileName.size() - extensionIndex));
+                    const QRect rect = QRect(column * tileWidth, row * tileHeight, tileWidth, tileHeight);
+                    QImage tileImage = createSubImage(&image, rect);
+                    tileImage.save(tileFileName);
+                }
+            }
+        }
+    } else {
+        image.save(fileName);
+        mPath = QFileInfo(fileName).path();
+    }
 
     // Store settings for next time
     QSettings *s = Preferences::instance()->settings();
@@ -277,6 +336,7 @@ void ExportAsImageDialog::accept()
     s->setValue(QLatin1String(CURRENT_SCALE_KEY), useCurrentScale);
     s->setValue(QLatin1String(DRAW_GRID_KEY), drawTileGrid);
     s->setValue(QLatin1String(INCLUDE_BACKGROUND_COLOR), includeBackgroundColor);
+    s->setValue(QLatin1String(SPLIT_INTO_TILES_KEY), splitIntoTiles);
 
     QDialog::accept();
 }

--- a/src/tiled/exportasimagedialog.ui
+++ b/src/tiled/exportasimagedialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>337</width>
-    <height>231</height>
+    <height>374</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -82,6 +82,92 @@
          <string>&amp;Include background color</string>
         </property>
        </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="splitIntoTiles">
+        <property name="toolTip">
+         <string>Splits the image into tiles which are saved as individual files using a zero-based numerical suffix</string>
+        </property>
+        <property name="text">
+         <string>&amp;Split into tiles (overwrites existing files)</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <property name="bottomMargin">
+         <number>6</number>
+        </property>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Maximum</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <layout class="QFormLayout" name="tileSizeLayout">
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="tileWidthLabel">
+            <property name="text">
+             <string>Tile width</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="tileWidthSpinBox">
+            <property name="toolTip">
+             <string>The width of each tile</string>
+            </property>
+            <property name="minimum">
+             <number>8</number>
+            </property>
+            <property name="maximum">
+             <number>10000</number>
+            </property>
+            <property name="value">
+             <number>512</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="tileHeightLabel">
+            <property name="text">
+             <string>Tile height</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="tileHeightSpinBox">
+            <property name="toolTip">
+             <string>The height of each tile</string>
+            </property>
+            <property name="minimum">
+             <number>8</number>
+            </property>
+            <property name="maximum">
+             <number>10000</number>
+            </property>
+            <property name="value">
+             <number>512</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
This allows users to split their map into individual images, which
may be useful if they have static tiles (no animation) and don't
want to load lots of little tiles.
