### PR TITLE
Added switchable columns to objects view

### DIFF
--- a/src/tiled/mapobjectmodel.cpp
+++ b/src/tiled/mapobjectmodel.cpp
@@ -445,7 +445,7 @@ void MapObjectModel::emitObjectsChanged(const QList<MapObject *> &objects, const
     }
 }
 
-void MapObjectModel::emitObjectsChanged(const QList<MapObject *> &objects, const MapObjectModel::Column column)
+void MapObjectModel::emitObjectsChanged(const QList<MapObject *> &objects, Column column)
 {
     emitObjectsChanged(objects,
                        QList<MapObjectModel::Column>() << column);

--- a/src/tiled/mapobjectmodel.cpp
+++ b/src/tiled/mapobjectmodel.cpp
@@ -43,6 +43,8 @@ MapObjectModel::MapObjectModel(QObject *parent):
     mObjectGroupIcon(QLatin1String(":/images/16x16/layer-object.png"))
 {
     mObjectGroupIcon.addFile(QLatin1String(":images/32x32/layer-object.png"));
+    connect(this, &MapObjectModel::objectsChanged,
+            this, &MapObjectModel::emitObjectsDataChanged);
 }
 
 QModelIndex MapObjectModel::index(int row, int column,
@@ -430,6 +432,13 @@ void MapObjectModel::tileTypeChanged(Tile *tile)
             }
         }
     }
+}
+
+void MapObjectModel::emitObjectsDataChanged(const QList<MapObject *> &objects)
+{
+    emit dataChanged(index(objects.first(), Name),
+                     index(objects.last(), ColumnCount - 1),
+                     QVector<int>() << Qt::EditRole);
 }
 
 QList<Layer *> &MapObjectModel::filteredChildLayers(GroupLayer *parentLayer) const

--- a/src/tiled/mapobjectmodel.cpp
+++ b/src/tiled/mapobjectmodel.cpp
@@ -108,7 +108,7 @@ int MapObjectModel::rowCount(const QModelIndex &parent) const
 int MapObjectModel::columnCount(const QModelIndex &parent) const
 {
     Q_UNUSED(parent)
-    return ColumnsCount;
+    return ColumnCount;
 }
 
 QVariant MapObjectModel::data(const QModelIndex &index, int role) const
@@ -241,10 +241,10 @@ Qt::ItemFlags MapObjectModel::flags(const QModelIndex &index) const
     Qt::ItemFlags rc = QAbstractItemModel::flags(index);
     if (index.column() == 0)
         rc |= Qt::ItemIsUserCheckable | Qt::ItemIsEditable;
-    else if (toMapObject(index))
-        if (index.column() == Type) { // allow to edit only type column
+    else if (toMapObject(index)) {
+        if (index.column() == Type)// allow to edit only type column
             rc |= Qt::ItemIsEditable;
-        }
+    }
     return rc;
 }
 
@@ -255,7 +255,7 @@ QVariant MapObjectModel::headerData(int section, Qt::Orientation orientation,
         switch (section) {
         case Name: return tr("Name");
         case Type: return tr("Type");
-        case Id: return tr("Id");
+        case Id: return tr("ID");
         case X: return tr("X");
         case Y: return tr("Y");
         }

--- a/src/tiled/mapobjectmodel.cpp
+++ b/src/tiled/mapobjectmodel.cpp
@@ -433,7 +433,7 @@ void MapObjectModel::tileTypeChanged(Tile *tile)
     }
 }
 
