### PR TITLE
Disable width and height for Polygon and Polyline objects.

### DIFF
--- a/src/libtiled/mapobject.h
+++ b/src/libtiled/mapobject.h
@@ -157,6 +157,8 @@ public:
     Shape shape() const;
     void setShape(Shape shape);
 
+    bool isPolyShape() const;
+
     QRectF bounds() const;
     QRectF boundsUseTile() const;
 
@@ -359,6 +361,12 @@ inline MapObject::Shape MapObject::shape() const
  */
 inline void MapObject::setShape(MapObject::Shape shape)
 { mShape = shape; }
+
+/**
+ * Returns true if this is a Polygon or a Polyline.
+ */
+inline bool MapObject::isPolyShape() const
+{ return mShape == Polygon || mShape == Polyline; }
 
 /**
  * Shortcut to getting a QRectF from position() and size().

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -629,11 +629,16 @@ void PropertyBrowser::addMapObjectProperties()
     addProperty(VisibleProperty, QVariant::Bool, tr("Visible"), groupProperty);
     addProperty(XProperty, QVariant::Double, tr("X"), groupProperty);
     addProperty(YProperty, QVariant::Double, tr("Y"), groupProperty);
-    addProperty(WidthProperty, QVariant::Double, tr("Width"), groupProperty);
-    addProperty(HeightProperty, QVariant::Double, tr("Height"), groupProperty);
-    addProperty(RotationProperty, QVariant::Double, tr("Rotation"), groupProperty);
 
     auto mapObject = static_cast<const MapObject*>(mObject);
+
+    if (!mapObject->isPolyShape()) {
+        addProperty(WidthProperty, QVariant::Double, tr("Width"), groupProperty);
+        addProperty(HeightProperty, QVariant::Double, tr("Height"), groupProperty);
+    }
+
+    addProperty(RotationProperty, QVariant::Double, tr("Rotation"), groupProperty);
+
 
     if (!mapObject->cell().isEmpty()) {
         QtVariantProperty *flippingProperty =
@@ -1336,8 +1341,12 @@ void PropertyBrowser::updateProperties()
         mIdToProperty[VisibleProperty]->setValue(mapObject->isVisible());
         mIdToProperty[XProperty]->setValue(mapObject->x());
         mIdToProperty[YProperty]->setValue(mapObject->y());
-        mIdToProperty[WidthProperty]->setValue(mapObject->width());
-        mIdToProperty[HeightProperty]->setValue(mapObject->height());
+
+        if (!mapObject->isPolyShape()) {
+            mIdToProperty[WidthProperty]->setValue(mapObject->width());
+            mIdToProperty[HeightProperty]->setValue(mapObject->height());
+        }
+
         mIdToProperty[RotationProperty]->setValue(mapObject->rotation());
 
         if (QtVariantProperty *property = mIdToProperty[FlippingProperty]) {


### PR DESCRIPTION
Fix for #1451. Disables WidthProperty and HeightProperty for Polygon and Polyline objects.