### PR TITLE
Prevent segfault when adding new property to many tiles.

### DIFF
--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -294,7 +294,7 @@ void PropertyBrowser::propertyAdded(Object *object, const QString &name)
         QtProperty *precedingProperty = (index > 0) ? properties.at(index - 1) : nullptr;
 
         mUpdating = true;
-        QVariant value = mObject->property(name);
+        QVariant value = object->property(name);
         QtVariantProperty *property = mVariantManager->addProperty(value.type(), name);
         property->setValue(value);
         mCustomPropertiesGroup->insertSubProperty(property, precedingProperty);


### PR DESCRIPTION
Found a bug: If you select multiple tiles, and try to add a new property to them, the editor segfaults. This does not happen if you select the tile with lowest ID last.

I think the reason is, that mObject doesn't have the property (yet?), since the value.type() will be 0. When I selected the lowest ID tile last, the value.type() was 10 and there was no segfault.

When you then call mVariantManager->addProperty(value.type(), name); and value.type() is 0, then it returns property that is NULL, and things start going wrong.

I made a little fix, but I have to admit that **I have no idea if this is the correct way to fix this**. Anyway, it seems to work with tiles now. I also tested with map properties and I also played with undo/redo and I didn't found any problems after this fix.