### PR TITLE
Flare Code Changed

### DIFF
--- a/src/plugins/flare/flareplugin.cpp
+++ b/src/plugins/flare/flareplugin.cpp
@@ -278,6 +278,8 @@ bool FlarePlugin::write(const Tiled::Map *map, const QString &fileName)
     }
 
     QTextStream out(&file);
+	QColor backgroundColor;
+	backgroundColor = map->backgroundColor();
     out.setCodec("UTF-8");
 
     const int mapWidth = map->width();
@@ -290,6 +292,10 @@ bool FlarePlugin::write(const Tiled::Map *map, const QString &fileName)
     out << "tilewidth=" << map->tileWidth() << "\n";
     out << "tileheight=" << map->tileHeight() << "\n";
     out << "orientation=" << orientationToString(map->orientation()) << "\n";
+	out << "backgroundColorR=" << backgroundColor.red() << "\n";
+	out << "backgroundColorG=" << backgroundColor.green() << "\n";
+	out << "backgroundColorB=" << backgroundColor.blue() << "\n";
+	out << "backgroundColorA=" << backgroundColor.alpha() << "\n";
 
     // write all properties for this map
     Properties::const_iterator it = map->properties().constBegin();
@@ -333,7 +339,13 @@ bool FlarePlugin::write(const Tiled::Map *map, const QString &fileName)
                     out << ",";
                 out << "\n";
             }
