### PR TITLE
Added an executable picker - Fixes #942

### DIFF
--- a/src/tiled/command.cpp
+++ b/src/tiled/command.cpp
@@ -26,7 +26,6 @@
 
 #include <QDir>
 #include <QMessageBox>
-#include <QSettings>
 
 using namespace Tiled;
 using namespace Tiled::Internal;
@@ -68,10 +67,7 @@ QString Command::finalCommand() const
 
 void Command::execute(bool inTerminal) const
 {
-    // Save if save option is unset or true
-    QSettings settings;
-    QVariant variant = settings.value(QLatin1String("saveBeforeExecute"), true);
-    if (variant.toBool()) {
+    if (saveBeforeExecute) {
         Document *document = DocumentManager::instance()->currentDocument();
         if (document)
             document->save(document->fileName());
@@ -88,6 +84,7 @@ QVariant Command::toQVariant() const
     hash[QLatin1String("Name")] = name;
     hash[QLatin1String("Command")] = command;
     hash[QLatin1String("Shortcut")] = shortcut;
+    hash[QLatin1String("SaveBeforeExecute")] = saveBeforeExecute;
     return hash;
 }
 
@@ -99,6 +96,7 @@ Command Command::fromQVariant(const QVariant &variant)
     const QString commandPref = QLatin1String("Command");
     const QString enablePref = QLatin1String("Enabled");
     const QString shortcutPref = QLatin1String("Shortcut");
+    const QString saveBeforeExecutePref = QLatin1String("SaveBeforeExecute");
 
     Command command;
     if (hash.contains(enablePref))
@@ -109,6 +107,8 @@ Command Command::fromQVariant(const QVariant &variant)
         command.command = hash[commandPref].toString();
     if (hash.contains(shortcutPref))
         command.shortcut = hash[shortcutPref].value<QKeySequence>();
+    if (hash.contains(saveBeforeExecutePref))
+        command.saveBeforeExecute = hash[saveBeforeExecutePref].toBool();
 
     return command;
 }

--- a/src/tiled/command.h
+++ b/src/tiled/command.h
@@ -37,16 +37,19 @@ struct Command
     Command(bool isEnabled = true,
             QString name = QString(),
             QString command = QString(),
-            QKeySequence shortcut = QKeySequence())
+            QKeySequence shortcut = QKeySequence(),
+            bool saveBeforeExecute = true)
         : isEnabled(isEnabled)
         , name(std::move(name))
         , command(std::move(command))
-        , shortcut(shortcut) {}
+        , shortcut(shortcut)
+        , saveBeforeExecute(saveBeforeExecute) {}
 
     bool isEnabled;
     QString name;
     QString command;
     QKeySequence shortcut;
