### PR TITLE
Stamp brush now works with the stagger in hex mode as expected

### DIFF
--- a/src/libtiled/map.h
+++ b/src/libtiled/map.h
@@ -357,6 +357,12 @@ public:
      */
     bool isTilesetUsed(const Tileset *tileset) const;
 
+    /**
+     * Returns whether the map is staggered
+     */
+    bool isStaggered() const
+    { return orientation() == Hexagonal || orientation() == Staggered; }
+
     LayerDataFormat layerDataFormat() const
     { return mLayerDataFormat; }
     void setLayerDataFormat(LayerDataFormat format)

--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -391,7 +391,7 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &list)
         QRegion paintedRegion;
         QVector<PaintOperation> operations;
         QHash<TileLayer *, QRegion> regionCache;
-        QHash<TileLayer *,TileLayer *> shiftedCopies;
+        QHash<TileLayer *, TileLayer *> shiftedCopies;
 
         for (const QPoint &p : list) {
             const TileStampVariation variation = mStamp.randomVariation();
@@ -414,7 +414,7 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &list)
                         TileLayer *shiftedStamp = shiftedCopies.value(stamp);
                         if (!shiftedStamp) {
                             shiftedStamp = static_cast<TileLayer *>(stamp->clone());
-                            shiftedCopies.insert(stamp,shiftedStamp);
+                            shiftedCopies.insert(stamp, shiftedStamp);
 
                             shiftedStamp->resize(QSize(shiftedStamp->width() + 1, shiftedStamp->height()), QPoint());
 
@@ -433,7 +433,7 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &list)
                         TileLayer *shiftedStamp = shiftedCopies.value(stamp);
                         if (!shiftedStamp) {
                             shiftedStamp = static_cast<TileLayer *>(stamp->clone());
-                            shiftedCopies.insert(stamp,shiftedStamp);
+                            shiftedCopies.insert(stamp, shiftedStamp);
 
                             shiftedStamp->resize(QSize(shiftedStamp->width(), shiftedStamp->height() + 1), QPoint());
 

--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -45,7 +45,6 @@ StampBrush::StampBrush(QObject *parent)
                        parent)
     , mBrushBehavior(Free)
     , mIsRandom(false)
-    , mCaptureTopCorner(-1)
 {
 }
 
@@ -391,7 +390,7 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &list)
             TileLayer *stamp = variation.tileLayer()->copy(variation.tileLayer()->bounds());
 
             //If using a hexagonal map, this takes into acount staggering
