### PR TITLE
RandomPicker no longer accepts things that have probability zero or less

### DIFF
--- a/src/tiled/randompicker.h
+++ b/src/tiled/randompicker.h
@@ -40,8 +40,10 @@ public:
 
     void add(const T &value, qreal probability = 1.0)
     {
-        mSum += probability;
-        mThresholds.insert(mSum, value);
+        if (probability > 0) {
+            mSum += probability;
+            mThresholds.insert(mSum, value);
+        }
     }
 
     bool isEmpty() const


### PR DESCRIPTION
I'm developing [a game](https://youtu.be/mrLlPNSvDJ0) with my friend, that includes random level generator. The level generator works better, if I set terraintypes to as many tiles as possible. However, I don't want these tiles to appear when modifying terrain in Tiled, so I set their probability to zero. This causes problems, because things in QMap container in RandomPicker get overwritten.

In this pull request, I've modifier the RandomPicker class, so it ignores those things that have zero probability or less. It fixes the problem.

I tested it with stamp and bucket fill with random mode, and I also tested terrain tool. It didn't cause any problems, not even when I set everything to have zero or negative probability.