### PR TITLE
It is now possible to set probability of multiple tiles.

### DIFF
--- a/src/tiled/changetileprobability.cpp
+++ b/src/tiled/changetileprobability.cpp
@@ -29,22 +29,28 @@ namespace Tiled {
 namespace Internal {
 
 ChangeTileProbability::ChangeTileProbability(MapDocument *mapDocument,
-                                             Tile *tile,
+                                             const QList<Tile*>& tiles,
                                              float probability)
     : mMapDocument(mapDocument)
-    , mTile(tile)
-    , mProbability(probability)
+    , mTiles(tiles)
 {
+    mProbabilities.reserve(tiles.size());
+    for (int i = 0; i < tiles.size(); ++ i) {
+        mProbabilities.append(probability);
+    }
     setText(QCoreApplication::translate("Undo Commands",
                                         "Change Tile Probability"));
 }
 
 void ChangeTileProbability::swap()
 {
-    float probability = mTile->probability();
-    mTile->setProbability(mProbability);
-    mProbability = probability;
-    mMapDocument->emitTileProbabilityChanged(mTile);
+    for (int i = 0; i < mTiles.size(); ++ i) {
+        Tile* tile = mTiles[i];
+        float probability = tile->probability();
+        tile->setProbability(mProbabilities[i]);
+        mProbabilities[i] = probability;
+        mMapDocument->emitTileProbabilityChanged(tile);
+    }
 }
 
 } // namespace Internal

--- a/src/tiled/changetileprobability.h
+++ b/src/tiled/changetileprobability.h
@@ -35,7 +35,7 @@ class ChangeTileProbability : public QUndoCommand
 {
 public:
     ChangeTileProbability(MapDocument *mapDocument,
-                          Tile *tile,
+                          const QList<Tile*> &tiles,
                           float probability);
 
     void undo() override { swap(); }
@@ -45,8 +45,8 @@ private:
     void swap();
 
     MapDocument *mMapDocument;
-    Tile *mTile;
-    float mProbability;
+    QList<Tile*> mTiles;
+    QList<float> mProbabilities;
 };
 
 } // namespace Internal

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -937,7 +937,8 @@ void PropertyBrowser::applyTileValue(PropertyId id, const QVariant &val)
     switch (id) {
     case TileProbabilityProperty:
         undoStack->push(new ChangeTileProbability(mMapDocument,
-                                                  tile, val.toFloat()));
+                                                  mMapDocument->selectedTiles(),
+                                                  val.toFloat()));
         break;
     case ImageSourceProperty:
         undoStack->push(new ChangeTileImageSource(mMapDocument,


### PR DESCRIPTION
I tested undo and redo and they seem to work.

There is one case that doesn't work:

1. Have tiles with probabilities 0, 0, 0, 1.
2. Select them from first to last, so that last selected has probability 1.
3. Now try to set probability to 1 for all of them and nothing happens.

The reason is, that the whole changing event is not triggered, since the value of the last tile wasn't really changed (1 changes to 1).