### PR TITLE
Issue #1382: Added short and consistent map format names to use with --export-map

### DIFF
--- a/src/libtiled/mapformat.h
+++ b/src/libtiled/mapformat.h
@@ -81,6 +81,11 @@ public:
     virtual QString nameFilter() const = 0;
 
     /**
+     * Returns short name for this map format
+     */
+    virtual QString shortName() const = 0;
+
+    /**
      * Returns whether this map format supports reading the given file.
      *
      * Generally would do a file extension check.

--- a/src/plugins/csv/csvplugin.cpp
+++ b/src/plugins/csv/csvplugin.cpp
@@ -130,3 +130,8 @@ QString CsvPlugin::nameFilter() const
 {
     return tr("CSV files (*.csv)");
 }
+
+QString CsvPlugin::shortName() const
+{
+    return "csv";
+}

--- a/src/plugins/csv/csvplugin.cpp
+++ b/src/plugins/csv/csvplugin.cpp
@@ -133,5 +133,5 @@ QString CsvPlugin::nameFilter() const
 
 QString CsvPlugin::shortName() const
 {
-    return "csv";
+    return QLatin1String("csv");
 }

--- a/src/plugins/csv/csvplugin.h
+++ b/src/plugins/csv/csvplugin.h
@@ -40,6 +40,7 @@ public:
 
 protected:
     QString nameFilter() const override;
+    QString shortName() const override;
 
 private:
     QString mError;

--- a/src/plugins/csv/csvplugin.h
+++ b/src/plugins/csv/csvplugin.h
@@ -38,9 +38,10 @@ public:
     QString errorString() const override;
     QStringList outputFiles(const Tiled::Map *map, const QString &fileName) const override;
 
+    QString shortName() const override;
+
 protected:
     QString nameFilter() const override;
-    QString shortName() const override;
 
 private:
     QString mError;

--- a/src/plugins/defold/defoldplugin.cpp
+++ b/src/plugins/defold/defoldplugin.cpp
@@ -58,6 +58,11 @@ QString DefoldPlugin::nameFilter() const
     return tr("Defold files (*.tilemap)");
 }
 
+QString DefoldPlugin::shortName() const
+{
+    return "defold";
+}
+
 QString DefoldPlugin::errorString() const
 {
     return mError;

--- a/src/plugins/defold/defoldplugin.cpp
+++ b/src/plugins/defold/defoldplugin.cpp
@@ -60,7 +60,7 @@ QString DefoldPlugin::nameFilter() const
 
 QString DefoldPlugin::shortName() const
 {
-    return "defold";
+    return QLatin1String("defold");
 }
 
 QString DefoldPlugin::errorString() const

--- a/src/plugins/defold/defoldplugin.h
+++ b/src/plugins/defold/defoldplugin.h
@@ -42,6 +42,7 @@ public:
 
 protected:
     QString nameFilter() const override;
+    QString shortName() const override;
 
 private:
     QString mError;

--- a/src/plugins/defold/defoldplugin.h
+++ b/src/plugins/defold/defoldplugin.h
@@ -38,11 +38,12 @@ public:
 
     bool write(const Tiled::Map *map, const QString &fileName) override;
     QString errorString() const override;
+    QString shortName() const override;
     QStringList outputFiles(const Tiled::Map *, const QString &fileName) const override;
+
 
 protected:
     QString nameFilter() const override;
-    QString shortName() const override;
 
 private:
     QString mError;

--- a/src/plugins/droidcraft/droidcraftplugin.cpp
+++ b/src/plugins/droidcraft/droidcraftplugin.cpp
@@ -146,6 +146,11 @@ QString DroidcraftPlugin::nameFilter() const
     return tr("Droidcraft map files (*.dat)");
 }
 
+QString DroidcraftPlugin::shortName() const
+{
+    return "droidcraft";
+}
+
 QString DroidcraftPlugin::errorString() const
 {
     return mError;

--- a/src/plugins/droidcraft/droidcraftplugin.cpp
+++ b/src/plugins/droidcraft/droidcraftplugin.cpp
@@ -148,7 +148,7 @@ QString DroidcraftPlugin::nameFilter() const
 
 QString DroidcraftPlugin::shortName() const
 {
-    return "droidcraft";
+    return QLatin1String("droidcraft");
 }
 
 QString DroidcraftPlugin::errorString() const

--- a/src/plugins/droidcraft/droidcraftplugin.h
+++ b/src/plugins/droidcraft/droidcraftplugin.h
@@ -43,6 +43,7 @@ public:
 
     bool write(const Tiled::Map *map, const QString &fileName) override;
     QString nameFilter() const override;
+    QString shortName() const override;
     QString errorString() const override;
 
 private:

--- a/src/plugins/flare/flareplugin.cpp
+++ b/src/plugins/flare/flareplugin.cpp
@@ -264,6 +264,11 @@ QString FlarePlugin::nameFilter() const
     return tr("Flare map files (*.txt)");
 }
 
+QString FlarePlugin::shortName() const
+{
+    return "flare";
+}
+
 QString FlarePlugin::errorString() const
 {
     return mError;

--- a/src/plugins/flare/flareplugin.cpp
+++ b/src/plugins/flare/flareplugin.cpp
@@ -266,7 +266,7 @@ QString FlarePlugin::nameFilter() const
 
 QString FlarePlugin::shortName() const
 {
-    return "flare";
+    return QLatin1String("flare");
 }
 
 QString FlarePlugin::errorString() const

--- a/src/plugins/flare/flareplugin.h
+++ b/src/plugins/flare/flareplugin.h
@@ -44,6 +44,7 @@ public:
 
     bool write(const Tiled::Map *map, const QString &fileName) override;
     QString nameFilter() const override;
+    QString shortName() const override;
     QString errorString() const override;
 
 private:

--- a/src/plugins/gmx/gmxplugin.cpp
+++ b/src/plugins/gmx/gmxplugin.cpp
@@ -378,5 +378,5 @@ QString GmxPlugin::nameFilter() const
 
 QString GmxPlugin::shortName() const
 {
-    return "gamemaker";
+    return QLatin1String("gmx");
 }

--- a/src/plugins/gmx/gmxplugin.cpp
+++ b/src/plugins/gmx/gmxplugin.cpp
@@ -375,3 +375,8 @@ QString GmxPlugin::nameFilter() const
 {
     return tr("GameMaker room files (*.room.gmx)");
 }
+
+QString GmxPlugin::shortName() const
+{
+    return "gamemaker";
+}

--- a/src/plugins/gmx/gmxplugin.h
+++ b/src/plugins/gmx/gmxplugin.h
@@ -39,6 +39,7 @@ public:
 
 protected:
     QString nameFilter() const override;
+    QString shortName() const override;
 
 private:
     QString mError;

--- a/src/plugins/gmx/gmxplugin.h
+++ b/src/plugins/gmx/gmxplugin.h
@@ -36,10 +36,10 @@ public:
 
     bool write(const Tiled::Map *map, const QString &fileName) override;
     QString errorString() const override;
+    QString shortName() const override;
 
 protected:
     QString nameFilter() const override;
-    QString shortName() const override;
 
 private:
     QString mError;

--- a/src/plugins/json/jsonplugin.cpp
+++ b/src/plugins/json/jsonplugin.cpp
@@ -150,6 +150,14 @@ QString JsonMapFormat::nameFilter() const
         return tr("JavaScript map files (*.js)");
 }
 
+QString JsonMapFormat::shortName() const
+{
+    if (mSubFormat == Json)
+        return "json";
+    else
+        return "js";
+}
+
 bool JsonMapFormat::supportsFile(const QString &fileName) const
 {
     if (mSubFormat == Json) {
@@ -298,6 +306,11 @@ bool JsonTilesetFormat::write(const Tiled::Tileset &tileset,
 QString JsonTilesetFormat::nameFilter() const
 {
     return tr("Json tileset files (*.json)");
+}
+
+QString JsonTilesetFormat::shortName() const
+{
+    return tr("json");
 }
 
 QString JsonTilesetFormat::errorString() const

--- a/src/plugins/json/jsonplugin.cpp
+++ b/src/plugins/json/jsonplugin.cpp
@@ -153,9 +153,9 @@ QString JsonMapFormat::nameFilter() const
 QString JsonMapFormat::shortName() const
 {
     if (mSubFormat == Json)
-        return "json";
+        return QLatin1String("json");
     else
-        return "js";
+        return QLatin1String("js");
 }
 
 bool JsonMapFormat::supportsFile(const QString &fileName) const
@@ -310,7 +310,7 @@ QString JsonTilesetFormat::nameFilter() const
 
 QString JsonTilesetFormat::shortName() const
 {
-    return tr("json");
+    return QLatin1String("json");
 }
 
 QString JsonTilesetFormat::errorString() const

--- a/src/plugins/json/jsonplugin.h
+++ b/src/plugins/json/jsonplugin.h
@@ -65,6 +65,7 @@ public:
     bool write(const Tiled::Map *map, const QString &fileName) override;
 
     QString nameFilter() const override;
+    QString shortName() const override;
     QString errorString() const override;
 
 protected:
@@ -87,6 +88,7 @@ public:
     bool write(const Tiled::Tileset &tileset, const QString &fileName) override;
 
     QString nameFilter() const override;
+    QString shortName() const override;
     QString errorString() const override;
 
 protected:

--- a/src/plugins/lua/luaplugin.cpp
+++ b/src/plugins/lua/luaplugin.cpp
@@ -88,7 +88,7 @@ QString LuaPlugin::nameFilter() const
 
 QString LuaPlugin::shortName() const
 {
-    return "lua";
+    return QLatin1String("lua");
 }
 
 QString LuaPlugin::errorString() const

--- a/src/plugins/lua/luaplugin.cpp
+++ b/src/plugins/lua/luaplugin.cpp
@@ -86,6 +86,11 @@ QString LuaPlugin::nameFilter() const
     return tr("Lua files (*.lua)");
 }
 
+QString LuaPlugin::shortName() const
+{
+    return "lua";
+}
+
 QString LuaPlugin::errorString() const
 {
     return mError;

--- a/src/plugins/lua/luaplugin.h
+++ b/src/plugins/lua/luaplugin.h
@@ -55,6 +55,7 @@ public:
 
     bool write(const Tiled::Map *map, const QString &fileName) override;
     QString nameFilter() const override;
+    QString shortName() const override;
     QString errorString() const override;
 
 private:

--- a/src/plugins/python/pythonplugin.cpp
+++ b/src/plugins/python/pythonplugin.cpp
@@ -363,6 +363,32 @@ QString PythonMapFormat::nameFilter() const
     return ret;
 }
 
+QString PythonMapFormat::shortName() const
+{
+    QString ret;
+
+    // find fun
+    PyObject *pfun = PyObject_GetAttrString(mClass, "shortName");
+    if (!pfun || !PyCallable_Check(pfun)) {
+        PySys_WriteStderr("Plugin extension doesn't define \"shortName\"\n");
+        return ret;
+    }
+
+    // have fun
+    PyObject *pinst = PyEval_CallFunction(pfun, "()");
+    if (!pinst) {
+        PySys_WriteStderr("** Uncaught exception in script **\n");
+    } else {
+        ret = PyString_AsString(pinst);
+        Py_DECREF(pinst);
+    }
+    handleError();
+
+    Py_DECREF(pfun);
+
+    return ret;
+}
+
 QString PythonMapFormat::errorString() const
 {
     return mError;

--- a/src/plugins/python/pythonplugin.cpp
+++ b/src/plugins/python/pythonplugin.cpp
@@ -370,6 +370,7 @@ QString PythonMapFormat::shortName() const
     // find fun
     PyObject *pfun = PyObject_GetAttrString(mClass, "shortName");
     if (!pfun || !PyCallable_Check(pfun)) {
+        PySys_WriteStderr("Plugin extension doesn't define \"nameFilter\". Falling back to \"nameFilter\"\n");
         return nameFilter();
     }
 

--- a/src/plugins/python/pythonplugin.cpp
+++ b/src/plugins/python/pythonplugin.cpp
@@ -370,8 +370,7 @@ QString PythonMapFormat::shortName() const
     // find fun
     PyObject *pfun = PyObject_GetAttrString(mClass, "shortName");
     if (!pfun || !PyCallable_Check(pfun)) {
-        PySys_WriteStderr("Plugin extension doesn't define \"shortName\"\n");
-        return ret;
+        return nameFilter();
     }
 
     // have fun

--- a/src/plugins/python/pythonplugin.cpp
+++ b/src/plugins/python/pythonplugin.cpp
@@ -370,7 +370,7 @@ QString PythonMapFormat::shortName() const
     // find fun
     PyObject *pfun = PyObject_GetAttrString(mClass, "shortName");
     if (!pfun || !PyCallable_Check(pfun)) {
-        PySys_WriteStderr("Plugin extension doesn't define \"nameFilter\". Falling back to \"nameFilter\"\n");
+        PySys_WriteStderr("Plugin extension doesn't define \"shortName\". Falling back to \"nameFilter\"\n");
         return nameFilter();
     }
 

--- a/src/plugins/python/pythonplugin.h
+++ b/src/plugins/python/pythonplugin.h
@@ -117,6 +117,7 @@ public:
     bool write(const Tiled::Map *map, const QString &fileName) override;
 
     QString nameFilter() const override;
+    QString shortName() const override;
     QString errorString() const override;
 
     PyObject *pythonClass() const { return mClass; }

--- a/src/plugins/python/scripts/mappy.py
+++ b/src/plugins/python/scripts/mappy.py
@@ -65,6 +65,10 @@ class Mappy(Plugin, FMPPicklerMixin):
     return "Mappy (*.fmp)"
 
   @classmethod
+  def shortName(cls):
+    return "mappy"
+
+  @classmethod
   def supportsFile(cls, f):
     return open(f).read(4) == 'FORM'
 

--- a/src/plugins/python/scripts/pk2.py
+++ b/src/plugins/python/scripts/pk2.py
@@ -21,6 +21,10 @@ class PK2(Plugin):
     return "Pekka Kana 2 (*.map)"
 
   @classmethod
+  def shortName(cls):
+    return "pk2"
+
+  @classmethod
   def supportsFile(cls, f):
     return open(f, 'rb').read(4) == '1.3\0'
 

--- a/src/plugins/python/scripts/zst.py
+++ b/src/plugins/python/scripts/zst.py
@@ -20,6 +20,10 @@ class ZST(Plugin):
     return "zSNES Save State (*.zs?)"
 
   @classmethod
+  def shortName(cls):
+    return "zst"
+
+  @classmethod
   def supportsFile(cls, f):
     return open(f).read(26) == 'ZSNES Save State File V0.6'
 

--- a/src/plugins/replicaisland/replicaislandplugin.cpp
+++ b/src/plugins/replicaisland/replicaislandplugin.cpp
@@ -207,6 +207,11 @@ QString ReplicaIslandPlugin::nameFilter() const
     return tr("Replica Island map files (*.bin)");
 }
 
+QString ReplicaIslandPlugin::shortName() const
+{
+    return "replicaisland";
+}
+
 bool ReplicaIslandPlugin::supportsFile(const QString &fileName) const
 {
     // Check the file extension first.

--- a/src/plugins/replicaisland/replicaislandplugin.cpp
+++ b/src/plugins/replicaisland/replicaislandplugin.cpp
@@ -209,7 +209,7 @@ QString ReplicaIslandPlugin::nameFilter() const
 
 QString ReplicaIslandPlugin::shortName() const
 {
-    return "replicaisland";
+    return QLatin1String("replicaisland");
 }
 
 bool ReplicaIslandPlugin::supportsFile(const QString &fileName) const

--- a/src/plugins/replicaisland/replicaislandplugin.h
+++ b/src/plugins/replicaisland/replicaislandplugin.h
@@ -53,6 +53,7 @@ public:
 
     Tiled::Map *read(const QString &fileName) override;
     QString nameFilter() const override;
+    QString shortName() const override;
     bool supportsFile(const QString &fileName) const override;
     QString errorString() const override;
     bool write(const Tiled::Map *map, const QString &fileName) override;

--- a/src/plugins/tengine/tengineplugin.cpp
+++ b/src/plugins/tengine/tengineplugin.cpp
@@ -293,6 +293,11 @@ QString TenginePlugin::nameFilter() const
     return tr("T-Engine4 map files (*.lua)");
 }
 
+QString TenginePlugin::shortName() const
+{
+    return "te4";
+}
+
 QString TenginePlugin::errorString() const
 {
     return mError;

--- a/src/plugins/tengine/tengineplugin.cpp
+++ b/src/plugins/tengine/tengineplugin.cpp
@@ -295,7 +295,7 @@ QString TenginePlugin::nameFilter() const
 
 QString TenginePlugin::shortName() const
 {
-    return "te4";
+    return QLatin1String("te4");
 }
 
 QString TenginePlugin::errorString() const

--- a/src/plugins/tengine/tengineplugin.h
+++ b/src/plugins/tengine/tengineplugin.h
@@ -42,6 +42,7 @@ public:
 
     bool write(const Tiled::Map *map, const QString &fileName) override;
     QString nameFilter() const override;
+    QString shortName() const override;
     QString errorString() const override;
 
 private:

--- a/src/plugins/tmw/tmwplugin.cpp
+++ b/src/plugins/tmw/tmwplugin.cpp
@@ -94,7 +94,7 @@ QString TmwPlugin::nameFilter() const
 
 QString TmwPlugin::shortName() const
 {
-    return "tmw";
+    return QLatin1String("tmw");
 }
 
 QString TmwPlugin::errorString() const

--- a/src/plugins/tmw/tmwplugin.cpp
+++ b/src/plugins/tmw/tmwplugin.cpp
@@ -92,6 +92,11 @@ QString TmwPlugin::nameFilter() const
     return tr("TMW-eAthena collision files (*.wlk)");
 }
 
+QString TmwPlugin::shortName() const
+{
+    return "tmw";
+}
+
 QString TmwPlugin::errorString() const
 {
     return mError;

--- a/src/plugins/tmw/tmwplugin.h
+++ b/src/plugins/tmw/tmwplugin.h
@@ -38,6 +38,7 @@ public:
 
     bool write(const Tiled::Map *map, const QString &fileName) override;
     QString nameFilter() const override;
+    QString shortName() const override;
     QString errorString() const override;
 
 private:

--- a/src/tiled/main.cpp
+++ b/src/tiled/main.cpp
@@ -165,7 +165,7 @@ void CommandLineHandler::showExportFormats()
     const auto formats = PluginManager::objects<MapFormat>();
     for (MapFormat *format : formats) {
         if (format->hasCapabilities(MapFormat::Write))
-            qWarning(" %s", qUtf8Printable(format->nameFilter()));
+            qWarning(" %s", qUtf8Printable(format->shortName()));
     }
 
     quit = true;
@@ -252,7 +252,7 @@ int main(int argc, char *argv[])
             for (MapFormat *format : formats) {
                 if (!format->hasCapabilities(MapFormat::Write))
                     continue;
-                if (format->nameFilter().compare(*filter, Qt::CaseInsensitive) == 0) {
+                if (format->shortName().compare(*filter, Qt::CaseInsensitive) == 0) {
                     chosenFormat = format;
                     break;
                 }

--- a/src/tiled/tmxmapformat.h
+++ b/src/tiled/tmxmapformat.h
@@ -63,6 +63,8 @@ public:
 
     QString nameFilter() const override { return tr("Tiled map files (*.tmx)"); }
 
+    QString shortName() const override { return tr("tmx"); }
+
     bool supportsFile(const QString &fileName) const override;
 
     QString errorString() const override { return mError; }
@@ -88,6 +90,8 @@ public:
     bool write(const Tileset &tileset, const QString &fileName) override;
 
     QString nameFilter() const override { return tr("Tiled tileset files (*.tsx)"); }
+
+    QString shortName() const override { return tr("tsx"); }
 
     bool supportsFile(const QString &fileName) const override;
 

--- a/src/tiled/tmxmapformat.h
+++ b/src/tiled/tmxmapformat.h
@@ -63,7 +63,7 @@ public:
 
     QString nameFilter() const override { return tr("Tiled map files (*.tmx)"); }
 
-    QString shortName() const override { return tr("tmx"); }
+    QString shortName() const override { return QLatin1String("tmx"); }
 
     bool supportsFile(const QString &fileName) const override;
 
@@ -91,7 +91,7 @@ public:
 
     QString nameFilter() const override { return tr("Tiled tileset files (*.tsx)"); }
 
-    QString shortName() const override { return tr("tsx"); }
+    QString shortName() const override { return QLatin1String("tsx"); }
 
     bool supportsFile(const QString &fileName) const override;
 


### PR DESCRIPTION
For Issue #1382 
Added a new virtual method to MapFormat called `shortName` to use whenever a short descriptive name is needed. Particularly for CLI input/output.

Added short names for all map format plugins.

`--export-formats` now uses the `shortName()`
`--export-map` now uses the `shortName()`
`--export-map` with no filter argument still uses `nameFilter()`

I've used the names of the modules as reference, if any of them are not appropriate I will change them.