-void MapObjectModel::emitObjectsChanged(const QList<MapObject *> &objects, const QList<Columns> &columns)
+void MapObjectModel::emitObjectsChanged(const QList<MapObject *> &objects, const QList<Column> &columns)
 {
     emit objectsChanged(objects);
     if (columns.isEmpty())
@@ -443,6 +443,12 @@ void MapObjectModel::emitObjectsChanged(const QList<MapObject *> &objects, const
     for (auto object : objects) {
         emit dataChanged(index(object, *minMaxPair.first), index(object, *minMaxPair.second));
     }
+}
+
+void MapObjectModel::emitObjectsChanged(const QList<MapObject *> &objects, const MapObjectModel::Column column)
+{
+    emitObjectsChanged(objects,
+                       QList<MapObjectModel::Column>() << column);
 }
 
 QList<Layer *> &MapObjectModel::filteredChildLayers(GroupLayer *parentLayer) const

--- a/src/tiled/mapobjectmodel.cpp
+++ b/src/tiled/mapobjectmodel.cpp
@@ -108,7 +108,7 @@ int MapObjectModel::rowCount(const QModelIndex &parent) const
 int MapObjectModel::columnCount(const QModelIndex &parent) const
 {
     Q_UNUSED(parent)
-    return 2; // MapObject name|type
+    return ColumnsCount;
 }
 
 QVariant MapObjectModel::data(const QModelIndex &index, int role) const
@@ -117,10 +117,19 @@ QVariant MapObjectModel::data(const QModelIndex &index, int role) const
         switch (role) {
         case Qt::DisplayRole:
         case Qt::EditRole:
-            if (index.column() == 0) {
+            switch (index.column()) {
+            case Name:
                 return mapObject->name();
-            } else if (index.column() == 1) {
+            case Type:
                 return mapObject->effectiveType();
+            case Id:
+                return mapObject->id();
+            case X:
+                return mapObject->x();
+            case Y:
+                return mapObject->y();
+            default:
+                break;
             }
         case Qt::ForegroundRole:
             if (index.column() == 1) {
@@ -233,7 +242,9 @@ Qt::ItemFlags MapObjectModel::flags(const QModelIndex &index) const
     if (index.column() == 0)
         rc |= Qt::ItemIsUserCheckable | Qt::ItemIsEditable;
     else if (toMapObject(index))
-        rc |= Qt::ItemIsEditable; // MapObject type
+        if (index.column() == Type) { // allow to edit only type column
+            rc |= Qt::ItemIsEditable;
+        }
     return rc;
 }
 
@@ -242,8 +253,11 @@ QVariant MapObjectModel::headerData(int section, Qt::Orientation orientation,
 {
     if (role == Qt::DisplayRole && orientation == Qt::Horizontal) {
         switch (section) {
-        case 0: return tr("Name");
-        case 1: return tr("Type");
+        case Name: return tr("Name");
+        case Type: return tr("Type");
+        case Id: return tr("Id");
+        case X: return tr("X");
+        case Y: return tr("Y");
         }
     }
     return QVariant();

--- a/src/tiled/mapobjectmodel.h
+++ b/src/tiled/mapobjectmodel.h
@@ -52,6 +52,15 @@ public:
         OpacityRole = Qt::UserRole
     };
 
+    enum Columns {
+        Name,
+        Type,
+        Id,
+        X,
+        Y,
+        ColumnsCount
+    };
+
     MapObjectModel(QObject *parent = nullptr);
 
     QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;

--- a/src/tiled/mapobjectmodel.h
+++ b/src/tiled/mapobjectmodel.h
@@ -98,7 +98,7 @@ public:
 
     void setObjectProperty(MapObject *o, MapObject::Property property, const QVariant &value);
     void emitObjectsChanged(const QList<MapObject *> &objects, const QList<Column> &columns = QList<Column>());
-    void emitObjectsChanged(const QList<MapObject*> &objects, const Column column);
+    void emitObjectsChanged(const QList<MapObject*> &objects, Column column);
 
 signals:
     void objectsAdded(const QList<MapObject *> &objects);

--- a/src/tiled/mapobjectmodel.h
+++ b/src/tiled/mapobjectmodel.h
@@ -56,8 +56,7 @@ public:
         Name,
         Type,
         Id,
-        X,
-        Y,
+        Position,
         ColumnCount
     };
 
@@ -98,6 +97,7 @@ public:
     void setObjectRotation(MapObject *o, qreal rotation);
 
     void setObjectProperty(MapObject *o, MapObject::Property property, const QVariant &value);
+    void emitObjectsChanged(const QList<MapObject *> &objects, const QList<Columns> &columns = QList<Columns>());
 
 signals:
     void objectsAdded(const QList<MapObject *> &objects);
@@ -110,7 +110,6 @@ private slots:
     void layerChanged(Layer *layer);
     void layerAboutToBeRemoved(GroupLayer *groupLayer, int index);
     void tileTypeChanged(Tile *tile);
-    void emitObjectsDataChanged(const QList<MapObject *> &objects);
 
 private:
     MapDocument *mMapDocument;

--- a/src/tiled/mapobjectmodel.h
+++ b/src/tiled/mapobjectmodel.h
@@ -52,7 +52,7 @@ public:
         OpacityRole = Qt::UserRole
     };
 
-    enum Columns {
+    enum Column {
         Name,
         Type,
         Id,
@@ -97,7 +97,8 @@ public:
     void setObjectRotation(MapObject *o, qreal rotation);
 
     void setObjectProperty(MapObject *o, MapObject::Property property, const QVariant &value);
-    void emitObjectsChanged(const QList<MapObject *> &objects, const QList<Columns> &columns = QList<Columns>());
+    void emitObjectsChanged(const QList<MapObject *> &objects, const QList<Column> &columns = QList<Column>());
+    void emitObjectsChanged(const QList<MapObject*> &objects, const Column column);
 
 signals:
     void objectsAdded(const QList<MapObject *> &objects);

--- a/src/tiled/mapobjectmodel.h
+++ b/src/tiled/mapobjectmodel.h
@@ -58,7 +58,7 @@ public:
         Id,
         X,
         Y,
-        ColumnsCount
+        ColumnCount
     };
 
     MapObjectModel(QObject *parent = nullptr);

--- a/src/tiled/mapobjectmodel.h
+++ b/src/tiled/mapobjectmodel.h
@@ -110,6 +110,7 @@ private slots:
     void layerChanged(Layer *layer);
     void layerAboutToBeRemoved(GroupLayer *groupLayer, int index);
     void tileTypeChanged(Tile *tile);
+    void emitObjectDataChanged(const QList<MapObject *> &objects);
 
 private:
     MapDocument *mMapDocument;

--- a/src/tiled/mapobjectmodel.h
+++ b/src/tiled/mapobjectmodel.h
@@ -110,7 +110,7 @@ private slots:
     void layerChanged(Layer *layer);
     void layerAboutToBeRemoved(GroupLayer *groupLayer, int index);
     void tileTypeChanged(Tile *tile);
-    void emitObjectDataChanged(const QList<MapObject *> &objects);
+    void emitObjectsDataChanged(const QList<MapObject *> &objects);
 
 private:
     MapDocument *mMapDocument;

--- a/src/tiled/objectsdock.cpp
+++ b/src/tiled/objectsdock.cpp
@@ -45,7 +45,7 @@
 #include <QUrl>
 
 static const char FIRST_SECTION_SIZE_KEY[] = "ObjectsDock/FirstSectionSize";
-static const char SHOWED_SECTIONS_KEY[] = "ObjectsDock/ShowedSections";
+static const char VISIBLE_SECTIONS_KEY[] = "ObjectsDock/VisibleSections";
 
 using namespace Tiled;
 using namespace Tiled::Internal;
@@ -303,7 +303,7 @@ void ObjectsView::setMapDocument(MapDocument *mapDoc)
         connect(mMapDocument, SIGNAL(selectedObjectsChanged()),
                 this, SLOT(selectedObjectsChanged()));
 
-        hideExtraColumns();
+        restoreVisibleSections();
         synchronizeSelectedItems();
     } else {
         mProxyModel->setSourceModel(nullptr);
@@ -416,12 +416,12 @@ void ObjectsView::setColumnVisibility(bool visible)
     header()->setSectionHidden(column, !visible);
 
     QSettings *settings = Preferences::instance()->settings();
-    QVariantList showedColumns;
+    QVariantList visibleSections;
     for (int i = 0; i < mProxyModel->columnCount(); i++) {
         if (!header()->isSectionHidden(i))
-            showedColumns.append(i);
+            visibleSections.append(i);
     }
-    settings->setValue(QLatin1String(SHOWED_SECTIONS_KEY), showedColumns);
+    settings->setValue(QLatin1String(VISIBLE_SECTIONS_KEY), visibleSections);
 }
 
 void ObjectsView::showCustomMenu(const QPoint &point)
@@ -442,13 +442,13 @@ void ObjectsView::showCustomMenu(const QPoint &point)
     contextMenu.exec(QCursor::pos());
 }
 
-void ObjectsView::hideExtraColumns()
+void ObjectsView::restoreVisibleSections()
 {
     QSettings *settings = Preferences::instance()->settings();
-    QVariantList showedColumns = settings->value(QLatin1String(SHOWED_SECTIONS_KEY),
+    QVariantList visibleSections = settings->value(QLatin1String(VISIBLE_SECTIONS_KEY),
                                                  QVariantList() << MapObjectModel::Name << MapObjectModel::Type).toList();
     for (int i = 0; i < mProxyModel->columnCount(); i++) {
-        header()->setSectionHidden(i, !showedColumns.contains(i));
+        header()->setSectionHidden(i, !visibleSections.contains(i));
     }
 }
 

--- a/src/tiled/objectsdock.h
+++ b/src/tiled/objectsdock.h
@@ -98,12 +98,18 @@ private slots:
     void onActivated(const QModelIndex &proxyIndex);
     void onSectionResized(int logicalIndex);
     void selectedObjectsChanged();
+    void setColumnVisibility(bool visible);
+
+    void showCustomMenu(const QPoint &point);
 
 private:
+    void updateColumnVisibilityActions();
+    void hideExtraColumns();
     void synchronizeSelectedItems();
 
     MapDocument *mMapDocument;
     QAbstractProxyModel *mProxyModel;
+    QList<QAction*> mActions;
     bool mSynching;
 };
 

--- a/src/tiled/objectsdock.h
+++ b/src/tiled/objectsdock.h
@@ -103,13 +103,11 @@ private slots:
     void showCustomMenu(const QPoint &point);
 
 private:
-    void updateColumnVisibilityActions();
     void hideExtraColumns();
     void synchronizeSelectedItems();
 
     MapDocument *mMapDocument;
     QAbstractProxyModel *mProxyModel;
-    QList<QAction*> mActions;
     bool mSynching;
 };
 