-            if (mapDocument()->map()->orientation() == 4 && stamp->height()>1) {
+            if (mapDocument()->map()->orientation() == Map::Hexagonal && stamp->height() > 1) {
                 int shiftMode;//-1 do not shift, 0 shift even rows (relatived to the stamp), 1 shift odd rows
                 int rowOfTop = p.y()-stamp->height()/2;
                 if (rowOfTop<0)

--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -250,16 +250,8 @@ void StampBrush::endCapture()
 
     // Intersect with the layer and translate to layer coordinates
     QRect captured = capturedArea();
-
     captured &= QRect(tileLayer->x(), tileLayer->y(),
                       tileLayer->width(), tileLayer->height());
-
-    //gets if the relative stagger should be the same as the base layer
-    int staggerIndexOffSet;
-    if (tileLayer->map()->staggerAxis() == Map::StaggerX)
-        staggerIndexOffSet = captured.x() % 2;
-    else
-        staggerIndexOffSet = captured.y() % 2;
 
     if (captured.isValid()) {
         captured.translate(-tileLayer->x(), -tileLayer->y());
@@ -270,6 +262,13 @@ void StampBrush::endCapture()
                              capture->height(),
                              map->tileWidth(),
                              map->tileHeight());
+
+        //gets if the relative stagger should be the same as the base layer
+        int staggerIndexOffSet;
+        if (tileLayer->map()->staggerAxis() == Map::StaggerX)
+            staggerIndexOffSet = captured.x() % 2;
+        else
+            staggerIndexOffSet = captured.y() % 2;
 
         stamp->setStaggerAxis(map->staggerAxis());
         stamp->setStaggerIndex((Map::StaggerIndex)((map->staggerIndex() + staggerIndexOffSet) % 2));

--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -391,43 +391,37 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &list)
             TileLayer *stamp = variation.tileLayer()->copy(variation.tileLayer()->bounds());
 
             //If using a hexagonal map, this takes into acount staggering
-            if(mapDocument()->map()->orientation() == 4 && stamp->height()>1)
-            {
+            if (mapDocument()->map()->orientation() == 4 && stamp->height()>1) {
                 int shiftMode;//-1 do not shift, 0 shift even rows (relatived to the stamp), 1 shift odd rows
                 int rowOfTop = p.y()-stamp->height()/2;
-                if(rowOfTop<0)rowOfTop*=-1; //Only used to check if even or odd, and being negative can mess this up.
+                if (rowOfTop<0)
+                    rowOfTop*=-1; //Only used to check if even or odd, and being negative can mess this up.
 
-                if(mCaptureTopCorner == -1)
+                if (mCaptureTopCorner == -1)
                     shiftMode = 1;
-                else
-                //if what the stamp captured starts by going left
-                if((mCaptureTopCorner+1)%2 == mapDocument()->map()->staggerIndex())
-                {
+                else if ((mCaptureTopCorner+1)%2 == mapDocument()->map()->staggerIndex()) {
                     //if where the top is now will go down the correct way
-                    if((rowOfTop+1)%2 != mapDocument()->map()->staggerIndex())
+                    if ((rowOfTop+1)%2 != mapDocument()->map()->staggerIndex())
                         shiftMode = 0;
                     else
                         shiftMode = -1;
-                }
-                else//if going right
-                {
+                } else {
                     //if where the top is now will go down the correct way
-                    if((rowOfTop+1)%2 == mapDocument()->map()->staggerIndex())
+                    if ((rowOfTop+1)%2 == mapDocument()->map()->staggerIndex())
                         shiftMode = 1;
                     else
                         shiftMode = -1;
                 }
 
-                if(shiftMode != -1)
-                {
+                if (shiftMode != -1) {
                     stamp->resize(QSize(stamp->width()+1,stamp->height()),QPoint());
 
                     QRect boundBox = stamp->bounds();
                     //Actually does the shift of the tiles. Maybe this could be done as
                     //a method of TileLayer?
-                    for(int i = shiftMode; i <= boundBox.bottom(); i+=2)
+                    for (int i = shiftMode; i <= boundBox.bottom(); i+=2)
                     {
-                        for(int j = boundBox.right()-1; j >= 0; --j)
+                        for (int j = boundBox.right()-1; j >= 0; --j)
                         {
                             stamp->setCell(j+1,i,stamp->cellAt(j,i));
                             stamp->setCell(j,i,Cell());

--- a/src/tiled/stampbrush.h
+++ b/src/tiled/stampbrush.h
@@ -103,6 +103,7 @@ private:
 
     QPoint mCaptureStart;
     QPoint mPrevTilePosition;
+    int mCaptureTopCorner;
 
     void drawPreviewLayer(const QVector<QPoint> &list);
 

--- a/src/tiled/stampbrush.h
+++ b/src/tiled/stampbrush.h
@@ -103,7 +103,6 @@ private:
 
     QPoint mCaptureStart;
     QPoint mPrevTilePosition;
-    int mCaptureTopCorner;
 
     void drawPreviewLayer(const QVector<QPoint> &list);
 


### PR DESCRIPTION
Previously when using the stamp brush tool when in hexagonal mode, moving down rows would cause a stamp to behave strangely (not accounting for the stagger). This has been patched over by shifting every other row of the stamp over in the appropriate direction when needed.

This is my first contribution, and major edit of tiled, so feedback on how anything could be done better would be greatly appreciated!

Ben