### PR TITLE
Fix macOS build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,8 @@ environment:
 configuration: Release
 
 install:
-  - set PATH=%PATH%;%QTDIR%\bin;%MINGW%\bin;C:\Qt\Tools\QtCreator\bin
+  - choco install -y qbs
+  - set PATH=%PATH%;%QTDIR%\bin;%MINGW%\bin
 
 build_script:
   - FOR /F "tokens=*" %%i in ('git describe') do SET COMMITNOW=%%i
@@ -35,7 +36,7 @@ build_script:
   - qbs install --all-products --install-root install-root release
 
 after_build:
-  - cd qt-release
+  - cd release
   - cd installer*
   - move tiled-*.msi %APPVEYOR_BUILD_FOLDER%
   - if defined TILED_SNAPSHOT move appcast-win*-snapshots.xml %APPVEYOR_BUILD_FOLDER%

--- a/dist/distribute.qbs
+++ b/dist/distribute.qbs
@@ -50,11 +50,10 @@ Product {
             }
         }
         property string postfix: {
-            if (qbs.targetOS.contains("windows")) {
-                return qbs.debugInformation ? "d.dll" : ".dll"
-            } else {
-                return ".so"
-            }
+            var suffix = "";
+            if (qbs.targetOS.contains("windows") && qbs.debugInformation)
+                suffix += "d";
+            return suffix + cpp.dynamicLibrarySuffix;
         }
         files: {
             function addQtVersions(libs) {
@@ -68,13 +67,17 @@ Product {
                 return result;
             }
 
-            var list = [
-                "Qt5Core" + postfix,
-                "Qt5Gui" + postfix,
-                "Qt5Network" + postfix,
-                "Qt5Svg" + postfix,
-                "Qt5Widgets" + postfix,
-            ];
+            var list = [];
+
+            if (!Qt.core.frameworkBuild) {
+                list.push(
+                    "Qt5Core" + postfix,
+                    "Qt5Gui" + postfix,
+                    "Qt5Network" + postfix,
+                    "Qt5Svg" + postfix,
+                    "Qt5Widgets" + postfix
+                );
+            }
 
             if (Qt.core.versionMinor < 4) {
                 list.push("Qt5OpenGL" + postfix);

--- a/qbs/imports/TiledPlugin.qbs
+++ b/qbs/imports/TiledPlugin.qbs
@@ -10,7 +10,7 @@ DynamicLibrary {
     bundle.isBundle: false
 
     Properties {
-        condition: qbs.targetOS.contains("osx")
+        condition: qbs.targetOS.contains("macos")
         cpp.cxxFlags: ["-Wno-unknown-pragmas"]
     }
 
@@ -19,7 +19,7 @@ DynamicLibrary {
         qbs.installDir: {
             if (qbs.targetOS.contains("windows") || project.linuxArchive)
                 return "plugins/tiled"
-            else if (qbs.targetOS.contains("osx"))
+            else if (qbs.targetOS.contains("macos"))
                 return "Tiled.app/Contents/PlugIns"
             else
                 return "lib/tiled/plugins"

--- a/qbs/imports/TiledQtGuiApplication.qbs
+++ b/qbs/imports/TiledQtGuiApplication.qbs
@@ -12,7 +12,7 @@ QtGuiApplication {
     cpp.cxxLanguageVersion: "c++11"
 
     Properties {
-        condition: qbs.targetOS.contains("osx")
+        condition: qbs.targetOS.contains("macos")
         cpp.cxxFlags: ["-Wno-unknown-pragmas"]
     }
 

--- a/src/automappingconverter/automappingconverter.qbs
+++ b/src/automappingconverter/automappingconverter.qbs
@@ -23,7 +23,7 @@ TiledQtGuiApplication {
     ]
 
     Properties {
-        condition: qbs.targetOS.contains("osx")
+        condition: qbs.targetOS.contains("macos")
         targetName: "Automapping Converter"
     }
 }

--- a/src/libtiled/libtiled.qbs
+++ b/src/libtiled/libtiled.qbs
@@ -26,7 +26,7 @@ DynamicLibrary {
     }
 
     Properties {
-        condition: qbs.targetOS.contains("osx")
+        condition: qbs.targetOS.contains("macos")
         cpp.cxxFlags: ["-Wno-unknown-pragmas"]
     }
 

--- a/src/tiled/tiled.qbs
+++ b/src/tiled/tiled.qbs
@@ -383,15 +383,15 @@ QtGuiApplication {
     ]
 
     Properties {
-        condition: qbs.targetOS.contains("osx")
+        condition: qbs.targetOS.contains("macos")
         cpp.frameworks: "Foundation"
         cpp.cxxFlags: ["-Wno-unknown-pragmas"]
         bundle.infoPlistFile: "Info.plist"
         targetName: "Tiled"
     }
     Group {
-        name: "OS X"
-        condition: qbs.targetOS.contains("osx")
+        name: "macOS"
+        condition: qbs.targetOS.contains("macos")
         files: [
             "Info.plist",
             "macsupport.h",
@@ -403,14 +403,14 @@ QtGuiApplication {
         qbs.install: true
         qbs.installDir: {
             if (qbs.targetOS.contains("windows")
-                    || qbs.targetOS.contains("osx")
+                    || qbs.targetOS.contains("macos")
                     || project.linuxArchive)
                 return ""
             else
                 return "bin"
         }
         qbs.installSourceBase: product.buildDirectory
-        fileTagsFilter: product.type.concat(["infoplist", "pkginfo"])
+        fileTagsFilter: product.type.concat(["aggregate_infoplist", "pkginfo"])
     }
 
     Properties {
@@ -438,8 +438,8 @@ QtGuiApplication {
     }
 
     Group {
-        name: "OS X (icons)"
-        condition: qbs.targetOS.contains("osx")
+        name: "macOS (icons)"
+        condition: qbs.targetOS.contains("macos")
         qbs.install: true
         qbs.installDir: "Tiled.app/Contents/Resources"
         files: ["images/*.icns"]

--- a/tiled.qbs
+++ b/tiled.qbs
@@ -5,7 +5,7 @@ Project {
     name: "Tiled"
 
     qbsSearchPaths: "qbs"
-    minimumQbsVersion: "1.5.0"
+    minimumQbsVersion: "1.5.2"
 
     property string version: Environment.getEnv("TILED_VERSION") || "0.17.2";
     property bool sparkleEnabled: Environment.getEnv("TILED_SPARKLE")

--- a/translations/translations.qbs
+++ b/translations/translations.qbs
@@ -19,7 +19,7 @@ Product {
         qbs.installDir: {
             if (qbs.targetOS.contains("windows") || project.linuxArchive)
                 return "translations"
-            else if (qbs.targetOS.contains("osx"))
+            else if (qbs.targetOS.contains("macos"))
                 return "Tiled.app/Contents/Translations"
             else
                 return "share/tiled/translations"


### PR DESCRIPTION
This raises the minimumQbsVersion to 1.5.2. In Qbs 1.5.2, osx was
renamed to macos. This is a forward compatible change, as Qbs guarantees
that macos is in the targetOS list if osx is.