### PR TITLE
Added option for removing invisible objects in resize dialog.

### DIFF
--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -1401,7 +1401,7 @@ void MainWindow::resizeMap()
         const QSize &newSize = resizeDialog.newSize();
         const QPoint &offset = resizeDialog.offset();
         if (newSize != map->size() || !offset.isNull())
-            mMapDocument->resizeMap(newSize, offset);
+            mMapDocument->resizeMap(newSize, offset, resizeDialog.removeObjsOutsideMap());
     }
 }
 

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -320,7 +320,7 @@ static bool visibleIn(const QRectF &area, MapObject *object,
     return intersects(area, boundingRect);
 }
 
-void MapDocument::resizeMap(const QSize &size, const QPoint &offset)
+void MapDocument::resizeMap(const QSize &size, const QPoint &offset, bool removeOutsideObjs)
 {
     const QRegion movedSelection = mSelectedArea.translated(offset);
     const QRect newArea = QRect(-offset, size);
@@ -345,13 +345,15 @@ void MapDocument::resizeMap(const QSize &size, const QPoint &offset)
             ObjectGroup *objectGroup = static_cast<ObjectGroup*>(layer);
 
             // Remove objects that will fall outside of the map
-            foreach (MapObject *o, objectGroup->objects()) {
-                if (!visibleIn(visibleArea, o, mRenderer)) {
-                    mUndoStack->push(new RemoveMapObject(this, o));
-                } else {
-                    QPointF oldPos = o->position();
-                    QPointF newPos = oldPos + pixelOffset;
-                    mUndoStack->push(new MoveMapObject(this, o, newPos, oldPos));
+            if (removeOutsideObjs) {
+                foreach (MapObject *o, objectGroup->objects()) {
+                    if (!visibleIn(visibleArea, o, mRenderer)) {
+                        mUndoStack->push(new RemoveMapObject(this, o));
+                    } else {
+                        QPointF oldPos = o->position();
+                        QPointF newPos = oldPos + pixelOffset;
+                        mUndoStack->push(new MoveMapObject(this, o, newPos, oldPos));
+                    }
                 }
             }
             break;

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -153,9 +153,10 @@ public:
 
     /**
      * Resize this map to the given \a size, while at the same time shifting
-     * the contents by \a offset.
+     * the contents by \a offset. If \a removeOutsideObjs is true then all
+     * objects which are outside the map will be removed.
      */
-    void resizeMap(const QSize &size, const QPoint &offset);
+    void resizeMap(const QSize &size, const QPoint &offset, bool removeOutsideObjs);
 
     /**
      * Offsets the layers at \a layerIndexes by \a offset, within \a bounds,

--- a/src/tiled/mapdocumentactionhandler.cpp
+++ b/src/tiled/mapdocumentactionhandler.cpp
@@ -252,7 +252,7 @@ void MapDocumentActionHandler::cropToSelection()
     if (bounds.isNull())
         return;
 
-    mMapDocument->resizeMap(bounds.size(), -bounds.topLeft());
+    mMapDocument->resizeMap(bounds.size(), -bounds.topLeft(), true);
 }
 
 void MapDocumentActionHandler::addTileLayer()

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -62,6 +62,7 @@ Preferences::Preferences()
     mReloadTilesetsOnChange = boolValue("ReloadTilesets", true);
     mStampsDirectory = stringValue("StampsDirectory");
     mObjectTypesFile = stringValue("ObjectTypesFile");
+    mRemoveObjsOutsideMap = boolValue("RemoveObjsOutsideMap", true);
     mSettings->endGroup();
 
     // Retrieve interface settings
@@ -295,6 +296,16 @@ void Preferences::setMapRenderOrder(Map::RenderOrder mapRenderOrder)
                         mMapRenderOrder);
 }
 
+bool Preferences::removeObjectsOutsideMap() const
+{
+    return mRemoveObjsOutsideMap;
+}
+
+void Preferences::setRemoveObjectsOutsideMap(bool remove)
+{
+    mRemoveObjsOutsideMap = remove;
+    mSettings->setValue(QLatin1String("Storage/RemoveObjsOutsideMap"), remove);
+}
 
 bool Preferences::dtdEnabled() const
 {

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -72,6 +72,9 @@ public:
     Map::RenderOrder mapRenderOrder() const;
     void setMapRenderOrder(Map::RenderOrder mapRenderOrder);
 
+    bool removeObjectsOutsideMap() const;
+    void setRemoveObjectsOutsideMap(bool remove);
+
     bool dtdEnabled() const;
     void setDtdEnabled(bool enabled);
 
@@ -186,6 +189,7 @@ private:
     bool mHighlightCurrentLayer;
     bool mShowTilesetGrid;
     bool mOpenLastFilesOnStartup;
+    bool mRemoveObjsOutsideMap;
     ObjectLabelVisiblity mObjectLabelVisibility;
 
     Map::LayerDataFormat mLayerDataFormat;

--- a/src/tiled/resizedialog.cpp
+++ b/src/tiled/resizedialog.cpp
@@ -19,6 +19,7 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "preferences.h"
 #include "resizedialog.h"
 #include "ui_resizedialog.h"
 
@@ -32,6 +33,12 @@ ResizeDialog::ResizeDialog(QWidget *parent)
 {
     mUi->setupUi(this);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+    connect(mUi->buttonBox, SIGNAL(accepted()),
+                            SLOT(saveSettings()));
+
+    Preferences *prefs = Preferences::instance();
+    mUi->removeObjsCheckBox->setChecked(prefs->removeObjectsOutsideMap());
 
     // Initialize the new size of the resizeHelper to the default values of
     // the spin boxes. Otherwise, if the map width or height is default, then
@@ -69,6 +76,19 @@ const QSize &ResizeDialog::newSize() const
 const QPoint &ResizeDialog::offset() const
 {
     return mUi->resizeHelper->offset();
+}
+
+bool ResizeDialog::removeObjsOutsideMap() const
+{
+    return mUi->removeObjsCheckBox->isChecked();
+}
+
+void ResizeDialog::saveSettings()
+{
+    Preferences *prefs = Preferences::instance();
+    prefs->setRemoveObjectsOutsideMap(mUi->removeObjsCheckBox->isChecked());
+    done(QDialog::Accepted);
+
 }
 
 void ResizeDialog::updateOffsetBounds(const QRect &bounds)

--- a/src/tiled/resizedialog.h
+++ b/src/tiled/resizedialog.h
@@ -44,7 +44,10 @@ public:
     const QSize &newSize() const;
     const QPoint &offset() const;
 
+    bool removeObjsOutsideMap() const;
+
 private slots:
+    void saveSettings();
     void updateOffsetBounds(const QRect &bounds);
 
 private:

--- a/src/tiled/resizedialog.ui
+++ b/src/tiled/resizedialog.ui
@@ -113,6 +113,16 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="removeObjsCheckBox">
+     <property name="text">
+      <string>Remove objects outside of map</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QFrame" name="frame">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -170,22 +180,6 @@
  </tabstops>
  <resources/>
  <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>ResizeDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>227</x>
-     <y>376</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>


### PR DESCRIPTION
Code for #1032 Added option in resize dialog to decide whether invisible objects (which are outside of map) should be deleted from the map. The option is stored/loaded to/from settings.