+    bool saveBeforeExecute;
 
     /**
      * Returns the final command with replaced tokens.

--- a/src/tiled/commanddatamodel.cpp
+++ b/src/tiled/commanddatamodel.cpp
@@ -127,7 +127,7 @@ int CommandDataModel::rowCount(const QModelIndex &parent) const
 
 int CommandDataModel::columnCount(const QModelIndex &parent) const
 {
-    return parent.isValid() ? 0 : 4;
+    return parent.isValid() ? 0 : 3;
 }
 
 QVariant CommandDataModel::data(const QModelIndex &index, int role) const
@@ -143,8 +143,6 @@ QVariant CommandDataModel::data(const QModelIndex &index, int role) const
         if (isNormalRow) {
             if (index.column() == NameColumn)
                 return command.name;
-            if (index.column() == CommandColumn)
-                return command.command;
             if (index.column() == ShortcutColumn)
                 return command.shortcut;
         } else {
@@ -161,8 +159,6 @@ QVariant CommandDataModel::data(const QModelIndex &index, int role) const
         if (isNormalRow) {
             if (index.column() == NameColumn)
                 return tr("Set a name for this command");
-            if (index.column() == CommandColumn)
-                return tr("Set the shell command to execute");
             if (index.column() == ShortcutColumn)
                 return tr("Shortcut for this command");
             if (index.column() == EnabledColumn)
@@ -200,9 +196,6 @@ bool CommandDataModel::setData(const QModelIndex &index,
             if (!text.isEmpty()) {
                 if (index.column() == NameColumn) {
                     command.name = value.toString();
-                    isModified = true;
-                } else if (index.column() == CommandColumn) {
-                    command.command = value.toString();
                     isModified = true;
                 }
             }
@@ -258,7 +251,7 @@ Qt::ItemFlags CommandDataModel::flags(const QModelIndex &index) const
         f |= Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled;
         if (index.column() == EnabledColumn)
             f |= Qt::ItemIsUserCheckable;
-        else if (index.column() == NameColumn || index.column() == CommandColumn)
+        else if (index.column() == NameColumn)
             f |= Qt::ItemIsEditable;
     } else {
         f |= Qt::ItemIsDropEnabled;
@@ -275,9 +268,8 @@ QVariant CommandDataModel::headerData(int section, Qt::Orientation orientation,
     if (role != Qt::DisplayRole || orientation != Qt::Horizontal)
         return QVariant();
 
-    const char *sectionLabels[4] = {
+    const char *sectionLabels[3] = {
         QT_TR_NOOP("Name"),
-        QT_TR_NOOP("Command"),
         QT_TR_NOOP("Shortcut"),
         QT_TR_NOOP("Enable") };
 

--- a/src/tiled/commanddatamodel.cpp
+++ b/src/tiled/commanddatamodel.cpp
@@ -113,12 +113,12 @@ void CommandDataModel::removeRows(QModelIndexList indices)
     }
 }
 
-int CommandDataModel::rowCount(const QModelIndex &parent = QModelIndex()) const
+int CommandDataModel::rowCount(const QModelIndex &parent) const
 {
     return parent.isValid() ? 0 : mCommands.size() + 1;
 }
 
-int CommandDataModel::columnCount(const QModelIndex &parent = QModelIndex()) const
+int CommandDataModel::columnCount(const QModelIndex &parent) const
 {
     return parent.isValid() ? 0 : 3;
 }

--- a/src/tiled/commanddatamodel.cpp
+++ b/src/tiled/commanddatamodel.cpp
@@ -113,12 +113,12 @@ void CommandDataModel::removeRows(QModelIndexList indices)
     }
 }
 
-int CommandDataModel::rowCount(const QModelIndex &parent) const
+int CommandDataModel::rowCount(const QModelIndex &parent = QModelIndex()) const
 {
     return parent.isValid() ? 0 : mCommands.size() + 1;
 }
 
-int CommandDataModel::columnCount(const QModelIndex &parent) const
+int CommandDataModel::columnCount(const QModelIndex &parent = QModelIndex()) const
 {
     return parent.isValid() ? 0 : 3;
 }
@@ -456,7 +456,7 @@ bool CommandDataModel::saveBeforeExecute(const QModelIndex &index) const
         return false;
 }
 
-void CommandDataModel::setSaveBeforeExecute(const QModelIndex &index, const bool &value)
+void CommandDataModel::setSaveBeforeExecute(const QModelIndex &index, bool value)
 {
     const bool isNormalRow = index.row() < mCommands.size();
 

--- a/src/tiled/commanddatamodel.cpp
+++ b/src/tiled/commanddatamodel.cpp
@@ -33,10 +33,6 @@ const char *commandMimeType = "application/x-tiled-commandptr";
 CommandDataModel::CommandDataModel(QObject *parent)
     : QAbstractTableModel(parent)
 {
-    // Load saveBeforeExecute option
-    QVariant s = mSettings.value(QLatin1String("saveBeforeExecute"), true);
-    mSaveBeforeExecute = s.toBool();
-
     // Load command list
     const QVariant variant = mSettings.value(QLatin1String("commandList"));
     const QList<QVariant> commands = variant.toList();
@@ -70,9 +66,6 @@ CommandDataModel::CommandDataModel(QObject *parent)
 
 void CommandDataModel::commit()
 {
-    // Save saveBeforeExecute option
-    mSettings.setValue(QLatin1String("saveBeforeExecute"), mSaveBeforeExecute);
-
     // Save command list
     QList<QVariant> commands;
     foreach (const Command &command, mCommands)
@@ -441,14 +434,52 @@ QKeySequence CommandDataModel::shortcut(const QModelIndex &index) const
         return QKeySequence();
 }
 
-void CommandDataModel::setShortcut(const QModelIndex &index, const QKeySequence &keySequence)
+void CommandDataModel::setShortcut(const QModelIndex &index, const QKeySequence &value)
 {
-    if (index.row() < mCommands.size()) {
-        mCommands[index.row()].shortcut = keySequence;
+    const bool isNormalRow = index.row() < mCommands.size();
+
+    if (isNormalRow) {
+        mCommands[index.row()].shortcut = value;
 
         QModelIndex shortcutIndex = this->index(index.row(), ShortcutColumn);
         emit dataChanged(shortcutIndex, shortcutIndex);
     }
+}
+
+bool CommandDataModel::saveBeforeExecute(const QModelIndex &index) const
+{
+    const bool isNormalRow = index.row() < mCommands.size();
+
+    if (isNormalRow)
+        return mCommands[index.row()].saveBeforeExecute;
+    else
+        return false;
+}
+
+void CommandDataModel::setSaveBeforeExecute(const QModelIndex &index, const bool &value)
+{
+    const bool isNormalRow = index.row() < mCommands.size();
+
+    if (isNormalRow)
+        mCommands[index.row()].saveBeforeExecute = value;
+}
+
+QString CommandDataModel::command(const QModelIndex &index) const
+{
+    const bool isNormalRow = index.row() < mCommands.size();
+
+    if (isNormalRow)
+        return mCommands[index.row()].command;
+    else
+        return QString();
+}
+
+void CommandDataModel::setCommand(const QModelIndex &index, const QString &value)
+{
+    const bool isNormalRow = index.row() < mCommands.size();
+
+    if (isNormalRow)
+        mCommands[index.row()].command = value;
 }
 
 bool CommandDataModel::move(int commandIndex, int newIndex)

--- a/src/tiled/commanddatamodel.h
+++ b/src/tiled/commanddatamodel.h
@@ -36,7 +36,7 @@ class CommandDataModel : public QAbstractTableModel
 
 public:
 
-    enum { NameColumn, CommandColumn, ShortcutColumn, EnabledColumn };
+    enum { NameColumn, ShortcutColumn, EnabledColumn };
 
     /**
       * Constructs the object and parses the users settings to allow easy

--- a/src/tiled/commanddatamodel.h
+++ b/src/tiled/commanddatamodel.h
@@ -133,7 +133,7 @@ public:
 
     bool saveBeforeExecute(const QModelIndex &index) const;
 
-    void setSaveBeforeExecute(const QModelIndex &index, const bool &value);
+    void setSaveBeforeExecute(const QModelIndex &index, bool value);
 
     QString command(const QModelIndex &index) const;
 

--- a/src/tiled/commanddatamodel.h
+++ b/src/tiled/commanddatamodel.h
@@ -49,20 +49,6 @@ public:
       */
     void commit();
 
