### PR TITLE
Fix out-of-sync tile selection during offset change

### DIFF
--- a/src/tiled/tileselectionitem.cpp
+++ b/src/tiled/tileselectionitem.cpp
@@ -39,6 +39,8 @@ TileSelectionItem::TileSelectionItem(MapDocument *mapDocument)
 
     connect(mMapDocument, &MapDocument::selectedAreaChanged,
             this, &TileSelectionItem::selectionChanged);
+    connect(mapDocument, &MapDocument::layerChanged,
+            this, &TileSelectionItem::layerChanged);
     connect(mMapDocument, &MapDocument::currentLayerIndexChanged,
             this, &TileSelectionItem::currentLayerIndexChanged);
 
@@ -72,6 +74,12 @@ void TileSelectionItem::selectionChanged(const QRegion &newSelection,
     // Make sure changes within the bounding rect are updated
     const QRect changedArea = newSelection.xored(oldSelection).boundingRect();
     update(mMapDocument->renderer()->boundingRect(changedArea));
+}
+
+void TileSelectionItem::layerChanged(int index)
+{
+    const Layer *layer = mMapDocument->map()->layerAt(index);
+    setPos(layer->offset());
 }
 
 void TileSelectionItem::currentLayerIndexChanged()

--- a/src/tiled/tileselectionitem.cpp
+++ b/src/tiled/tileselectionitem.cpp
@@ -76,9 +76,10 @@ void TileSelectionItem::selectionChanged(const QRegion &newSelection,
     update(mMapDocument->renderer()->boundingRect(changedArea));
 }
 
-void TileSelectionItem::layerChanged(int)
+void TileSelectionItem::layerChanged(int index)
 {
-    if (Layer *layer = mMapDocument->currentLayer())
+    const Layer *layer = mMapDocument->map()->layerAt(index);
+    if (layer == mMapDocument->currentLayer())
         setPos(layer->offset());
 }
 

--- a/src/tiled/tileselectionitem.cpp
+++ b/src/tiled/tileselectionitem.cpp
@@ -76,10 +76,10 @@ void TileSelectionItem::selectionChanged(const QRegion &newSelection,
     update(mMapDocument->renderer()->boundingRect(changedArea));
 }
 
-void TileSelectionItem::layerChanged(int index)
+void TileSelectionItem::layerChanged(int)
 {
-    const Layer *layer = mMapDocument->map()->layerAt(index);
-    setPos(layer->offset());
+    if (Layer *layer = mMapDocument->currentLayer())
+        setPos(layer->offset());
 }
 
 void TileSelectionItem::currentLayerIndexChanged()

--- a/src/tiled/tileselectionitem.h
+++ b/src/tiled/tileselectionitem.h
@@ -49,6 +49,8 @@ private slots:
     void selectionChanged(const QRegion &newSelection,
                           const QRegion &oldSelection);
 
+    void layerChanged(int index);
+
     void currentLayerIndexChanged();
 
 private:


### PR DESCRIPTION
Here's my proposal for fixing the misalignment bug and it seems to be working for me. Issue: #1377 