### PR TITLE
Suppress unsupported attribute warnings in libtiled-java

### DIFF
--- a/util/java/libtiled-java/src/main/java/tiled/core/ObjectGroup.java
+++ b/util/java/libtiled-java/src/main/java/tiled/core/ObjectGroup.java
@@ -29,6 +29,7 @@
  */
 package tiled.core;
 
+import java.awt.Color;
 import java.awt.Rectangle;
 import java.awt.Shape;
 import java.awt.geom.Area;
@@ -49,6 +50,7 @@ public class ObjectGroup extends MapLayer implements Iterable<MapObject> {
 
     private List<MapObject> objects = new LinkedList<>();
     private String draworder;
+    private Color color;
 
     /**
      * Default constructor.
@@ -104,6 +106,24 @@ public class ObjectGroup extends MapLayer implements Iterable<MapObject> {
      */
     public void setDraworder(String draworder) {
         this.draworder = draworder;
+    }
+
+    /**
+     * gets the color.
+     *
+     * @return color
+     */
+    public Color getColor() {
+        return color;
+    }
+
+    /**
+     * sets the color.
+     *
+     * @param color ObjectGroup color
+     */
+    public void setColor(String color) {
+        this.color = Color.decode(color);
     }
 
     /**
@@ -292,5 +312,4 @@ public class ObjectGroup extends MapLayer implements Iterable<MapObject> {
 
         return null;
     }
-
 }

--- a/util/java/libtiled-java/src/test/resources/tiled/io/resources/csvmap.tmx
+++ b/util/java/libtiled-java/src/test/resources/tiled/io/resources/csvmap.tmx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" width="100" height="100" tilewidth="32" tileheight="32">
- <tileset firstgid="1" name="UHMcx" tilewidth="32" tileheight="32">
+<map version="1.0" orientation="orthogonal" renderorder="right-down" width="100" height="100" tilewidth="32" tileheight="32" nextobjectid="1">
+ <tileset firstgid="1" name="UHMcx" tilewidth="32" tileheight="32" tilecount="256" columns="16">
   <image source="cvsmap_tileset.png" width="512" height="512"/>
  </tileset>
  <layer name="Kachelebene 1" width="100" height="100">

--- a/util/java/libtiled-java/src/test/resources/tiled/io/resources/sewers.tmx
+++ b/util/java/libtiled-java/src/test/resources/tiled/io/resources/sewers.tmx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" width="50" height="50" tilewidth="24" tileheight="24">
- <tileset firstgid="1" name="sewer_tileset" tilewidth="24" tileheight="24">
+<map version="1.0" orientation="orthogonal" renderorder="right-down" width="50" height="50" tilewidth="24" tileheight="24" nextobjectid="3">
+ <tileset firstgid="1" name="sewer_tileset" tilewidth="24" tileheight="24" tilecount="72" columns="8">
   <image source="sewer_tileset.png" trans="ff00ff" width="192" height="217"/>
  </tileset>
  <layer name="Bottom" width="50" height="50">
@@ -13,12 +13,12 @@
    eJzt1jsKgDAQQEELtVKvYuGvEDvvfya3MBeQQAzMwCPdsum2af5lL71AJv7xL7X+Y46WtzXayq7z2RGd0f2+V6a5bdRFfaZ5pQzRGE2lFwEAoArpDk7Veg+nOzjlHgYAAAAAIIcHvboDlQ==
   </data>
  </layer>
- <objectgroup color="#4a4530" name="Objects" width="50" height="50">
-  <object name="rect1" type="spawn" x="456" y="120" width="168" height="120">
+ <objectgroup color="#4a4530" name="Objects">
+  <object id="1" name="rect1" type="spawn" x="456" y="120" width="168" height="120">
    <properties>
     <property name="quantity" value="2"/>
    </properties>
   </object>
-  <object name="exit" type="warp" x="0" y="336" width="24" height="48"/>
+  <object id="2" name="exit" type="warp" x="0" y="336" width="24" height="48"/>
  </objectgroup>
 </map>


### PR DESCRIPTION
Update test tmx files to v0.17.0 format and add color to ObjectGroup to suppress unsupported attribute warning when loading map to fix issue #124