-            out << "\n";
+            //Write all properties for this layer
+			Properties::const_iterator it = tileLayer->properties().constBegin();
+			Properties::const_iterator it_end = tileLayer->properties().constEnd();
+			for (; it != it_end; ++it) {
+				out << it.key() << "=" << it.value().toString() << "\n";
+			}
+			out << "\n";
         }
         if (ObjectGroup *group = layer->asObjectGroup()) {
             for (const MapObject *o : group->objects()) {

--- a/src/plugins/flare/flareplugin.cpp
+++ b/src/plugins/flare/flareplugin.cpp
@@ -294,7 +294,7 @@ bool FlarePlugin::write(const Tiled::Map *map, const QString &fileName)
     out << "tilewidth=" << map->tileWidth() << "\n";
     out << "tileheight=" << map->tileHeight() << "\n";
     out << "orientation=" << orientationToString(map->orientation()) << "\n";
-    out << "backgroundColor=" << backgroundColor.name(QColor::HexArgb) << "\n";
+    out << "backgroundColorARGB=" << backgroundColor.name(QColor::HexArgb) << "\n";
 
     // write all properties for this map
     Properties::const_iterator it = map->properties().constBegin();

--- a/src/plugins/flare/flareplugin.cpp
+++ b/src/plugins/flare/flareplugin.cpp
@@ -271,7 +271,7 @@ Tiled::Map *FlarePlugin::read(const QString &fileName)
                     int w,h;
                     if (map->orientation() == Map::Orthogonal) {
                         x = (loc[0].toFloat())*map->tileWidth();
-                        y = (loc[1].toFloat() - 1)*map->tileHeight();
+                        y = (loc[1].toFloat())*map->tileHeight();
                         if (loc.size() > 3) {
                             w = loc[2].toInt()*map->tileWidth();
                             h = loc[3].toInt()*map->tileHeight();

--- a/src/plugins/flare/flareplugin.cpp
+++ b/src/plugins/flare/flareplugin.cpp
@@ -42,6 +42,54 @@
 using namespace Flare;
 using namespace Tiled;
 
+int hexToDecimal(const std::string& hex){
+   int value = 0;
+   int i = hex.size() - 1;
+   for (int pos = 0; pos < hex.size(); pos++){
+       int modifier = 0;
+       char x = hex[pos];
+       switch (x){
+       case '0':
+       case '1':
+       case '2':
+       case '3':
+       case '4':
+       case '5':
+       case '6':
+       case '7':
+       case '8':
+       case '9':
+           modifier = x - 48;
+           break;
+       case 'a':
+       case 'b':
+       case 'c':
+       case 'd':
+       case 'e':
+       case 'f':
+           modifier = x - 87;
+           break;
+       default:
+           throw "Uknown hex character!";
+           break;
+       }
+       value += modifier * pow(16, i);
+       i--;
+   }
+   return value;
+}
+
+QColor enrichColorInformation(const QString& colorHex){
+    QColor color;
+    std::string hexVal = colorHex.toStdString();
+    int startHex = hexVal.find('#') + 1;
+    color.setAlpha(hexToDecimal(hexVal.substr(startHex, 2)));
+    color.setRed(hexToDecimal(hexVal.substr(startHex + 2, 2)));
+    color.setGreen(hexToDecimal(hexVal.substr(startHex + 4, 2)));
+    color.setBlue(hexToDecimal(hexVal.substr(startHex + 6, 2)));
+    return color;
+}
+
 FlarePlugin::FlarePlugin()
 {
 }
@@ -72,6 +120,7 @@ Tiled::Map *FlarePlugin::read(const QString &fileName)
     bool tilesetsSectionFound = false;
     bool headerSectionFound = false;
     bool tilelayerSectionFound = false; // tile layer or objects
+    QColor backgroundColor;
 
     while (!stream.atEnd()) {
         line = stream.readLine();
@@ -103,6 +152,10 @@ Tiled::Map *FlarePlugin::read(const QString &fileName)
                     map->setTileHeight(value.toInt());
                 else if (key == QLatin1String("orientation"))
                     map->setOrientation(orientationFromString(value));
+                else if (key == QLatin1String("backgroundColor")){
+                    backgroundColor = enrichColorInformation(value);
+                    map->setBackgroundColor(backgroundColor);
+                }
                 else
                     map->setProperty(key, value);
             }
@@ -217,8 +270,8 @@ Tiled::Map *FlarePlugin::read(const QString &fileName)
                     float x,y;
                     int w,h;
                     if (map->orientation() == Map::Orthogonal) {
-                        x = loc[0].toFloat()*map->tileWidth();
-                        y = loc[1].toFloat()*map->tileHeight();
+                        x = (loc[0].toFloat())*map->tileWidth();
+                        y = (loc[1].toFloat() - 1)*map->tileHeight();
                         if (loc.size() > 3) {
                             w = loc[2].toInt()*map->tileWidth();
                             h = loc[3].toInt()*map->tileHeight();
@@ -294,7 +347,7 @@ bool FlarePlugin::write(const Tiled::Map *map, const QString &fileName)
     out << "tilewidth=" << map->tileWidth() << "\n";
     out << "tileheight=" << map->tileHeight() << "\n";
     out << "orientation=" << orientationToString(map->orientation()) << "\n";
-    out << "backgroundColorARGB=" << backgroundColor.name(QColor::HexArgb) << "\n";
+    out << "backgroundColor=" << backgroundColor.name(QColor::HexArgb) << "\n";
 
     // write all properties for this map
     Properties::const_iterator it = map->properties().constBegin();
@@ -342,7 +395,7 @@ bool FlarePlugin::write(const Tiled::Map *map, const QString &fileName)
 			Properties::const_iterator it = tileLayer->properties().constBegin();
 			Properties::const_iterator it_end = tileLayer->properties().constEnd();
 			for (; it != it_end; ++it) {
-                if(strcmp(it->typeName(), "Tiled::FilePath") == 0){
+                if(it->userType() == filePathTypeId()){
                     out << it.key() << "=" << mapDir.relativeFilePath(toExportValue(it.value()).toString()) << "\n";
                 }
                 else{
@@ -379,7 +432,7 @@ bool FlarePlugin::write(const Tiled::Map *map, const QString &fileName)
                     // write all properties for this object
                     QVariantMap propsMap = o->properties();
                     for (QVariantMap::const_iterator it = propsMap.constBegin(); it != propsMap.constEnd(); ++it) {
-                        if(strcmp(it->typeName(), "Tiled::FilePath") == 0){
+                        if(it->userType() == filePathTypeId()){
                             out << it.key() << "=" << mapDir.relativeFilePath(toExportValue(it.value()).toString()) << "\n";
                         }
                         else{

--- a/src/plugins/flare/flareplugin.cpp
+++ b/src/plugins/flare/flareplugin.cpp
@@ -36,9 +36,43 @@
 #include <QSettings>
 #include <QStringList>
 #include <QTextStream>
+#include <QTextCodec>
+#include <qnumeric.h>
 
 using namespace Flare;
 using namespace Tiled;
+
+
+static QString escape(const QVariant &variant)
+{
+    QString str = variant.toString();
+    QString res;
+    res.reserve(str.length());
+    for (int i = 0; i < str.length(); i++) {
+        if (str[i] == QLatin1Char('\b')) {
+            res += QLatin1String("\\b");
+        } else if (str[i] == QLatin1Char('\f')) {
+            res += QLatin1String("\\f");
+        } else if (str[i] == QLatin1Char('\n')) {
+            res += QLatin1String("\\n");
+        } else if (str[i] == QLatin1Char('\r')) {
+            res += QLatin1String("\\r");
+        } else if (str[i] == QLatin1Char('\t')) {
+            res += QLatin1String("\\t");
+        } else if (str[i] == QLatin1Char('\"')) {
+            res += QLatin1String("\\\"");
+        } else if (str[i] == QLatin1Char('\\')) {
+            res += QLatin1String("\\\\");
+        } else if (str[i] == QLatin1Char('/')) {
+            res += QLatin1String("\\/");
+        } else if (str[i].unicode() > 127) {
+            res += QLatin1String("\\u") + QString::number(str[i].unicode(), 16).rightJustified(4, QLatin1Char('0'));
+        } else {
+            res += str[i];
+        }
+    }
+    return res;
+}
 
 FlarePlugin::FlarePlugin()
 {
@@ -70,6 +104,12 @@ Tiled::Map *FlarePlugin::read(const QString &fileName)
     bool tilesetsSectionFound = false;
     bool headerSectionFound = false;
     bool tilelayerSectionFound = false; // tile layer or objects
+    QColor color;
+    color.setBlue(0);
+    color.setRed(0);
+    color.setGreen(0);
+    color.setAlpha(0);
+    bool colorRead = false;
 
     while (!stream.atEnd()) {
         line = stream.readLine();
@@ -101,8 +141,27 @@ Tiled::Map *FlarePlugin::read(const QString &fileName)
                     map->setTileHeight(value.toInt());
                 else if (key == QLatin1String("orientation"))
                     map->setOrientation(orientationFromString(value));
+                else if (key == QLatin1String("backgroundColorR")){
+                    color.setRed(value.toInt());
+                    colorRead = true;
+                }
+                else if (key == QLatin1String("backgroundColorB")){
+                    color.setBlue(value.toInt());
+                    colorRead = true;
+                }
+                else if (key == QLatin1String("backgroundColorG")){
+                    color.setGreen(value.toInt());
+                    colorRead = true;
+                }
+                else if (key == QLatin1String("backgroundColorA")){
+                    color.setAlpha(value.toInt());
+                    colorRead = true;
+                }
                 else
                     map->setProperty(key, value);
+            }
+            if(colorRead){
+                map->setBackgroundColor(color);
             }
         } else if (sectionName == QLatin1String("tilesets")) {
             tilesetsSectionFound = true;
@@ -373,10 +432,16 @@ bool FlarePlugin::write(const Tiled::Map *map, const QString &fileName)
                     out << "," << w << "," << h << "\n";
 
                     // write all properties for this object
-                    Properties::const_iterator it = o->properties().constBegin();
-                    Properties::const_iterator it_end = o->properties().constEnd();
-                    for (; it != it_end; ++it) {
-                        out << it.key() << "=" << it.value().toString() << "\n";
+                    QVariantMap propsMap = o->properties();
+                    for (QVariantMap::const_iterator it = propsMap.constBegin(); it != propsMap.constEnd(); ++it) {
+                        const char* a = it->typeName();
+                        if(strcmp(a, "Tiled::FilePath") == 0){
+                            QString z = escape(it.value());
+                            out << it.key() << "=" << z << "\n";
+                        }
+                        else{
+                            out << it.key() << "=" << it.value().toString() << "\n";
+                        }
                     }
                     out << "\n";
                 }


### PR DESCRIPTION
Changed code of flare plugin to allow for exportation of custom layer properties and the previously excluded map property of "Background Color".

I placed each section of the color - red, blue, green, and alpha - into its own respective key-value pair, as some computers utilize RGBA encoding, and others utilize RBGA encoding, so anybody trying to use these values shouldn't have a problem worrying about the order of the color values.