### PR TITLE
Building on debian requires libqt5opengl5-dev.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Compiling
 
 Make sure the Qt (>= 5.1) development libraries are installed:
 
-* In Ubuntu/Debian: `apt-get install qt5-default qttools5-dev-tools zlib1g-dev`
+* In Ubuntu/Debian: `apt-get install qt5-default qttools5-dev-tools zlib1g-dev libqt5opengl5-dev`
 * In Fedora:        `yum install qt-devel`
 * In Arch Linux:    `pacman -S qt`
 * In Mac OS X with [Homebrew](http://brew.sh/): `brew install qt`


### PR DESCRIPTION
Just an update to the readme.