### PR TITLE
Option to run commands from Menu as well as edit them - Fixes #943

### DIFF
--- a/src/tiled/commandbutton.cpp
+++ b/src/tiled/commandbutton.cpp
@@ -44,10 +44,10 @@ CommandButton::CommandButton(QWidget *parent)
     setMenu(mMenu);
 
     // Populate the menu once in order to register shortcuts beforehand
-    CommandManager::instance()->populateMenu(mMenu);
+    CommandManager::instance()->populateMenu(mMenu, true);
 
     connect(mMenu, &QMenu::aboutToShow,  
-            [this]() { CommandManager::instance()->populateMenu(mMenu); });
+            [this]() { CommandManager::instance()->populateMenu(mMenu, true); });
     connect(this, SIGNAL(clicked()), SLOT(runCommand()));
 }
 

--- a/src/tiled/commandbutton.cpp
+++ b/src/tiled/commandbutton.cpp
@@ -43,6 +43,9 @@ CommandButton::CommandButton(QWidget *parent)
     setPopupMode(QToolButton::MenuButtonPopup);
     setMenu(mMenu);
 
+    // Populate the menu once in order to register shortcuts beforehand
+    CommandManager::instance()->populateMenu(mMenu);
+
     connect(mMenu, &QMenu::aboutToShow, 
             CommandManager::instance(), [this]() { CommandManager::instance()->populateMenu(mMenu); });
     connect(this, SIGNAL(clicked()), SLOT(runCommand()));

--- a/src/tiled/commandbutton.cpp
+++ b/src/tiled/commandbutton.cpp
@@ -127,5 +127,6 @@ void CommandButton::changeEvent(QEvent *event)
 
 void CommandButton::retranslateUi()
 {
+    setShortcut(QKeySequence(tr("F5")));
     setToolTip(tr("Execute Command"));
 }

--- a/src/tiled/commandbutton.cpp
+++ b/src/tiled/commandbutton.cpp
@@ -35,7 +35,6 @@ using namespace Tiled::Internal;
 CommandButton::CommandButton(QWidget *parent)
     : QToolButton(parent)
     , mMenu(new QMenu(this))
-    , mCommandManager(new CommandManager(this))
 {
     setIcon(QIcon(QLatin1String(":images/24x24/system-run.png")));
     setThemeIcon(this, "system-run");
@@ -45,7 +44,7 @@ CommandButton::CommandButton(QWidget *parent)
     setMenu(mMenu);
 
     connect(mMenu, &QMenu::aboutToShow, 
-            mCommandManager, [this]() { mCommandManager->populateMenu(mMenu); });
+            CommandManager::instance(), [this]() { CommandManager::instance()->populateMenu(mMenu); });
     connect(this, SIGNAL(clicked()), SLOT(runCommand()));
 }
 

--- a/src/tiled/commandbutton.cpp
+++ b/src/tiled/commandbutton.cpp
@@ -127,6 +127,6 @@ void CommandButton::changeEvent(QEvent *event)
 
 void CommandButton::retranslateUi()
 {
-    setShortcut(QKeySequence(tr("F5")));
     setToolTip(tr("Execute Command"));
+    setShortcut(QKeySequence(tr("F5")));
 }

--- a/src/tiled/commandbutton.cpp
+++ b/src/tiled/commandbutton.cpp
@@ -128,5 +128,4 @@ void CommandButton::changeEvent(QEvent *event)
 void CommandButton::retranslateUi()
 {
     setToolTip(tr("Execute Command"));
-    setShortcut(QKeySequence(tr("F5")));
 }

--- a/src/tiled/commandbutton.cpp
+++ b/src/tiled/commandbutton.cpp
@@ -46,8 +46,8 @@ CommandButton::CommandButton(QWidget *parent)
     // Populate the menu once in order to register shortcuts beforehand
     CommandManager::instance()->populateMenu(mMenu);
 
-    connect(mMenu, &QMenu::aboutToShow, 
-            CommandManager::instance(), [this]() { CommandManager::instance()->populateMenu(mMenu); });
+    connect(mMenu, &QMenu::aboutToShow,  
+            [this]() { CommandManager::instance()->populateMenu(mMenu); });
     connect(this, SIGNAL(clicked()), SLOT(runCommand()));
 }
 

--- a/src/tiled/commandbutton.h
+++ b/src/tiled/commandbutton.h
@@ -27,7 +27,6 @@ class QMenu;
 namespace Tiled {
 namespace Internal {
 
-class CommandManager;
 class MainWindow;
 class DocumentManager;
 
@@ -49,7 +48,6 @@ private:
     void retranslateUi();
 
     QMenu *mMenu;
-    CommandManager *mCommandManager;
 };
 
 } // namespace Internal