-    /**
-      * Returns whether saving before executing commands is enabled.
-      */
-    bool saveBeforeExecute() const { return mSaveBeforeExecute; }
-
-    /**
-      * Enables or disables saving before executing commands.
-      */
-    void setSaveBeforeExecute(bool enabled) { mSaveBeforeExecute = enabled; }
-
-    /**
-      * Returns the first enabled command in the list, or an empty
-      * disabled command if there are no enabled commands.
-      */
     Command firstEnabledCommand() const;
 
     /**
@@ -143,7 +129,15 @@ public:
 
     QKeySequence shortcut(const QModelIndex &index) const;
 
-    void setShortcut(const QModelIndex &index, const QKeySequence &keySequence);
+    void setShortcut(const QModelIndex &index, const QKeySequence &value);
+
+    bool saveBeforeExecute(const QModelIndex &index) const;
+
+    void setSaveBeforeExecute(const QModelIndex &index, const bool &value);
+
+    QString command(const QModelIndex &index) const;
+
+    void setCommand(const QModelIndex &index, const QString &value);
 
 public slots:
 
@@ -182,7 +176,6 @@ private:
 
     QSettings mSettings;
     QList<Command> mCommands;
-    bool mSaveBeforeExecute;
 };
 
 } // namespace Internal

--- a/src/tiled/commanddatamodel.h
+++ b/src/tiled/commanddatamodel.h
@@ -70,12 +70,12 @@ public:
     /**
      * Returns the number of rows (this includes the <New Command> row).
      */
-    int rowCount(const QModelIndex &) const override;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 
     /**
      * Returns the number of columns.
      */
