### PR TITLE
Check for duplicates when adding tiles

### DIFF
--- a/src/tiled/tileseteditor.cpp
+++ b/src/tiled/tileseteditor.cpp
@@ -445,6 +445,7 @@ void TilesetEditor::addTiles()
         QPixmap image;
     };
     QVector<LoadedFile> loadedFiles;
+
     // If the tile is already in the tileset, warn user and confirm addition
     bool dontAskAgain = false;
     bool rememberOption = true;
@@ -462,14 +463,10 @@ void TilesetEditor::addTiles()
             warning.setInformativeText(tr("Add anyway?"));
             warning.setCheckBox(checkBox);
             int warningBoxChoice = warning.exec();
-            if (checkBox->checkState() == Qt::Checked)
-                dontAskAgain = true;
-            if (warningBoxChoice != QMessageBox::Yes) {
-                rememberOption = false;
+            dontAskAgain = checkBox->checkState() == Qt::Checked;
+            rememberOption = warningBoxChoice == QMessageBox::Yes;
+            if (!rememberOption)
                 continue;
-            }
-            else
-                rememberOption = true;
         }
         const QPixmap image(file);
         if (!image.isNull()) {

--- a/src/tiled/tileseteditor.cpp
+++ b/src/tiled/tileseteditor.cpp
@@ -418,6 +418,14 @@ void TilesetEditor::retranslateUi()
     mEditTerrain->setText(tr("Edit &Terrain Information"));
 }
 
+bool hasTileInTileset(QString tileName, const QMap<int, Tile*> addedTiles){
+    for (auto tile : addedTiles) {
+        if (tile->imageSource() == tileName)
+            return true;
+    }
+    return false;
+}
+
 void TilesetEditor::addTiles()
 {
     Tileset *tileset = currentTileset();
@@ -437,16 +445,14 @@ void TilesetEditor::addTiles()
     };
     QVector<LoadedFile> loadedFiles;
     // If the tile is already in the tileset, warn user and confirm addition
-    bool dontAskAgain = false, rememberOption = true;
+    bool dontAskAgain = false;
+    bool rememberOption = true;
     for (const QString &file : files) {
         bool addImage = true;
-        const QMap<int, Tile*> addedTiles = mCurrentTilesetDocument->tileset().data()->tiles();
-        for (auto tile : addedTiles) {
-            if (tile->imageSource() == file) {
-                if (dontAskAgain) {
-                    addImage = rememberOption;
-                    break;
-                }
+        if (hasTileInTileset(file, mCurrentTilesetDocument->tileset().data()->tiles())) {
+            if (dontAskAgain) 
+                addImage = rememberOption;
+            else {
                 QCheckBox *checkBox = new QCheckBox(tr("Apply this action to all tiles"));
                 QMessageBox warning(QMessageBox::Warning,
                             tr("Add Tiles"),
@@ -456,16 +462,12 @@ void TilesetEditor::addTiles()
                 warning.setDefaultButton(QMessageBox::Yes);
                 warning.setInformativeText(tr("Add anyway?"));
                 warning.setCheckBox(checkBox);
-                if (warning.exec() != QMessageBox::Yes) {
+                if (warning.exec() != QMessageBox::Yes)
                     rememberOption = addImage = false;
-                }
-                else {
+                else 
                     rememberOption = true;
-                }
-                if (checkBox->checkState() == Qt::Checked) {
+                if (checkBox->checkState() == Qt::Checked)
                     dontAskAgain = true;
-                }
-                break;
             }
         }
         if(!addImage){

--- a/src/tiled/tileseteditor.cpp
+++ b/src/tiled/tileseteditor.cpp
@@ -465,7 +465,28 @@ void TilesetEditor::addTiles()
         Tile *newTile = new Tile(tileset->takeNextTileId(), tileset);
         newTile->setImage(loadedFile.image);
         newTile->setImageSource(loadedFile.imageSource);
-        tiles.append(newTile);
+
+        // If the tile is already in the tileset, warn user and confirm addition
+        bool addImage = true;
+        const QMap<int, Tile*> addedTiles = mCurrentTilesetDocument->tileset().data()->tiles();
+        for(auto tile : addedTiles) {
+            if(tile->imageSource() == newTile->imageSource()) {
+                QMessageBox warning(QMessageBox::Warning,
+                            tr("Add Tiles"),
+                            tr("Tile already exists in the Tileset!"),
+                            QMessageBox::Yes | QMessageBox::No,
+                            mMainWindow->window());
+                warning.setDefaultButton(QMessageBox::Yes);
+                warning.setInformativeText(tr("Add anyway?"));
+                if (warning.exec() != QMessageBox::Yes) {
+                    addImage = false;
+                }
+                break;
+            }
+        }
+        if(addImage){
+            tiles.append(newTile);
+        }
     }
 
     mCurrentTilesetDocument->undoStack()->push(new AddTiles(mCurrentTilesetDocument, tiles));


### PR DESCRIPTION
This pull request closes https://github.com/bjorn/tiled/issues/1227 

When adding an image to a Tileset, it checks if the image already exists in the collection and warn the user if so.

![add](https://cloud.githubusercontent.com/assets/2761487/23521360/647909f6-ff5d-11e6-9cb3-94ba88200290.png)

The approach was: try to match for each added image, its image source with the images already in the collection (O(n^2))