--- a/src/tiled/commandbutton.h
+++ b/src/tiled/commandbutton.h
@@ -27,6 +27,7 @@ class QMenu;
 namespace Tiled {
 namespace Internal {
 
+class CommandManager;
 class MainWindow;
 class DocumentManager;
 
@@ -43,12 +44,12 @@ protected:
 private slots:
     void runCommand();
     void showDialog();
-    void populateMenu();
 
 private:
     void retranslateUi();
 
     QMenu *mMenu;
+    CommandManager *mCommandManager;
 };
 
 } // namespace Internal

--- a/src/tiled/commanddatamodel.cpp
+++ b/src/tiled/commanddatamodel.cpp
@@ -29,7 +29,8 @@ using namespace Tiled::Internal;
 
 const char *commandMimeType = "application/x-tiled-commandptr";
 
-CommandDataModel::CommandDataModel()
+CommandDataModel::CommandDataModel(QObject *parent)
+    : QAbstractTableModel(parent)
 {
     // Load saveBeforeExecute option
     QVariant s = mSettings.value(QLatin1String("saveBeforeExecute"), true);

--- a/src/tiled/commanddatamodel.h
+++ b/src/tiled/commanddatamodel.h
@@ -42,7 +42,7 @@ public:
       * Constructs the object and parses the users settings to allow easy
       * programmatic access to the command list.
       */
-    CommandDataModel();
+    CommandDataModel(QObject *parent = nullptr);
 
     /**
       * Saves the data to the users preferences.

--- a/src/tiled/commanddialog.cpp
+++ b/src/tiled/commanddialog.cpp
@@ -22,6 +22,7 @@
 #include "ui_commanddialog.h"
 
 #include "commanddatamodel.h"
+#include "commandmanager.h"
 #include "utils.h"
 
 #include <QShortcut>
@@ -62,7 +63,7 @@ void CommandDialog::accept()
 
 CommandTreeView::CommandTreeView(QWidget *parent)
     : QTreeView(parent)
-    , mModel(new CommandDataModel)
+    , mModel(CommandManager::instance()->getCommandDataModel())
 {
     setModel(mModel);
     setRootIsDecorated(false);
@@ -83,11 +84,6 @@ CommandTreeView::CommandTreeView(QWidget *parent)
 
     connect(mModel, SIGNAL(rowsRemoved(QModelIndex, int, int)),
                     SLOT(handleRowsRemoved(QModelIndex, int, int)));
-}
-
-CommandTreeView::~CommandTreeView()
-{
-    delete mModel;
 }
 
 void CommandTreeView::contextMenuEvent(QContextMenuEvent *event)

--- a/src/tiled/commanddialog.cpp
+++ b/src/tiled/commanddialog.cpp
@@ -63,7 +63,7 @@ void CommandDialog::accept()
 
 CommandTreeView::CommandTreeView(QWidget *parent)
     : QTreeView(parent)
-    , mModel(CommandManager::instance()->getCommandDataModel())
+    , mModel(CommandManager::instance()->commandDataModel())
 {
     setModel(mModel);
     setRootIsDecorated(false);

--- a/src/tiled/commanddialog.h
+++ b/src/tiled/commanddialog.h
@@ -56,7 +56,6 @@ class CommandTreeView : public QTreeView
 
 public:
     CommandTreeView(QWidget *parent);
-    ~CommandTreeView();
 
     /**
       * Returns the model used by this view in CommandDataMode form.

--- a/src/tiled/commanddialog.ui
+++ b/src/tiled/commanddialog.ui
@@ -35,6 +35,9 @@
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>6</number>
+     </property>
      <item>
       <widget class="QCheckBox" name="saveBox">
        <property name="text">
@@ -43,12 +46,15 @@
       </widget>
      </item>
      <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+      <widget class="QPushButton" name="pushButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       <property name="text">
+        <string>Close</string>
        </property>
       </widget>
      </item>
@@ -66,34 +72,18 @@
  <resources/>
  <connections>
   <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
+   <sender>pushButton</sender>
+   <signal>clicked()</signal>
    <receiver>CommandDialog</receiver>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>248</x>
+     <x>342</x>
+     <y>233</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>372</x>
      <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>CommandDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
     </hint>
    </hints>
   </connection>

--- a/src/tiled/commandmanager.cpp
+++ b/src/tiled/commandmanager.cpp
@@ -62,6 +62,7 @@ void CommandManager::populateMenu(QMenu *menu)
 {
 	menu->clear();
 
+	// Add Edit Commands first
 	QAction *mEditCommands = new QAction(this);
     mEditCommands->setIcon(
             QIcon(QLatin1String(":/images/24x24/system-run.png")));
@@ -70,4 +71,24 @@ void CommandManager::populateMenu(QMenu *menu)
     menu->addAction(mEditCommands);
 
     connect(mEditCommands, SIGNAL(triggered()), this, SLOT(showDialog()));
+
+    menu->addSeparator();
+
+    // Add all enabled commands now
+
+    bool firstEnabledCommand = true;
+
+    const CommandDataModel model;
+    const QList<Command> &commands = model.allCommands();
+
+    foreach (const Command &command, commands) {
+        if (!command.isEnabled)
+            continue;
+
+        QAction *mAction = menu->addAction(command.name);
+        if(firstEnabledCommand)
+        	mAction->setShortcut(QKeySequence(tr("F5")));
+        firstEnabledCommand = false;
+        
+    }
 }

--- a/src/tiled/commandmanager.cpp
+++ b/src/tiled/commandmanager.cpp
@@ -26,6 +26,7 @@
 #include <QAction>
 #include <QLatin1String>
 #include <QMenu>
+#include <QShortcut>
 #include <QSignalMapper>
 #include <QWidget>
 
@@ -90,13 +91,18 @@ void CommandManager::populateMenu(QMenu *menu)
             continue;
 
         QAction *mAction = menu->addAction(command.name);
-        if(firstEnabledCommand)
-        	mAction->setShortcut(QKeySequence(tr("F5")));
+
         firstEnabledCommand = false;
 
         QSignalMapper *mapper = new QSignalMapper(mAction);
         mapper->setMapping(mAction, counter);
         connect(mAction, SIGNAL(triggered()), mapper, SLOT(map()));
         connect(mapper, SIGNAL(mapped(int)), mModel, SLOT(execute(int)));
+
+        if(firstEnabledCommand) {
+        	mAction->setShortcut(QKeySequence(tr("F5")));
+        	QShortcut *key = new QShortcut(QKeySequence(tr("F5")), mMainWindow);
+		    connect(key, SIGNAL(activated()), mAction, SLOT(trigger()));
+        }
     }
 }

--- a/src/tiled/commandmanager.cpp
+++ b/src/tiled/commandmanager.cpp
@@ -35,7 +35,7 @@ namespace Internal {
 CommandManager *CommandManager::mInstance;
 
 CommandManager::CommandManager()
-    : mModel(new CommandDataModel)
+    : mModel(new CommandDataModel(this))
 {
     
 }

--- a/src/tiled/commandmanager.cpp
+++ b/src/tiled/commandmanager.cpp
@@ -20,15 +20,54 @@
 
 #include "commandmanager.h"
 
+#include "commanddatamodel.h"
+#include "commanddialog.h"
+
+#include <QAction>
+#include <QLatin1String>
+#include <QMenu>
+#include <QWidget>
+
 using namespace Tiled;
 using namespace Tiled::Internal;
 
-CommandManager::CommandManager(QObject *parent)
+CommandManager::CommandManager(QObject *parent, QWidget *window)
 	: QObject(parent)
+	, mMainWindow(window)
 {
 	
 }
 
 CommandManager::~CommandManager()
 {
+}
+
+void CommandManager::setMainWindowMenu(QMenu *menu)
+{
+	this->mMainWindowMenu = menu;
+}
+
+void CommandManager::populateMainWindowMenu()
+{
+	populateMenu(this->mMainWindowMenu);
+}
+
+void CommandManager::showDialog()
+{
+	CommandDialog dialog(mMainWindow);
+    dialog.exec();
+}
+
+void CommandManager::populateMenu(QMenu *menu)
+{
+	menu->clear();
+
+	QAction *mEditCommands = new QAction(this);
+    mEditCommands->setIcon(
+            QIcon(QLatin1String(":/images/24x24/system-run.png")));
+    mEditCommands->setText(tr("Edit Commands"));
+
+    menu->addAction(mEditCommands);
+
+    connect(mEditCommands, SIGNAL(triggered()), this, SLOT(showDialog()));
 }

--- a/src/tiled/commandmanager.cpp
+++ b/src/tiled/commandmanager.cpp
@@ -65,7 +65,7 @@ void CommandManager::showDialog()
     dialog.exec();
 }
 
-void CommandManager::populateMenu(QMenu *menu)
+void CommandManager::populateMenu(QMenu *menu, bool flag)
 {
     menu->clear();
 
@@ -82,7 +82,7 @@ void CommandManager::populateMenu(QMenu *menu)
             continue;
 
         QAction *mAction = menu->addAction(command.name);
-        if (firstEnabledCommand)
+        if (firstEnabledCommand && flag)
             mAction->setShortcut(QKeySequence(tr("F5")));
         firstEnabledCommand = false;
 

--- a/src/tiled/commandmanager.cpp
+++ b/src/tiled/commandmanager.cpp
@@ -26,6 +26,7 @@
 #include <QAction>
 #include <QLatin1String>
 #include <QMenu>
+#include <QSignalMapper>
 #include <QWidget>
 
 using namespace Tiled;
@@ -77,11 +78,14 @@ void CommandManager::populateMenu(QMenu *menu)
     // Add all enabled commands now
 
     bool firstEnabledCommand = true;
+    int counter = -1;
 
-    const CommandDataModel model;
-    const QList<Command> &commands = model.allCommands();
+    CommandDataModel *mModel = new CommandDataModel;
+    const QList<Command> &commands = mModel->allCommands();
 
     foreach (const Command &command, commands) {
+    	++counter;
+
         if (!command.isEnabled)
             continue;
 
@@ -89,6 +93,10 @@ void CommandManager::populateMenu(QMenu *menu)
         if(firstEnabledCommand)
         	mAction->setShortcut(QKeySequence(tr("F5")));
         firstEnabledCommand = false;
-        
+
+        QSignalMapper *mapper = new QSignalMapper(mAction);
+        mapper->setMapping(mAction, counter);
+        connect(mAction, SIGNAL(triggered()), mapper, SLOT(map()));
+        connect(mapper, SIGNAL(mapped(int)), mModel, SLOT(execute(int)));
     }
 }

--- a/src/tiled/commandmanager.cpp
+++ b/src/tiled/commandmanager.cpp
@@ -69,7 +69,8 @@ void CommandManager::populateMenu(QMenu *menu)
     }
 
     // Add Edit Commands action
-    menu->addSeparator();
+    if (!menu->isEmpty())
+        menu->addSeparator();
 
     QAction *mEditCommands = new QAction(this);
     mEditCommands->setIcon(

--- a/src/tiled/commandmanager.cpp
+++ b/src/tiled/commandmanager.cpp
@@ -27,8 +27,6 @@
 #include <QAction>
 #include <QLatin1String>
 #include <QMenu>
-#include <QSignalMapper>
-#include <QWidget>
 
 using namespace Tiled;
 using namespace Tiled::Internal;
@@ -52,13 +50,12 @@ void CommandManager::populateMenu(QMenu *menu)
     // Add all enabled commands
 
     bool firstEnabledCommand = true;
-    int counter = -1;
 
-    CommandDataModel *mModel = new CommandDataModel;
+    mModel = new CommandDataModel;
     const QList<Command> &commands = mModel->allCommands();
 
-    foreach (const Command &command, commands) {
-        ++counter;
+    for (int i = 0; i < commands.size(); ++i) {
+        const Command &command = commands.at(i);
 
         if (!command.isEnabled)
             continue;
@@ -68,10 +65,7 @@ void CommandManager::populateMenu(QMenu *menu)
             mAction->setShortcut(QKeySequence(tr("F5")));
         firstEnabledCommand = false;
 
-        QSignalMapper *mapper = new QSignalMapper(mAction);
-        mapper->setMapping(mAction, counter);
-        connect(mAction, SIGNAL(triggered()), mapper, SLOT(map()));
-        connect(mapper, SIGNAL(mapped(int)), mModel, SLOT(execute(int)));
+        connect(mAction, &QAction::triggered, [this,i]() { mModel->execute(i); });
     }
 
     // Add Edit Commands action

--- a/src/tiled/commandmanager.cpp
+++ b/src/tiled/commandmanager.cpp
@@ -28,13 +28,34 @@
 #include <QLatin1String>
 #include <QMenu>
 
-using namespace Tiled;
-using namespace Tiled::Internal;
+namespace Tiled {
+namespace Internal {
 
-CommandManager::CommandManager(QObject *parent)
-    : QObject(parent)
+CommandManager *CommandManager::mInstance;
+
+CommandManager::CommandManager()
+    : mModel(new CommandDataModel)
 {
     
+}
+
+CommandManager *CommandManager::instance()
+{
+    if (!mInstance)
+        mInstance = new CommandManager;
+
+    return mInstance;
+}
+
+void CommandManager::deleteInstance()
+{
+    delete mInstance;
+    mInstance = nullptr;
+}
+
+CommandDataModel *CommandManager::getCommandDataModel()
+{
+    return mModel;
 }
 
 void CommandManager::showDialog()
@@ -51,7 +72,6 @@ void CommandManager::populateMenu(QMenu *menu)
 
     bool firstEnabledCommand = true;
 
-    mModel = new CommandDataModel;
     const QList<Command> &commands = mModel->allCommands();
 
     for (int i = 0; i < commands.size(); ++i) {
@@ -79,6 +99,9 @@ void CommandManager::populateMenu(QMenu *menu)
 
     menu->addAction(mEditCommands);
 
-    connect(mEditCommands, SIGNAL(triggered()), this, SLOT(showDialog()));
+    connect(mEditCommands, &QAction::triggered, this, &CommandManager::showDialog);
 
 }
+
+} // namespace Internal
+} // namespace Tiled

--- a/src/tiled/commandmanager.cpp
+++ b/src/tiled/commandmanager.cpp
@@ -26,7 +26,6 @@
 #include <QAction>
 #include <QLatin1String>
 #include <QMenu>
-#include <QShortcut>
 #include <QSignalMapper>
 #include <QWidget>
 
@@ -91,18 +90,13 @@ void CommandManager::populateMenu(QMenu *menu)
             continue;
 
         QAction *mAction = menu->addAction(command.name);
-
+        if(firstEnabledCommand)
+        	mAction->setShortcut(QKeySequence(tr("F5")));
         firstEnabledCommand = false;
 
         QSignalMapper *mapper = new QSignalMapper(mAction);
         mapper->setMapping(mAction, counter);
         connect(mAction, SIGNAL(triggered()), mapper, SLOT(map()));
         connect(mapper, SIGNAL(mapped(int)), mModel, SLOT(execute(int)));
-
-        if(firstEnabledCommand) {
-        	mAction->setShortcut(QKeySequence(tr("F5")));
-        	QShortcut *key = new QShortcut(QKeySequence(tr("F5")), mMainWindow);
-		    connect(key, SIGNAL(activated()), mAction, SLOT(trigger()));
-        }
     }
 }

--- a/src/tiled/commandmanager.cpp
+++ b/src/tiled/commandmanager.cpp
@@ -1,0 +1,34 @@
+/*
+ * commandmanagar.cpp
+ * Copyright 2017, Ketan Gupta <ketan19972010@gmail.com>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "commandmanager.h"
+
+using namespace Tiled;
+using namespace Tiled::Internal;
+
+CommandManager::CommandManager(QObject *parent)
+	: QObject(parent)
+{
+	
+}
+
+CommandManager::~CommandManager()
+{
+}

--- a/src/tiled/commandmanager.cpp
+++ b/src/tiled/commandmanager.cpp
@@ -22,6 +22,7 @@
 
 #include "commanddatamodel.h"
 #include "commanddialog.h"
+#include "utils.h"
 
 #include <QApplication>
 #include <QAction>
@@ -53,7 +54,7 @@ void CommandManager::deleteInstance()
     mInstance = nullptr;
 }
 
-CommandDataModel *CommandManager::getCommandDataModel()
+CommandDataModel *CommandManager::commandDataModel()
 {
     return mModel;
 }
@@ -96,6 +97,7 @@ void CommandManager::populateMenu(QMenu *menu)
     mEditCommands->setIcon(
             QIcon(QLatin1String(":/images/24x24/system-run.png")));
     mEditCommands->setText(tr("Edit Commands..."));
+    Utils::setThemeIcon(mEditCommands, "system-run");
 
     menu->addAction(mEditCommands);
 

--- a/src/tiled/commandmanager.h
+++ b/src/tiled/commandmanager.h
@@ -22,6 +22,9 @@
 
 #include <QObject>
 
+class QMenu;
+class QWidget;
+
 namespace Tiled {
 namespace Internal {
 
@@ -30,8 +33,30 @@ class CommandManager : public QObject
 	Q_OBJECT
 
 public:
-    CommandManager(QObject *parent = nullptr);
+    CommandManager(QObject *parent = nullptr, QWidget *window = nullptr);
     ~CommandManager();
+
+    /**
+     * Sets the value of mMainWindowMenu
+     */
+    void setMainWindowMenu(QMenu *menu);
+
+public slots:
+	void populateMainWindowMenu();
+
+	/**
+     * Displays the dialog to edit the commands
+     */
+    void showDialog();
+
+private:
+	/**
+	 * Populates the menu pointed by menu
+	 */
+	void populateMenu(QMenu *menu);
+
+	QMenu *mMainWindowMenu;
+	QWidget *mMainWindow;
 };
 
 } // namespace Internal

