### PR TITLE
Fix the export choice parameter from CLI

### DIFF
--- a/src/tiled/main.cpp
+++ b/src/tiled/main.cpp
@@ -241,7 +241,7 @@ int main(int argc, char *argv[])
             for (MapFormat *format : formats) {
                 if (!format->hasCapabilities(MapFormat::Write))
                     continue;
-                if (format->nameFilter().compare(*filter, Qt::CaseInsensitive) == 0) {
+                if (filter->contains(format->nameFilter(), Qt::CaseInsensitive)) {
                     chosenFormat = format;
                     break;
                 }


### PR DESCRIPTION
Filter match with the right format even if it comes prepended with the
absolute path. As all the options are read as filesToOpen.
(which get the values from QFileInfo(arg).absoluteFilePath()) 