--- a/src/tiled/objectsdock.h
+++ b/src/tiled/objectsdock.h
@@ -103,7 +103,7 @@ private slots:
     void showCustomMenu(const QPoint &point);
 
 private:
-    void hideExtraColumns();
+    void restoreVisibleSections();
     void synchronizeSelectedItems();
 
     MapDocument *mMapDocument;

--- a/src/tiled/objectselectiontool.cpp
+++ b/src/tiled/objectselectiontool.cpp
@@ -1020,7 +1020,8 @@ void ObjectSelectionTool::updateMovingItems(const QPointF &pos,
         mapObject->setPosition(newPos);
     }
 
-    emit mapDocument()->mapObjectModel()->objectsChanged(changingObjects());
+    mapDocument()->mapObjectModel()->emitObjectsChanged(changingObjects(),
+                                                        QList<MapObjectModel::Columns>() << MapObjectModel::Position);
 
     mOriginIndicator->setPos(mOldOriginPosition + diff);
 }
@@ -1109,7 +1110,8 @@ void ObjectSelectionTool::updateRotatingItems(const QPointF &pos,
         mapObject->setRotation(newRotation);
     }
 
-    emit mapDocument()->mapObjectModel()->objectsChanged(changingObjects());
+    mapDocument()->mapObjectModel()->emitObjectsChanged(changingObjects(),
+                                                        QList<MapObjectModel::Columns>() << MapObjectModel::Position);
 }
 
 void ObjectSelectionTool::finishRotating(const QPointF &pos)