--- a/src/tiled/commandmanager.h
+++ b/src/tiled/commandmanager.h
@@ -27,6 +27,8 @@ class QMenu;
 namespace Tiled {
 namespace Internal {
 
+class CommandDataModel;
+
 class CommandManager : public QObject
 {
     Q_OBJECT
@@ -47,6 +49,7 @@ public slots:
 
 private:
     QMenu *mMainWindowMenu;
+    CommandDataModel *mModel;
 };
 
 } // namespace Internal

--- a/src/tiled/commandmanager.h
+++ b/src/tiled/commandmanager.h
@@ -1,5 +1,5 @@
 /*
- * commandmanagar.h
+ * commandmanager.h
  * Copyright 2017, Ketan Gupta <ketan19972010@gmail.com>
  *
  * This file is part of Tiled.
@@ -23,40 +23,30 @@
 #include <QObject>
 
 class QMenu;
-class QWidget;
 
 namespace Tiled {
 namespace Internal {
 
 class CommandManager : public QObject
 {
-	Q_OBJECT
+    Q_OBJECT
 
 public:
-    CommandManager(QObject *parent = nullptr, QWidget *window = nullptr);
-    ~CommandManager();
-
-    /**
-     * Sets the value of mMainWindowMenu
-     */
-    void setMainWindowMenu(QMenu *menu);
+    CommandManager(QObject *parent = nullptr);
 
 public slots:
-	void populateMainWindowMenu();
+    /**
+     * Populates the menu pointed by menu
+     */
+    void populateMenu(QMenu *menu);
 
-	/**
+    /**
      * Displays the dialog to edit the commands
      */
     void showDialog();
 
 private:
-	/**
-	 * Populates the menu pointed by menu
-	 */
-	void populateMenu(QMenu *menu);
-
-	QMenu *mMainWindowMenu;
-	QWidget *mMainWindow;
+    QMenu *mMainWindowMenu;
 };
 
 } // namespace Internal

