### PR TITLE
Same QAction to all QMenu. Follow up patch for #1463

### DIFF
--- a/src/tiled/commandbutton.cpp
+++ b/src/tiled/commandbutton.cpp
@@ -45,11 +45,6 @@ CommandButton::CommandButton(QWidget *parent)
 
     CommandManager::instance()->registerMenu(mMenu);
 
-    // Populate the menu once in order to register shortcuts beforehand
-    CommandManager::instance()->populateMenu();
-
-    connect(mMenu, &QMenu::aboutToShow,  
-            [this]() { CommandManager::instance()->populateMenu(); });
     connect(this, SIGNAL(clicked()), SLOT(runCommand()));
 }
 

--- a/src/tiled/commandbutton.cpp
+++ b/src/tiled/commandbutton.cpp
@@ -43,11 +43,13 @@ CommandButton::CommandButton(QWidget *parent)
     setPopupMode(QToolButton::MenuButtonPopup);
     setMenu(mMenu);
 
+    CommandManager::instance()->registerMenu(mMenu);
+
     // Populate the menu once in order to register shortcuts beforehand
-    CommandManager::instance()->populateMenu(mMenu, true);
+    CommandManager::instance()->populateMenu();
 
     connect(mMenu, &QMenu::aboutToShow,  
-            [this]() { CommandManager::instance()->populateMenu(mMenu, true); });
+            [this]() { CommandManager::instance()->populateMenu(); });
     connect(this, SIGNAL(clicked()), SLOT(runCommand()));
 }
 

--- a/src/tiled/commanddialog.cpp
+++ b/src/tiled/commanddialog.cpp
@@ -46,8 +46,7 @@ CommandDialog::CommandDialog(QWidget *parent)
     setWindowTitle(tr("Edit Commands"));
     Utils::restoreGeometry(this);
 
-    connect(mUi->pushButton, &QPushButton::clicked, 
-            [this]() { CommandManager::instance()->populateMenu(); });
+    setWindowFlags(Qt::Window | Qt::WindowTitleHint | Qt::CustomizeWindowHint);
 }
 
 CommandDialog::~CommandDialog()
@@ -62,6 +61,8 @@ void CommandDialog::accept()
 
     mUi->treeView->model()->setSaveBeforeExecute(mUi->saveBox->isChecked());
     mUi->treeView->model()->commit();
+
+    CommandManager::instance()->updateActions();
 }
 
 CommandTreeView::CommandTreeView(QWidget *parent)

--- a/src/tiled/commanddialog.cpp
+++ b/src/tiled/commanddialog.cpp
@@ -45,8 +45,6 @@ CommandDialog::CommandDialog(QWidget *parent)
 
     setWindowTitle(tr("Edit Commands"));
     Utils::restoreGeometry(this);
-
-    setWindowFlags(Qt::Window | Qt::WindowTitleHint | Qt::CustomizeWindowHint);
 }
 
 CommandDialog::~CommandDialog()
@@ -55,9 +53,9 @@ CommandDialog::~CommandDialog()
     delete mUi;
 }
 
-void CommandDialog::accept()
+void CommandDialog::closeEvent(QCloseEvent *event)
 {
-    QDialog::accept();
+    QDialog::closeEvent(event);
 
     mUi->treeView->model()->setSaveBeforeExecute(mUi->saveBox->isChecked());
     mUi->treeView->model()->commit();

--- a/src/tiled/commanddialog.cpp
+++ b/src/tiled/commanddialog.cpp
@@ -45,6 +45,9 @@ CommandDialog::CommandDialog(QWidget *parent)
 
     setWindowTitle(tr("Edit Commands"));
     Utils::restoreGeometry(this);
+
+    connect(mUi->pushButton, &QPushButton::clicked, 
+            [this]() { CommandManager::instance()->populateMenu(); });
 }
 
 CommandDialog::~CommandDialog()

--- a/src/tiled/commanddialog.h
+++ b/src/tiled/commanddialog.h
@@ -42,9 +42,9 @@ public:
 
     /**
       * Saves the changes to the users preferences.
-      * Automatically called when the dialog is accepted.
+      * Automatically called when the dialog is closed.
       */
-    void accept() override;
+    void closeEvent(QCloseEvent *event) override;
 
 private:
     Ui::CommandDialog *mUi;

--- a/src/tiled/commanddialog.ui
+++ b/src/tiled/commanddialog.ui
@@ -75,15 +75,15 @@
    <sender>pushButton</sender>
    <signal>clicked()</signal>
    <receiver>CommandDialog</receiver>
-   <slot>accept()</slot>
+   <slot>close()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>342</x>
-     <y>233</y>
+     <x>447</x>
+     <y>234</y>
     </hint>
     <hint type="destinationlabel">
-     <x>372</x>
-     <y>254</y>
+     <x>474</x>
+     <y>214</y>
     </hint>
    </hints>
   </connection>

--- a/src/tiled/commandmanager.cpp
+++ b/src/tiled/commandmanager.cpp
@@ -37,7 +37,7 @@ CommandManager *CommandManager::mInstance;
 CommandManager::CommandManager()
     : mModel(new CommandDataModel(this))
 {
-    
+    updateActions();
 }
 
 CommandManager *CommandManager::instance()
@@ -62,6 +62,8 @@ CommandDataModel *CommandManager::commandDataModel()
 void CommandManager::registerMenu(QMenu *menu)
 {
     mMenus.append(menu);
+    menu->clear();
+    menu->addActions(mActions);
 }
 
 void CommandManager::showDialog()
@@ -70,25 +72,18 @@ void CommandManager::showDialog()
     dialog.exec();
 }
 