@@ -1235,7 +1237,8 @@ void ObjectSelectionTool::updateResizingItems(const QPointF &pos,
         mapObject->setPosition(newPos);
     }
 
-    emit mapDocument()->mapObjectModel()->objectsChanged(changingObjects());
+    mapDocument()->mapObjectModel()->emitObjectsChanged(changingObjects(),
+                                                        QList<MapObjectModel::Columns>() << MapObjectModel::Position);
 }
 
 void ObjectSelectionTool::updateResizingSingleItem(const QPointF &resizingOrigin,
@@ -1374,7 +1377,8 @@ void ObjectSelectionTool::updateResizingSingleItem(const QPointF &resizingOrigin
     mapObject->setSize(newSize);
     mapObject->setPosition(newPos);
 
-    emit mapDocument()->mapObjectModel()->objectsChanged(changingObjects());
+    mapDocument()->mapObjectModel()->emitObjectsChanged(changingObjects(),
+                                                        QList<MapObjectModel::Columns>() << MapObjectModel::Position);
 }
 
 void ObjectSelectionTool::finishResizing(const QPointF &pos)

--- a/src/tiled/objectselectiontool.cpp
+++ b/src/tiled/objectselectiontool.cpp
@@ -1020,8 +1020,7 @@ void ObjectSelectionTool::updateMovingItems(const QPointF &pos,
         mapObject->setPosition(newPos);
     }
 
-    mapDocument()->mapObjectModel()->emitObjectsChanged(changingObjects(),
-                                                        QList<MapObjectModel::Columns>() << MapObjectModel::Position);
+    mapDocument()->mapObjectModel()->emitObjectsChanged(changingObjects(), MapObjectModel::Position);
 
     mOriginIndicator->setPos(mOldOriginPosition + diff);
 }
