### PR TITLE
auto-adjust the column count for tileset collections in TilesetView

### DIFF
--- a/src/tiled/tilesetmodel.cpp
+++ b/src/tiled/tilesetmodel.cpp
@@ -33,6 +33,7 @@ using namespace Tiled::Internal;
 
 TilesetModel::TilesetModel(Tileset *tileset, QObject *parent):
     QAbstractListModel(parent),
+    mColumnCount(5),
     mTileset(tileset)
 {
     refreshTileIds();
@@ -64,7 +65,25 @@ int TilesetModel::columnCount(const QModelIndex &parent) const
         return mTileset->columnCount();
     // TODO: Non-table tilesets should use a different model.
     // For now use an arbitrary number of columns.
-    return 5;
+    return mColumnCount;
+}
+
+void TilesetModel::setColumnCount(int columnCount)
+{
+    if (!mTileset)
+        return;
+
+    if (mTileset->columnCount())
+        return;
+
+    if (columnCount<1)
+        columnCount= 1;
+
+    if (mColumnCount != columnCount)
+    {
+        mColumnCount= columnCount;
+        tilesetChanged();
+    }
 }
 
 QVariant TilesetModel::data(const QModelIndex &index, int role) const

--- a/src/tiled/tilesetmodel.h
+++ b/src/tiled/tilesetmodel.h
@@ -64,6 +64,11 @@ public:
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 
     /**
+     * Sets the number of columns.
+     */
+    void setColumnCount(int columnCount);
+
+    /**
      * Returns the data stored under the given <i>role</i> for the item
      * referred to by the <i>index</i>.
      */
@@ -141,6 +146,7 @@ public slots:
 private:
     void refreshTileIds();
 
+    int mColumnCount;
     Tileset *mTileset;
     QList<int> mTileIds;
 };

--- a/src/tiled/tilesetview.cpp
+++ b/src/tiled/tilesetview.cpp
@@ -601,6 +601,15 @@ void TilesetView::wheelEvent(QWheelEvent *event)
 }
 
 /**
+ * Change the column width to fit the viewport width.
+ */
+void TilesetView::resizeEvent(QResizeEvent *event)
+{
+    adjustColumnCount();
+    QTableView::resizeEvent(event);
+}
+
+/**
  * Allow changing tile properties through a context menu.
  */
 void TilesetView::contextMenuEvent(QContextMenuEvent *event)
@@ -686,10 +695,27 @@ void TilesetView::setDrawGrid(bool drawGrid)
         model->resetModel();
 }
 
+void TilesetView::adjustColumnCount()
+{
+    int columnWidth= sizeHintForColumn(0);
+    int viewportWidth= viewport()->width();
+
+    if (columnWidth > 0)
+    {
+        int columnCount= ( viewportWidth ) / columnWidth;
+
+        if (TilesetModel *model = tilesetModel())
+            model->setColumnCount(columnCount);
+    }
+}
+
 void TilesetView::adjustScale()
 {
     if (TilesetModel *model = tilesetModel())
+    {
         model->resetModel();
+        adjustColumnCount();
+    }
 }
 
 void TilesetView::applyTerrain()

--- a/src/tiled/tilesetview.h
+++ b/src/tiled/tilesetview.h
@@ -123,6 +123,7 @@ protected:
     void leaveEvent(QEvent *) override;
     void wheelEvent(QWheelEvent *event) override;
     void contextMenuEvent(QContextMenuEvent *event) override;
+    void resizeEvent(QResizeEvent *event) override;
 
 private slots:
     void createNewTerrain();
@@ -131,6 +132,7 @@ private slots:
     void setDrawGrid(bool drawGrid);
 
     void adjustScale();
+    void adjustColumnCount();
 
 private:
     void applyTerrain();


### PR DESCRIPTION
auto-adjust the column count for tileset collections when TilesetView is resized or scaled.
Currently the column count is hard-coded to 5 tiles which is a usability hindrance when working. 

I tested that this works when the TilesetView is resized or scaled and when the collection is empty.
Please consider for addition.