-void CommandManager::populateMenu()
+void CommandManager::populateMenus()
 {
-    updateActions();
-
     for (int i = 0; i < mMenus.size(); ++i) {
         QMenu *menu = mMenus.at(i);
         menu->clear();
-
-        for (int j = 0; j < mActions.size(); ++j) {
-            menu->addAction(mActions.at(j));
-        }
+        menu->addActions(mActions);
     }
-
 }
 
 void CommandManager::updateActions()
 {
-    for (int i = 0; i < mActions.size(); ++i)
-        delete mActions.at(i);
+    qDeleteAll(mActions);
     mActions.clear();
 
     bool firstEnabledCommand = true;
@@ -101,10 +96,7 @@ void CommandManager::updateActions()
         if (!command.isEnabled)
             continue;
 
-        QAction *mAction = new QAction(this);
-
-        QString commandText = command.name;
-        mAction->setText(commandText);
+        QAction *mAction = new QAction(command.name, this);
 
         if (firstEnabledCommand)
             mAction->setShortcut(QKeySequence(tr("F5")));
@@ -130,6 +122,8 @@ void CommandManager::updateActions()
     connect(mEditCommands, &QAction::triggered, this, &CommandManager::showDialog);
 
     mActions.append(mEditCommands);
+
+    populateMenus();
 }
 
 } // namespace Internal

--- a/src/tiled/commandmanager.cpp
+++ b/src/tiled/commandmanager.cpp
@@ -74,8 +74,7 @@ void CommandManager::showDialog()
 
 void CommandManager::populateMenus()
 {
-    for (int i = 0; i < mMenus.size(); ++i) {
-        QMenu *menu = mMenus.at(i);
+    for (QMenu *menu : mMenus) {
         menu->clear();
         menu->addActions(mActions);
     }

--- a/src/tiled/commandmanager.h
+++ b/src/tiled/commandmanager.h
@@ -22,6 +22,7 @@
 
 #include <QObject>
 
+class QAction;
 class QMenu;
 
 namespace Tiled {
@@ -39,13 +40,22 @@ public:
 
     static void deleteInstance();
 
+    /**
+     * Returns the CommandDataModel instance stored
+     */
     CommandDataModel *commandDataModel();
 
+    /**
+     * Registers a new QMenu with the CommandManager
+     */
+    void registerMenu(QMenu* menu);
+
 public slots:
+
     /**
      * Populates the menu pointed by menu
      */
-    void populateMenu(QMenu *menu, bool flag = false);
+    void populateMenu();
 
     /**
      * Displays the dialog to edit the commands
@@ -57,8 +67,15 @@ private:
 
     CommandManager();
 
+    /**
+     * Updates mActions QList
+     */
+    void updateActions();
+
     static CommandManager *mInstance;
     CommandDataModel *mModel;
+    QList<QMenu*> mMenus;
+    QList<QAction*> mActions;
 };
 
 } // namespace Internal

--- a/src/tiled/commandmanager.h
+++ b/src/tiled/commandmanager.h
@@ -50,12 +50,9 @@ public:
      */
     void registerMenu(QMenu* menu);
 
-public slots:
+    void updateActions();
 
-    /**
-     * Populates the menu pointed by menu
-     */
-    void populateMenu();
+public slots:
 
     /**
      * Displays the dialog to edit the commands
@@ -68,9 +65,9 @@ private:
     CommandManager();
 
     /**
-     * Updates mActions QList
+     * Populates all the menus registered in CommandManager
      */
-    void updateActions();
+    void populateMenus();
 
     static CommandManager *mInstance;
     CommandDataModel *mModel;

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -318,9 +318,6 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
 
     CommandManager::instance()->registerMenu(mUi->menuCommand);
 
-    connect(mUi->menuCommand, &QMenu::aboutToShow, 
-            [this]() { CommandManager::instance()->populateMenu(); });
-
     connect(mUi->actionNewTileset, SIGNAL(triggered()), SLOT(newTileset()));
     connect(mUi->actionAddExternalTileset, SIGNAL(triggered()),
             SLOT(addExternalTileset()));

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -316,8 +316,10 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     connect(mUi->actionZoomNormal, SIGNAL(triggered()), SLOT(zoomNormal()));
     connect(mUi->actionFullScreen, &QAction::toggled, this, &MainWindow::setFullScreen);
 
+    CommandManager::instance()->registerMenu(mUi->menuCommand);
+
     connect(mUi->menuCommand, &QMenu::aboutToShow, 
-            [this]() { CommandManager::instance()->populateMenu(mUi->menuCommand); });
+            [this]() { CommandManager::instance()->populateMenu(); });
 
     connect(mUi->actionNewTileset, SIGNAL(triggered()), SLOT(newTileset()));
     connect(mUi->actionAddExternalTileset, SIGNAL(triggered()),


### PR DESCRIPTION
This is the follow-up patch for #1463. I've also modified the code on the basis of comments mentioned by @bjorn in the same pull request.

I've added a function `registerMenu(QMenu *menu)` which adds `menu` to the list of all menus that the singleton `CommandManger` has stored in `QList<QMenu*> mMenus`. Another function `updateActions` is added, which deletes all the previously created `QAction` instances and updates the list on the basis of `CommandDataModel`. The slot `populateMenu` will just add all the `QAction` instances present in `mActions` to all the registered `QMenu`.

I've also fixed a small bug: whenever the `Edit Commands...` dialog is prompted, and the list is updated, the effect is not visible until the user opens a particular menu (the menus and the commands get updated only when some menu is opened). So what I've done now is that I fired the `populateMenu` function when the `Close` button is hit in the Dialog. This fixed the problem.