--- a/src/tiled/commandmanager.h
+++ b/src/tiled/commandmanager.h
@@ -45,7 +45,7 @@ public slots:
     /**
      * Populates the menu pointed by menu
      */
-    void populateMenu(QMenu *menu);
+    void populateMenu(QMenu *menu, bool flag = false);
 
     /**
      * Displays the dialog to edit the commands

--- a/src/tiled/commandmanager.h
+++ b/src/tiled/commandmanager.h
@@ -1,0 +1,38 @@
+/*
+ * commandmanagar.h
+ * Copyright 2017, Ketan Gupta <ketan19972010@gmail.com>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+
+namespace Tiled {
+namespace Internal {
+
+class CommandManager : public QObject
+{
+	Q_OBJECT
+
+public:
+    CommandManager(QObject *parent = nullptr);
+    ~CommandManager();
+};
+
+} // namespace Internal
+} // namespace Tiled

--- a/src/tiled/commandmanager.h
+++ b/src/tiled/commandmanager.h
@@ -34,7 +34,12 @@ class CommandManager : public QObject
     Q_OBJECT
 
 public:
-    CommandManager(QObject *parent = nullptr);
+
+    static CommandManager *instance();
+
+    static void deleteInstance();
+
+    CommandDataModel *getCommandDataModel();
 
 public slots:
     /**
@@ -48,7 +53,11 @@ public slots:
     void showDialog();
 
 private:
-    QMenu *mMainWindowMenu;
+    Q_DISABLE_COPY(CommandManager);
+
+    CommandManager();
+
+    static CommandManager *mInstance;
     CommandDataModel *mModel;
 };
 

--- a/src/tiled/commandmanager.h
+++ b/src/tiled/commandmanager.h
@@ -39,7 +39,7 @@ public:
 
     static void deleteInstance();
 
-    CommandDataModel *getCommandDataModel();
+    CommandDataModel *commandDataModel();
 
 public slots:
     /**

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -104,7 +104,6 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     , mConsoleDock(new ConsoleDock(this))
     , mObjectTypesEditor(new ObjectTypesEditor(this))
     , mAutomappingManager(new AutomappingManager(this))
-    , mCommandManager(new CommandManager(this))
     , mDocumentManager(DocumentManager::instance())
     , mTmxMapFormat(new TmxMapFormat(this))
     , mTsxTilesetFormat(new TsxTilesetFormat(this))
@@ -313,7 +312,7 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     connect(mUi->actionFullScreen, &QAction::toggled, this, &MainWindow::setFullScreen);
 
     connect(mUi->menuCommand, &QMenu::aboutToShow, 
-            mCommandManager, [this]() { mCommandManager->populateMenu(mUi->menuCommand); });
+            CommandManager::instance(), [this]() { CommandManager::instance()->populateMenu(mUi->menuCommand); });
 
     connect(mUi->actionNewTileset, SIGNAL(triggered()), SLOT(newTileset()));
     connect(mUi->actionAddExternalTileset, SIGNAL(triggered()),

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -104,7 +104,7 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     , mConsoleDock(new ConsoleDock(this))
     , mObjectTypesEditor(new ObjectTypesEditor(this))
     , mAutomappingManager(new AutomappingManager(this))
-    , mCommandManager(new CommandManager(this, window()))
+    , mCommandManager(new CommandManager(this))
     , mDocumentManager(DocumentManager::instance())
     , mTmxMapFormat(new TmxMapFormat(this))
     , mTsxTilesetFormat(new TsxTilesetFormat(this))
@@ -270,8 +270,6 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
 
     menuBar()->insertMenu(mUi->menuHelp->menuAction(), mLayerMenu);
 
-    mCommandManager->setMainWindowMenu(mUi->menuCommand);
-
     connect(mUi->actionNewMap, SIGNAL(triggered()), SLOT(newMap()));
     connect(mUi->actionOpen, SIGNAL(triggered()), SLOT(openFile()));
     connect(mUi->actionClearRecentFiles, SIGNAL(triggered()),
@@ -314,7 +312,8 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     connect(mUi->actionZoomNormal, SIGNAL(triggered()), SLOT(zoomNormal()));
     connect(mUi->actionFullScreen, &QAction::toggled, this, &MainWindow::setFullScreen);
 
-    connect(mUi->menuCommand, SIGNAL(aboutToShow()), mCommandManager, SLOT(populateMainWindowMenu()));
+    connect(mUi->menuCommand, &QMenu::aboutToShow, 
+            mCommandManager, [this]() { mCommandManager->populateMenu(mUi->menuCommand); });
 
     connect(mUi->actionNewTileset, SIGNAL(triggered()), SLOT(newTileset()));
     connect(mUi->actionAddExternalTileset, SIGNAL(triggered()),

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -312,7 +312,7 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     connect(mUi->actionFullScreen, &QAction::toggled, this, &MainWindow::setFullScreen);
 
     connect(mUi->menuCommand, &QMenu::aboutToShow, 
-            CommandManager::instance(), [this]() { CommandManager::instance()->populateMenu(mUi->menuCommand); });
+            [this]() { CommandManager::instance()->populateMenu(mUi->menuCommand); });
 
     connect(mUi->actionNewTileset, SIGNAL(triggered()), SLOT(newTileset()));
     connect(mUi->actionAddExternalTileset, SIGNAL(triggered()),
@@ -477,6 +477,7 @@ MainWindow::~MainWindow()
     LanguageManager::deleteInstance();
     PluginManager::deleteInstance();
     ClipboardManager::deleteInstance();
+    CommandManager::deleteInstance();
 
     delete mUi;
 }

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -104,7 +104,7 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     , mConsoleDock(new ConsoleDock(this))
     , mObjectTypesEditor(new ObjectTypesEditor(this))
     , mAutomappingManager(new AutomappingManager(this))
-    , mCommandManager(new CommandManager(this))
+    , mCommandManager(new CommandManager(this, window()))
     , mDocumentManager(DocumentManager::instance())
     , mTmxMapFormat(new TmxMapFormat(this))
     , mTsxTilesetFormat(new TsxTilesetFormat(this))
@@ -270,6 +270,8 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
 
     menuBar()->insertMenu(mUi->menuHelp->menuAction(), mLayerMenu);
 
+    mCommandManager->setMainWindowMenu(mUi->menuCommand);
+
     connect(mUi->actionNewMap, SIGNAL(triggered()), SLOT(newMap()));
     connect(mUi->actionOpen, SIGNAL(triggered()), SLOT(openFile()));
     connect(mUi->actionClearRecentFiles, SIGNAL(triggered()),
@@ -311,6 +313,8 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     connect(mUi->actionZoomOut, SIGNAL(triggered()), SLOT(zoomOut()));
     connect(mUi->actionZoomNormal, SIGNAL(triggered()), SLOT(zoomNormal()));
     connect(mUi->actionFullScreen, &QAction::toggled, this, &MainWindow::setFullScreen);
+
+    connect(mUi->menuCommand, SIGNAL(aboutToShow()), mCommandManager, SLOT(populateMainWindowMenu()));
 
     connect(mUi->actionNewTileset, SIGNAL(triggered()), SLOT(newTileset()));
     connect(mUi->actionAddExternalTileset, SIGNAL(triggered()),

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -33,6 +33,7 @@
 #include "addremovetileset.h"
 #include "automappingmanager.h"
 #include "commandbutton.h"
+#include "commandmanager.h"
 #include "consoledock.h"
 #include "documentmanager.h"
 #include "exportasimagedialog.h"
@@ -103,6 +104,7 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     , mConsoleDock(new ConsoleDock(this))
     , mObjectTypesEditor(new ObjectTypesEditor(this))
     , mAutomappingManager(new AutomappingManager(this))
+    , mCommandManager(new CommandManager(this))
     , mDocumentManager(DocumentManager::instance())
     , mTmxMapFormat(new TmxMapFormat(this))
     , mTsxTilesetFormat(new TsxTilesetFormat(this))

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -50,7 +50,6 @@ namespace Internal {
 
 class ActionManager;
 class AutomappingManager;
-class CommandManager;
 class DocumentManager;
 class MapDocumentActionHandler;
 class MapScene;
@@ -222,7 +221,6 @@ private:
     void setupQuickStamps();
 
     AutomappingManager *mAutomappingManager;
-    CommandManager *mCommandManager;
     DocumentManager *mDocumentManager;
 
     TmxMapFormat *mTmxMapFormat;

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -50,6 +50,7 @@ namespace Internal {
 
 class ActionManager;
 class AutomappingManager;
+class CommandManager;
 class DocumentManager;
 class MapDocumentActionHandler;
 class MapScene;
@@ -221,6 +222,7 @@ private:
     void setupQuickStamps();
 
     AutomappingManager *mAutomappingManager;
+    CommandManager *mCommandManager;
     DocumentManager *mDocumentManager;
 
     TmxMapFormat *mTmxMapFormat;

--- a/src/tiled/mainwindow.ui
+++ b/src/tiled/mainwindow.ui
@@ -84,6 +84,7 @@
     <addaction name="actionReload"/>
     <addaction name="separator"/>
     <addaction name="menuCommand"/>
+    <addaction name="separator"/>
     <addaction name="actionClose"/>
     <addaction name="actionCloseAll"/>
     <addaction name="actionQuit"/>

--- a/src/tiled/mainwindow.ui
+++ b/src/tiled/mainwindow.ui
@@ -65,6 +65,12 @@
      <addaction name="actionNewMap"/>
      <addaction name="actionNewTileset"/>
     </widget>
+    <widget class="QMenu" name="menuCommand">
+     <property name="title">
+      <string>Command</string>
+     </property>
+     <addaction name="actionEditCommands"/>
+    </widget>
     <addaction name="menuNew"/>
     <addaction name="actionOpen"/>
     <addaction name="menuRecentFiles"/>
@@ -77,6 +83,7 @@
     <addaction name="actionExportAsImage"/>
     <addaction name="actionReload"/>
     <addaction name="separator"/>
+    <addaction name="menuCommand"/>
     <addaction name="actionClose"/>
     <addaction name="actionCloseAll"/>
     <addaction name="actionQuit"/>
@@ -157,17 +164,9 @@
     </property>
     <addaction name="actionTilesetProperties"/>
    </widget>
-   <widget class="QMenu" name="menuCommand">
-    <property name="title">
-     <string>Command</string>
-    </property>
-    <addaction name="actionEditCommands"/>
-    <addaction name="separator"/>
-   </widget>
    <addaction name="menuFile"/>
    <addaction name="menuEdit"/>
    <addaction name="menuView"/>
-   <addaction name="menuCommand"/>
    <addaction name="menuMap"/>
    <addaction name="menuTileset"/>
    <addaction name="menuHelp"/>
@@ -588,7 +587,7 @@
     </iconset>
    </property>
    <property name="text">
-    <string>Edit Commands</string>
+    <string>Edit Commands...</string>
    </property>
   </action>
  </widget>

--- a/src/tiled/mainwindow.ui
+++ b/src/tiled/mainwindow.ui
@@ -41,7 +41,7 @@
      <x>0</x>
      <y>0</y>
      <width>553</width>
-     <height>25</height>
+     <height>19</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -157,9 +157,17 @@
     </property>
     <addaction name="actionTilesetProperties"/>
    </widget>
+   <widget class="QMenu" name="menuCommand">
+    <property name="title">
+     <string>Command</string>
+    </property>
+    <addaction name="actionEditCommands"/>
+    <addaction name="separator"/>
+   </widget>
    <addaction name="menuFile"/>
    <addaction name="menuEdit"/>
    <addaction name="menuView"/>
+   <addaction name="menuCommand"/>
    <addaction name="menuMap"/>
    <addaction name="menuTileset"/>
    <addaction name="menuHelp"/>
@@ -571,6 +579,16 @@
    </property>
    <property name="text">
     <string>No Snapping</string>
+   </property>
+  </action>
+  <action name="actionEditCommands">
+   <property name="icon">
+    <iconset>
+     <normalon>:/images/24x24/system-run.png</normalon>
+    </iconset>
+   </property>
+   <property name="text">
+    <string>Edit Commands</string>
    </property>
   </action>
  </widget>

--- a/src/tiled/tiled.pro
+++ b/src/tiled/tiled.pro
@@ -117,6 +117,7 @@ SOURCES += aboutdialog.cpp \
     commanddatamodel.cpp \
     commanddialog.cpp \
     commandlineparser.cpp \
+    commandmanager.cpp \
     consoledock.cpp \
     createellipseobjecttool.cpp \
     createmultipointobjecttool.cpp \
@@ -283,6 +284,7 @@ HEADERS += aboutdialog.h \
     commanddialog.h \
     command.h \
     commandlineparser.h \
+    commandmanager.h \
     consoledock.h \
     containerhelpers.h \
     createellipseobjecttool.h \

--- a/src/tiled/tiled.qbs
+++ b/src/tiled/tiled.qbs
@@ -145,6 +145,8 @@ QtGuiApplication {
         "command.h",
         "commandlineparser.cpp",
         "commandlineparser.h",
+        "commandmanager.cpp",
+        "commandmanager.h",
         "consoledock.cpp",
         "consoledock.h",
         "containerhelpers.h",


### PR DESCRIPTION
This fixes #943. I previously made a PR, but it lacked a lot of features. Here's a basic gist of what I've done now:

- Created a menu just for Commands
- Contains an action to `Edit Commands`
- Contains a list of all the enabled commands. Also has a shortcut for the first enabled command. This list gets refreshed each time the menu is opened. This is to ensure that the command list is updated and the disabled/enabled commands are updated.

Here's a screenshot of the same:

![Screenshot](https://image.ibb.co/nEcp8v/tiled_screenshot5.png "Screenshot")

I made a `CommandManager` class which is instantiated once in `MainWindow`. This manages the menu (updates the commands) and the signals/slots for them.