### PR TITLE
Implemented marching ants effect on selected objects(#1489)

### DIFF
--- a/src/tiled/objectselectionitem.cpp
+++ b/src/tiled/objectselectionitem.cpp
@@ -29,6 +29,7 @@
 #include "objectgroup.h"
 #include "preferences.h"
 #include "tile.h"
+#include <QTimer>
 
 #include <QGuiApplication>
 
@@ -127,7 +128,8 @@ static Preferences::ObjectLabelVisiblity objectLabelVisibility()
 }
 
 
-class MapObjectOutline : public QGraphicsItem
+// MapObjectOuline inherits from QObject to use timer signals
+class MapObjectOutline : public QObject , public QGraphicsItem
 {
 public:
     MapObjectOutline(MapObject *object, QGraphicsItem *parent = nullptr)
@@ -135,6 +137,8 @@ public:
         , mObject(object)
     {
         setZValue(1); // makes sure outlines are above labels
+        connect(updateTimer, &QTimer::timeout, this, [this] {this->update();});
+        updateTimer->start(100);
     }
 
     void syncWithMapObject(MapRenderer *renderer);
@@ -147,6 +151,11 @@ public:
 private:
     QRectF mBoundingRect;
     MapObject *mObject;
+
+    // Timer is used to call update function repeatedly to animate selection
+    QTimer *updateTimer = new QTimer();
+    // Offset simulates the marching ants effect
+    int offset=0;
 };
 
 void MapObjectOutline::syncWithMapObject(MapRenderer *renderer)
@@ -184,17 +193,35 @@ void MapObjectOutline::paint(QPainter *painter,
         QLineF(mBoundingRect.topRight(), mBoundingRect.bottomRight())
     };
 
-    QPen dashPen(Qt::DashLine);
+    QPen dashPen(Qt::SolidLine);
     dashPen.setCosmetic(true);
-    dashPen.setDashOffset(qMax(qreal(0), x()));
+
+    // draw a solid white line
+    dashPen.setColor(Qt::white);
     painter->setPen(dashPen);
     painter->drawLines(horizontal, 2);
 
-    dashPen.setDashOffset(qMax(qreal(0), y()));
+    // Draw a black dashed line above above the white line
+    dashPen.setColor(Qt::black);
+    dashPen.setStyle(Qt::DashLine);
+    dashPen.setDashOffset(qMax(qreal(0), x())+offset);
+    painter->setPen(dashPen);
+    painter->drawLines(horizontal, 2);
+
+    dashPen.setColor(Qt::white);
+    dashPen.setStyle(Qt::SolidLine);
     painter->setPen(dashPen);
     painter->drawLines(vertical, 2);
-}
 
+    dashPen.setColor(Qt::black);
+    dashPen.setStyle(Qt::DashLine);
+    dashPen.setDashOffset(qMax(qreal(0), x())+offset);
+    painter->setPen(dashPen);
+    painter->drawLines(vertical, 2);
+
+    // Update offset used in drawing black dashed line
+    offset++;
+}
 
 class MapObjectLabel : public QGraphicsItem
 {


### PR DESCRIPTION
Used a QTimer to repeatedly redraw the marquee, upon every redraw, A solid white line is drawn then black dashes are drawn above it shifted by the offset to simulate the marching ants effect.

Currently when selecting 100 objects simultaneously there was a slight increase in CPU usage to about 7-8%.

Redraws happen every 100ms, and offset increases by one, this numbers were chosen arbitrarily to look ok, but needs feedback.

Here is how it looks:
![marchingants](https://cloud.githubusercontent.com/assets/7282243/24164635/0886cb8c-0e77-11e7-83ff-63cec814379f.gif)

