### PR TITLE
Tileset margin and spacing for gmx plugin

### DIFF
--- a/src/plugins/gmx/gmxplugin.cpp
+++ b/src/plugins/gmx/gmxplugin.cpp
@@ -177,8 +177,10 @@ bool GmxPlugin::write(const Map *map, const QString &fileName)
                     stream.writeAttribute("w", QString::number(tile->width()));
                     stream.writeAttribute("h", QString::number(tile->height()));
 
-                    stream.writeAttribute("xo", QString::number(tile->id() % tile->tileset()->columnCount() * tile->tileset()->tileWidth()));
-                    stream.writeAttribute("yo", QString::number((int)(tile->id() / tile->tileset()->columnCount()) * tile->tileset()->tileWidth()));
+                    int xInTilesetGrid = tile->id() % tile->tileset()->columnCount();
+                    int yInTilesetGrid = (int)(tile->id() / tile->tileset()->columnCount());
+                    stream.writeAttribute("xo", QString::number(tile->tileset()->margin() + (xInTilesetGrid * tile->tileset()->tileSpacing()) + (xInTilesetGrid * tile->tileset()->tileWidth())));
+                    stream.writeAttribute("yo", QString::number(tile->tileset()->margin() + (yInTilesetGrid * tile->tileset()->tileSpacing()) + (yInTilesetGrid * tile->tileset()->tileHeight())));
 
                     stream.writeAttribute("depth", depth);
                     stream.writeAttribute("id", QString::number(++tileId));

--- a/src/plugins/gmx/gmxplugin.cpp
+++ b/src/plugins/gmx/gmxplugin.cpp
@@ -179,8 +179,8 @@ bool GmxPlugin::write(const Map *map, const QString &fileName)
 
                     int xInTilesetGrid = tile->id() % tile->tileset()->columnCount();
                     int yInTilesetGrid = (int)(tile->id() / tile->tileset()->columnCount());
-                    stream.writeAttribute("xo", QString::number(tile->tileset()->margin() + (xInTilesetGrid * tile->tileset()->tileSpacing()) + (xInTilesetGrid * tile->tileset()->tileWidth())));
-                    stream.writeAttribute("yo", QString::number(tile->tileset()->margin() + (yInTilesetGrid * tile->tileset()->tileSpacing()) + (yInTilesetGrid * tile->tileset()->tileHeight())));
+                    stream.writeAttribute("xo", QString::number(tile->tileset()->margin() + (tile->tileset()->tileSpacing() + tile->tileset()->tileWidth()) * xInTilesetGrid));
+                    stream.writeAttribute("yo", QString::number(tile->tileset()->margin() + (tile->tileset()->tileSpacing() + tile->tileset()->tileHeight()) * yInTilesetGrid));
 
                     stream.writeAttribute("depth", depth);
                     stream.writeAttribute("id", QString::number(++tileId));


### PR DESCRIPTION
Hey @bjorn and @JonesBlunt,

Thanks for making this plugin.

Not sure if it was intended or not, to not include margin and spacing, so I added few code lines to support that.

Also fixed tile->tileset()->tileWidth() to tile->tileset()->tileHeight() for yo attribute.