### PR TITLE
Update OSX install instructions for QT

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Make sure the Qt (>= 5.1) development libraries are installed:
 * In Ubuntu/Debian: `apt-get install qt5-default qttools5-dev-tools zlib1g-dev libqt5opengl5-dev`
 * In Fedora:        `yum install qt-devel`
 * In Arch Linux:    `pacman -S qt`
-* In Mac OS X with [Homebrew](http://brew.sh/): `brew install qt`
+* In Mac OS X with [Homebrew](http://brew.sh/):
+  + `brew install qt5`
+  + `brew link qt5 --force`
 
 Now you can compile by running:
 


### PR DESCRIPTION
Since Tiled requires QT to be above version 5, you need to install qt5
with homebrew, not qt (which is version 4). Also since qt5 is keg-only,
it must be linked with the --force flag to be added to the path.