-    int columnCount(const QModelIndex &) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 
     /**
      * Returns the data at <i>index</i> for the given <i>role</i>.

--- a/src/tiled/commanddialog.cpp
+++ b/src/tiled/commanddialog.cpp
@@ -30,6 +30,7 @@
 #include <QContextMenuEvent>
 #include <QModelIndex>
 #include <QFileDialog>
+#include <QStandardPaths>
 
 using namespace Tiled;
 using namespace Tiled::Internal;
@@ -100,39 +101,36 @@ void CommandDialog::setCommand(const QString &text)
 void CommandDialog::updateWidgets(const QModelIndex &current, const QModelIndex &)
 {
     if (current.row() < mUi->treeView->model()->rowCount(QModelIndex()) - 1) {
-        enableWidgets(true);
+        mUi->commandEdit->setEnabled(true);
+        mUi->browseButton->setEnabled(true);
+        mUi->keySequenceEdit->setEnabled(true);
+        mUi->clearButton->setEnabled(true);
+        mUi->saveBox->setEnabled(true);
 
         mUi->keySequenceEdit->setKeySequence(mUi->treeView->model()->shortcut(current));
         mUi->saveBox->setChecked(mUi->treeView->model()->saveBeforeExecute(current));
         mUi->commandEdit->setText(mUi->treeView->model()->command(current));
     }
-    else
-        enableWidgets(false);
+    else {
+        mUi->commandEdit->clear();
+        mUi->keySequenceEdit->clear();
+        mUi->saveBox->setChecked(false);
+        mUi->commandEdit->setEnabled(false);
+        mUi->browseButton->setEnabled(false);
+        mUi->keySequenceEdit->setEnabled(false);
+        mUi->clearButton->setEnabled(false);
+        mUi->saveBox->setEnabled(false);
+    }
 }
 
 void CommandDialog::openFileDialog()
 {
-    QString caption = tr("Select executable");
-    QString dir = tr("/bin");
+    QString caption = tr("Select Executable");
+    QString dir = QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation);
     QString executableName = QFileDialog::getOpenFileName(this, caption, dir);
 
     if (!executableName.isEmpty())
         mUi->commandEdit->setText(executableName);
-}
-
-void CommandDialog::enableWidgets(const bool enable)
-{
-    if (!enable) {
-        mUi->commandEdit->clear();
-        mUi->keySequenceEdit->clear();
-        mUi->saveBox->setChecked(false);
-    }
-
-    mUi->commandEdit->setEnabled(enable);
-    mUi->browseButton->setEnabled(enable);
-    mUi->keySequenceEdit->setEnabled(enable);
-    mUi->clearButton->setEnabled(enable);
-    mUi->saveBox->setEnabled(enable);
 }
 
 CommandTreeView::CommandTreeView(QWidget *parent)
@@ -146,7 +144,7 @@ CommandTreeView::CommandTreeView(QWidget *parent)
     setColumnWidth(0, 200);
     QHeaderView *h = header();
     h->setStretchLastSection(false);
-    h->setSectionResizeMode(CommandDataModel::NameColumn, QHeaderView::Interactive);
+    h->setSectionResizeMode(CommandDataModel::NameColumn, QHeaderView::Stretch);
     h->setSectionResizeMode(CommandDataModel::ShortcutColumn, QHeaderView::Fixed);
     h->setSectionResizeMode(CommandDataModel::EnabledColumn,
                             QHeaderView::ResizeToContents);

--- a/src/tiled/commanddialog.cpp
+++ b/src/tiled/commanddialog.cpp
@@ -100,30 +100,22 @@ void CommandDialog::setCommand(const QString &text)
 
 void CommandDialog::updateWidgets(const QModelIndex &current, const QModelIndex &)
 {
-    bool enable = true;
+    bool enable = (current.row() < mUi->treeView->model()->rowCount() - 1);
 
-    if (current.row() < mUi->treeView->model()->rowCount() - 1) {
-        mUi->commandEdit->setEnabled(enable);
-        mUi->browseButton->setEnabled(enable);
-        mUi->keySequenceEdit->setEnabled(enable);
-        mUi->clearButton->setEnabled(enable);
-        mUi->saveBox->setEnabled(enable);
+    mUi->saveBox->setEnabled(enable);
+    mUi->commandEdit->setEnabled(enable);
+    mUi->browseButton->setEnabled(enable);
+    mUi->keySequenceEdit->setEnabled(enable);
+    mUi->clearButton->setEnabled(enable);
+    mUi->saveBox->setEnabled(enable);
 
+    if (enable) {
         mUi->keySequenceEdit->setKeySequence(mUi->treeView->model()->shortcut(current));
         mUi->saveBox->setChecked(mUi->treeView->model()->saveBeforeExecute(current));
         mUi->commandEdit->setText(mUi->treeView->model()->command(current));
-    }
-    else {
-        enable = false;
-
+    } else {
         mUi->commandEdit->clear();
         mUi->keySequenceEdit->clear();
-        mUi->saveBox->setChecked(enable);
-        mUi->commandEdit->setEnabled(enable);
-        mUi->browseButton->setEnabled(enable);
-        mUi->keySequenceEdit->setEnabled(enable);
-        mUi->clearButton->setEnabled(enable);
-        mUi->saveBox->setEnabled(enable);
     }
 }
 

--- a/src/tiled/commanddialog.cpp
+++ b/src/tiled/commanddialog.cpp
@@ -80,46 +80,50 @@ void CommandDialog::closeEvent(QCloseEvent *event)
 void CommandDialog::setShortcut(const QKeySequence &keySequence)
 {
     const QModelIndex &current = mUi->treeView->currentIndex();
-    if (current.row() < mUi->treeView->model()->rowCount(QModelIndex()))
+    if (current.row() < mUi->treeView->model()->rowCount())
         mUi->treeView->model()->setShortcut(current, keySequence);
 }
 
 void CommandDialog::setSaveBeforeExecute(int state)
 {
     const QModelIndex &current = mUi->treeView->currentIndex();
-    if (current.row() < mUi->treeView->model()->rowCount(QModelIndex()))
+    if (current.row() < mUi->treeView->model()->rowCount())
         mUi->treeView->model()->setSaveBeforeExecute(current, state);
 }
 
 void CommandDialog::setCommand(const QString &text)
 {
     const QModelIndex &current = mUi->treeView->currentIndex();
-    if (current.row() < mUi->treeView->model()->rowCount(QModelIndex()))
+    if (current.row() < mUi->treeView->model()->rowCount())
         mUi->treeView->model()->setCommand(current, text);
 }
 
 void CommandDialog::updateWidgets(const QModelIndex &current, const QModelIndex &)
 {
-    if (current.row() < mUi->treeView->model()->rowCount(QModelIndex()) - 1) {
-        mUi->commandEdit->setEnabled(true);
-        mUi->browseButton->setEnabled(true);
-        mUi->keySequenceEdit->setEnabled(true);
-        mUi->clearButton->setEnabled(true);
-        mUi->saveBox->setEnabled(true);
+    bool enable = true;
+
+    if (current.row() < mUi->treeView->model()->rowCount() - 1) {
+        mUi->commandEdit->setEnabled(enable);
+        mUi->browseButton->setEnabled(enable);
+        mUi->keySequenceEdit->setEnabled(enable);
+        mUi->clearButton->setEnabled(enable);
+        mUi->saveBox->setEnabled(enable);
 
         mUi->keySequenceEdit->setKeySequence(mUi->treeView->model()->shortcut(current));
         mUi->saveBox->setChecked(mUi->treeView->model()->saveBeforeExecute(current));
         mUi->commandEdit->setText(mUi->treeView->model()->command(current));
     }
     else {
+        enable = false;
+
         mUi->commandEdit->clear();
         mUi->keySequenceEdit->clear();
-        mUi->saveBox->setChecked(false);
-        mUi->commandEdit->setEnabled(false);
-        mUi->browseButton->setEnabled(false);
-        mUi->keySequenceEdit->setEnabled(false);
-        mUi->clearButton->setEnabled(false);
-        mUi->saveBox->setEnabled(false);
+        mUi->saveBox->setChecked(enable);
+        mUi->commandEdit->setEnabled(enable);
+        mUi->browseButton->setEnabled(enable);
+        mUi->keySequenceEdit->setEnabled(enable);
+        mUi->clearButton->setEnabled(enable);
+        mUi->saveBox->setEnabled(enable);
     }
 }
 

--- a/src/tiled/commanddialog.cpp
+++ b/src/tiled/commanddialog.cpp
@@ -101,7 +101,6 @@ CommandTreeView::CommandTreeView(QWidget *parent)
     QHeaderView *h = header();
     h->setStretchLastSection(false);
     h->setSectionResizeMode(CommandDataModel::NameColumn, QHeaderView::Interactive);
-    h->setSectionResizeMode(CommandDataModel::CommandColumn, QHeaderView::Stretch);
     h->setSectionResizeMode(CommandDataModel::ShortcutColumn, QHeaderView::Fixed);
     h->setSectionResizeMode(CommandDataModel::EnabledColumn,
                             QHeaderView::ResizeToContents);

--- a/src/tiled/commanddialog.cpp
+++ b/src/tiled/commanddialog.cpp
@@ -29,6 +29,7 @@
 #include <QMenu>
 #include <QContextMenuEvent>
 #include <QModelIndex>
+#include <QFileDialog>
 
 using namespace Tiled;
 using namespace Tiled::Internal;
@@ -55,6 +56,9 @@ CommandDialog::CommandDialog(QWidget *parent)
 
     connect(mUi->treeView->selectionModel(), &QItemSelectionModel::currentChanged, 
             this, &CommandDialog::updateWidgets);
+
+    connect(mUi->browseButton, &QPushButton::clicked,
+            this, &CommandDialog::openFileDialog);
 }
 
 CommandDialog::~CommandDialog()
@@ -104,6 +108,16 @@ void CommandDialog::updateWidgets(const QModelIndex &current, const QModelIndex 
     }
     else
         enableWidgets(false);
+}
+
+void CommandDialog::openFileDialog()
+{
+    QString caption = tr("Select executable");
+    QString dir = tr("/bin");
+    QString executableName = QFileDialog::getOpenFileName(this, caption, dir);
+
+    if (!executableName.isEmpty())
+        mUi->commandEdit->setText(executableName);
 }
 
 void CommandDialog::enableWidgets(const bool enable)

--- a/src/tiled/commanddialog.h
+++ b/src/tiled/commanddialog.h
@@ -55,6 +55,8 @@ public slots:
 
     void updateWidgets(const QModelIndex &current, const QModelIndex&);
 
+    void openFileDialog();
+
 private:
     void enableWidgets(const bool enable);
 

--- a/src/tiled/commanddialog.h
+++ b/src/tiled/commanddialog.h
@@ -49,9 +49,15 @@ public:
 public slots:
     void setShortcut(const QKeySequence &keySequence);
 
-    void updateKeySequenceEdit(const QModelIndex &current, const QModelIndex&);
+    void setSaveBeforeExecute(int state);
+
+    void setCommand(const QString &text);
+
+    void updateWidgets(const QModelIndex &current, const QModelIndex&);
 
 private:
+    void enableWidgets(const bool enable);
+
     Ui::CommandDialog *mUi;
 };
 

--- a/src/tiled/commanddialog.h
+++ b/src/tiled/commanddialog.h
@@ -58,8 +58,6 @@ public slots:
     void openFileDialog();
 
 private:
-    void enableWidgets(const bool enable);
-
     Ui::CommandDialog *mUi;
 };
 

--- a/src/tiled/commanddialog.ui
+++ b/src/tiled/commanddialog.ui
@@ -163,6 +163,19 @@
       <number>6</number>
      </property>
      <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
       <widget class="QPushButton" name="pushButton">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">

--- a/src/tiled/commanddialog.ui
+++ b/src/tiled/commanddialog.ui
@@ -31,7 +31,7 @@
      <item>
       <widget class="Tiled::Internal::CommandTreeView" name="treeView">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -52,32 +52,6 @@
      </item>
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_3">
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_7">
-         <item>
-          <widget class="QLabel" name="label_4">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>85</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Description:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="descriptionText"/>
-         </item>
-        </layout>
-       </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
@@ -100,7 +74,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QLineEdit" name="commandText">
+          <widget class="QLineEdit" name="commandEdit">
            <property name="inputMask">
             <string/>
            </property>
@@ -156,69 +130,63 @@
         </layout>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_6">
+        <layout class="QHBoxLayout" name="horizontalLayout_7">
          <item>
-          <widget class="QLabel" name="label_3">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>85</width>
-             <height>0</height>
-            </size>
-           </property>
+          <widget class="QCheckBox" name="saveBox">
            <property name="text">
-            <string>Enabled:</string>
+            <string>&amp;Save map before executing</string>
            </property>
           </widget>
          </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="spacing">
+          <number>6</number>
+         </property>
          <item>
-          <widget class="QCheckBox" name="checkBox">
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButton">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
            <property name="text">
-            <string/>
+            <string>Close</string>
            </property>
           </widget>
          </item>
         </layout>
        </item>
       </layout>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <item>
-      <widget class="QCheckBox" name="saveBox">
-       <property name="text">
-        <string>&amp;Save map before executing</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Close</string>
-       </property>
-      </widget>
      </item>
     </layout>
    </item>

--- a/src/tiled/commanddialog.ui
+++ b/src/tiled/commanddialog.ui
@@ -153,40 +153,27 @@
          </property>
         </spacer>
        </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <property name="spacing">
-          <number>6</number>
-         </property>
-         <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QPushButton" name="pushButton">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Close</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
       </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <item>
+      <widget class="QPushButton" name="pushButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/src/tiled/commanddialog.ui
+++ b/src/tiled/commanddialog.ui
@@ -53,79 +53,81 @@
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetDefaultConstraint</enum>
+         </property>
          <item>
-          <widget class="QLabel" name="label_2">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+          <layout class="QVBoxLayout" name="verticalLayout_4">
+           <property name="sizeConstraint">
+            <enum>QLayout::SetDefaultConstraint</enum>
            </property>
-           <property name="minimumSize">
-            <size>
-             <width>85</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Executable:</string>
-           </property>
-          </widget>
+           <item>
+            <widget class="QLabel" name="label_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Executable:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Shortcut:</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
          <item>
-          <widget class="QLineEdit" name="commandEdit">
-           <property name="inputMask">
-            <string/>
-           </property>
-          </widget>
+          <layout class="QVBoxLayout" name="verticalLayout_5">
+           <item>
+            <widget class="QLineEdit" name="commandEdit">
+             <property name="inputMask">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QKeySequenceEdit" name="keySequenceEdit">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
          <item>
-          <widget class="QPushButton" name="browseButton">
-           <property name="text">
-            <string>Browse...</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <item>
-          <widget class="QLabel" name="label">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>85</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Shortcut:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QKeySequenceEdit" name="keySequenceEdit">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="clearButton">
-           <property name="text">
-            <string>Clear</string>
-           </property>
-          </widget>
+          <layout class="QVBoxLayout" name="verticalLayout_6">
+           <item>
+            <widget class="QPushButton" name="browseButton">
+             <property name="text">
+              <string>Browse...</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="clearButton">
+             <property name="text">
+              <string>Clear</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
         </layout>
        </item>

--- a/src/tiled/commanddialog.ui
+++ b/src/tiled/commanddialog.ui
@@ -6,9 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>479</width>
-    <height>298</height>
+    <width>701</width>
+    <height>252</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Properties</string>
@@ -18,49 +24,174 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="Tiled::Internal::CommandTreeView" name="treeView">
-     <property name="dragDropMode">
-      <enum>QAbstractItemView::DragDrop</enum>
-     </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
-     </property>
-    </widget>
-   </item>
-   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <property name="spacing">
       <number>6</number>
      </property>
      <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Shortcut:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QKeySequenceEdit" name="keySequenceEdit">
+      <widget class="Tiled::Internal::CommandTreeView" name="treeView">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+        <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="dragDropMode">
+        <enum>QAbstractItemView::DragDrop</enum>
+       </property>
+       <property name="alternatingRowColors">
+        <bool>true</bool>
+       </property>
+       <property name="selectionMode">
+        <enum>QAbstractItemView::ExtendedSelection</enum>
+       </property>
+       <property name="selectionBehavior">
+        <enum>QAbstractItemView::SelectRows</enum>
+       </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="clearButton">
-       <property name="text">
-        <string>Clear</string>
-       </property>
-      </widget>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_7">
+         <item>
+          <widget class="QLabel" name="label_4">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>85</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Description:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="descriptionText"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <item>
+          <widget class="QLabel" name="label_2">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>85</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Executable:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="commandText">
+           <property name="inputMask">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="browseButton">
+           <property name="text">
+            <string>Browse...</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>85</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Shortcut:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QKeySequenceEdit" name="keySequenceEdit">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="clearButton">
+           <property name="text">
+            <string>Clear</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <item>
+          <widget class="QLabel" name="label_3">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>85</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Enabled:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="checkBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
This fixes #942 

![Command Dialog](https://image.ibb.co/gG5Viv/Screenshot_from_2017_03_15_19_12_28.png "Command Dialog")

Firstly, I've modified the layout of the Command Dialog. Also, I've made the option "Save Map before Execute" unique to each command. The user can now either enter the command, or he can browse an executable.