### PR TITLE
Switch current layer when selecting objects from a single layer.

### DIFF
--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -670,7 +670,7 @@ void MapDocument::setSelectedObjects(const QList<MapObject *> &selectedObjects)
 
     // Switch the current object layer if only one object layer (and/or its objects)
     // are included in the current selection.
-    if(singleObjectGroup)
+    if (singleObjectGroup)
         setCurrentLayer(singleObjectGroup);
 
     if (selectedObjects.size() == 1)

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -659,6 +659,20 @@ void MapDocument::setSelectedObjects(const QList<MapObject *> &selectedObjects)
     mSelectedObjects = selectedObjects;
     emit selectedObjectsChanged();
 
+    ObjectGroup *singleObjectGroup = nullptr;
+    for (MapObject const *nextMapObject : selectedObjects) {
+        if (singleObjectGroup && nextMapObject->objectGroup() != singleObjectGroup) {
+            singleObjectGroup = nullptr;
+            break;
+        }
+        singleObjectGroup = nextMapObject->objectGroup();
+    }
+
+    // Switch the current object layer if only one object layer (and/or its objects)
+    // are included in the current selection.
+    if(singleObjectGroup)
+        setCurrentLayer(singleObjectGroup);
+
     if (selectedObjects.size() == 1)
         setCurrentObject(selectedObjects.first());
 }

--- a/src/tiled/objectsdock.cpp
+++ b/src/tiled/objectsdock.cpp
@@ -347,23 +347,11 @@ void ObjectsView::selectionChanged(const QItemSelection &selected,
         return;
 
     const QModelIndexList selectedProxyRows = selectionModel()->selectedRows();
-    ObjectGroup *singleObjectGroup = nullptr;
-    bool multipleObjectGroups = false;
 
     QList<MapObject*> selectedObjects;
     for (const QModelIndex &proxyIndex : selectedProxyRows) {
         const QModelIndex index = mProxyModel->mapToSource(proxyIndex);
 
-        if (ObjectGroup *og = mapObjectModel()->toObjectGroupContext(index)) {
-            if (!multipleObjectGroups) {
-                if (!singleObjectGroup) {
-                    singleObjectGroup = og;
-                } else if (singleObjectGroup != og) {
-                    singleObjectGroup = nullptr;
-                    multipleObjectGroups = true;
-                }
-            }
-        }
         if (MapObject *o = mapObjectModel()->toMapObject(index))
             selectedObjects.append(o);
     }

--- a/src/tiled/objectsdock.cpp
+++ b/src/tiled/objectsdock.cpp
@@ -368,11 +368,6 @@ void ObjectsView::selectionChanged(const QItemSelection &selected,
             selectedObjects.append(o);
     }
 
-    // Switch the current object layer if only one object layer (and/or its objects)
-    // are included in the current selection.
-    if (singleObjectGroup)
-        mMapDocument->setCurrentLayer(singleObjectGroup);
-
     if (selectedObjects != mMapDocument->selectedObjects()) {
         mSynching = true;
         if (selectedObjects.count() == 1) {


### PR DESCRIPTION
Fix for #1424. When selecting objects from the editor, the current
layer is switched when the objects are from only a single layer.