### PR TITLE
Fixed compilation on Windows with MinGW and qmake.

### DIFF
--- a/src/tiled/tiled.pro
+++ b/src/tiled/tiled.pro
@@ -411,7 +411,7 @@ macx {
     ICON = images/tiled-icon-mac.icns
 }
 win32 {
-    RC_FILE = tiled.rc
+    RC_FILE = tiled.rc.in
     PRECOMPILED_HEADER = pch.h
 }
 win32:INCLUDEPATH += .


### PR DESCRIPTION
I have a resource compilation error when tried to build Tiled on Windows 7 with MinGW (Qt 5.4.2) with qmake. The error occured because of wrong resource filename in *.pro file. In *.qbs file name is written correctly. After this fix 'Tiled' was built OK.