@@ -1110,8 +1109,7 @@ void ObjectSelectionTool::updateRotatingItems(const QPointF &pos,
         mapObject->setRotation(newRotation);
     }
 
-    mapDocument()->mapObjectModel()->emitObjectsChanged(changingObjects(),
-                                                        QList<MapObjectModel::Columns>() << MapObjectModel::Position);
+    mapDocument()->mapObjectModel()->emitObjectsChanged(changingObjects(), MapObjectModel::Position);
 }
 
 void ObjectSelectionTool::finishRotating(const QPointF &pos)
@@ -1237,8 +1235,7 @@ void ObjectSelectionTool::updateResizingItems(const QPointF &pos,
         mapObject->setPosition(newPos);
     }
 
-    mapDocument()->mapObjectModel()->emitObjectsChanged(changingObjects(),
-                                                        QList<MapObjectModel::Columns>() << MapObjectModel::Position);
+    mapDocument()->mapObjectModel()->emitObjectsChanged(changingObjects(), MapObjectModel::Position);
 }
 
 void ObjectSelectionTool::updateResizingSingleItem(const QPointF &resizingOrigin,
@@ -1377,8 +1374,7 @@ void ObjectSelectionTool::updateResizingSingleItem(const QPointF &resizingOrigin
     mapObject->setSize(newSize);
     mapObject->setPosition(newPos);
 
-    mapDocument()->mapObjectModel()->emitObjectsChanged(changingObjects(),
-                                                        QList<MapObjectModel::Columns>() << MapObjectModel::Position);
+    mapDocument()->mapObjectModel()->emitObjectsChanged(changingObjects(), MapObjectModel::Position);
 }
 
 void ObjectSelectionTool::finishResizing(const QPointF &pos)


### PR DESCRIPTION
Implemented feature requested in #1462. Now objects view has switchable id, x, y columns. Columns can be switched by calling context menu on objects view header.