### PR TITLE
Command-line format conversion utility (cleaned up version)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tiled.exe
 tmxrasterizer.exe
 tmxviewer.exe
 automappingconverter.exe
+formatconvert.exe
 *.dll
 *.obj
 *.a

--- a/src/formatconvert/formatconvert.pro
+++ b/src/formatconvert/formatconvert.pro
@@ -1,0 +1,34 @@
+include(../../tiled.pri)
+include(../libtiled/libtiled.pri)
+
+TEMPLATE = app
+TARGET = formatconvert
+target.path = $${PREFIX}/bin
+INSTALLS += target
+CONFIG += console
+
+win32 {
+    DESTDIR = ../..
+} else {
+    DESTDIR = ../../bin
+}
+
+macx {
+    CONFIG -= app_bundle
+    QMAKE_LIBDIR += $$OUT_PWD/../../bin/Tiled.app/Contents/Frameworks
+} else:win32 {
+    LIBS += -L$$OUT_PWD/../../lib
+} else {
+    QMAKE_LIBDIR = $$OUT_PWD/../../lib $$QMAKE_LIBDIR
+}
+
+# Make sure the executable can find libtiled
+!win32:!macx:contains(RPATH, yes) {
+    QMAKE_RPATHDIR += \$\$ORIGIN/../lib
+
+    # It is not possible to use ORIGIN in QMAKE_RPATHDIR, so a bit manually
+    QMAKE_LFLAGS += -Wl,-z,origin \'-Wl,-rpath,$$join(QMAKE_RPATHDIR, ":")\'
+    QMAKE_RPATHDIR =
+}
+
+SOURCES += main.cpp

--- a/src/formatconvert/formatconvert.qbs
+++ b/src/formatconvert/formatconvert.qbs
@@ -1,0 +1,15 @@
+import qbs 1.0
+
+TiledQtGuiApplication {
+    name: "formatconvert"
+
+    consoleApplication: true
+
+    Depends { name: "libtiled" }
+
+    cpp.includePaths: ["."]
+
+    files: [
+        "main.cpp"
+    ]
+}

--- a/src/formatconvert/main.cpp
+++ b/src/formatconvert/main.cpp
@@ -75,6 +75,10 @@ int main(int argc, char *argv[]) {
 
   QStringList const args = parser.positionalArguments();
 
+  if (args.size() != 2) {
+    parser.showHelp(1);
+  }
+
   PluginManager::instance()->loadPlugins();
   foreach (PluginFile plugin, PluginManager::instance()->plugins()) {
     qDebug() << "Loaded plugin " << plugin.fileName();

--- a/src/formatconvert/main.cpp
+++ b/src/formatconvert/main.cpp
@@ -1,0 +1,71 @@
+#include <QDebug>
+#include <QGuiApplication>
+#include <QCommandLineParser>
+
+#include "mapformat.h"
+#include "mapreader.h"
+#include "mapwriter.h"
+
+using namespace Tiled;
+
+template <typename Format>
+Format *findFormat(QString const &fileName) {
+  FormatHelper<Format> formatHelper(FileFormat::ReadWrite, "");
+  foreach (Format *format, formatHelper.formats()) {
+    qDebug() << "Checking if " << format->nameFilter() << " supports " << fileName;
+    if (format->supportsFile(fileName))
+      return format;
+  }
+  return nullptr;
+}
+
+Map *readMap(QString const &fileName) {
+  MapFormat *format = findFormat<MapFormat>(fileName);
+  if (format) {
+    qDebug() << "Reading " << format->nameFilter();
+    return format->read(fileName);
+  } else {
+    qDebug() << "Reading TMX format";
+    MapReader reader;
+    return reader.readMap(fileName);
+  }
+}
+
+void writeMap(Tiled::Map *map, QString const &fileName) {
+  MapFormat *format = findFormat<MapFormat>(fileName);
+  if (format) {
+    qDebug() << "Writing " << format->nameFilter();
+    format->write(map, fileName);
+  } else {
+    qDebug() << "Writing TMX format";
+    MapWriter writer;
+    writer.writeMap(map, fileName);
+  }
+}
+
+int main(int argc, char *argv[]) {
+  QGuiApplication app(argc, argv);
+  QGuiApplication::setApplicationName("formatconvert");
+  QGuiApplication::setApplicationVersion("0.1");
+
+  QCommandLineParser parser;
+  parser.setApplicationDescription("Convert Tiled map files to other formats. Formats are detected from the file extensions.");
+  parser.addHelpOption();
+  parser.addVersionOption();
+  parser.addPositionalArgument("source", QCoreApplication::translate("formatconvert", "input file to read"));
+  parser.addPositionalArgument("destination", QCoreApplication::translate("formatconvert", "output file to write"));
+
+  parser.process(app);
+
+  QStringList const args = parser.positionalArguments();
+
+  PluginManager::instance()->loadPlugins();
+  foreach (PluginFile plugin, PluginManager::instance()->plugins()) {
+    qDebug() << "Loaded plugin " << plugin.fileName();
+  }
+
+  Tiled::Map *map = readMap(args.at(0));
+  writeMap(map, args.at(1));
+
+  return 0;
+}

--- a/src/src.pro
+++ b/src/src.pro
@@ -5,4 +5,5 @@ SUBDIRS = libtiled tiled plugins \
     tmxviewer \
     tmxrasterizer \
     automappingconverter \
-    terraingenerator
+    terraingenerator \
+    formatconvert

--- a/tiled.qbs
+++ b/tiled.qbs
@@ -16,6 +16,7 @@ Project {
         "src/tiled",
         "src/tmxrasterizer",
         "src/tmxviewer",
+        "src/formatconvert",
         "translations",
         "util/java/libtiled-java",
         "util/java/tmxviewer-java"


### PR DESCRIPTION
I created a pull request in #1182 that contained some extraneous commits. Here, I've provided a cleaned up version of history containing nothing that it shouldn't.

This command line utility converts files between Tiled's various formats (including tilesets), and should work on Windows where graphical utilities reportedly can't do console output (#953).
