### PR TITLE
Copy the mVisible member member when cloning an object.

### DIFF
--- a/src/libtiled/mapobject.cpp
+++ b/src/libtiled/mapobject.cpp
@@ -131,5 +131,6 @@ MapObject *MapObject::clone() const
     o->setShape(mShape);
     o->setCell(mCell);
     o->setRotation(mRotation);
+    o->setVisible(mVisible);
     return o;
 }


### PR DESCRIPTION
When an object was cloned, the clone's visibility was always set to default, which is `true`.
This caused hidden objects to become visible when using the map offsetting tool.