### PR TITLE
Added layer properties: horizontal/vertical repeat, move speed, width, height

### DIFF
--- a/src/libtiled/layer.cpp
+++ b/src/libtiled/layer.cpp
@@ -151,6 +151,9 @@ QPointF Layer::totalOffset() const
  */
 Layer *Layer::initializeClone(Layer *clone) const
 {
+    clone->mRepeatedY = mRepeatedY;
+    clone->mRepeatedX = mRepeatedX;
+    clone->mMoveSpeed = mMoveSpeed;
     clone->mOffset = mOffset;
     clone->mOpacity = mOpacity;
     clone->mVisible = mVisible;

--- a/src/libtiled/layer.h
+++ b/src/libtiled/layer.h
@@ -154,6 +154,14 @@ public:
     void setOffset(const QPointF &offset);
     QPointF offset() const;
 
+    void setMoveSpeed(const QPointF &moveSpeed);
+    QPointF moveSpeed() const;
+
+    void setRepeatedX(const bool repeatX);
+    bool repeatedX() const;
+    void setRepeatedY(const bool repeatY);
+    bool repeatedY() const;
+
     QPointF totalOffset() const;
 
     virtual bool isEmpty() const = 0;
@@ -224,7 +232,10 @@ protected:
     int mY;
     QPointF mOffset;
     float mOpacity;
+    QPointF mMoveSpeed;
     bool mVisible;
+    bool mRepeatedX;
+    bool mRepeatedY;
     Map *mMap;
     GroupLayer *mParentLayer;
 
@@ -249,6 +260,53 @@ inline QPointF Layer::offset() const
     return mOffset;
 }
 
+/**
+ * Sets the movement speed multiplier of this layer.
+ */
+inline void Layer::setMoveSpeed(const QPointF &moveSpeed)
+{
+    mMoveSpeed = moveSpeed;
+}
+
+/**
+ * Returns the movement speed multiplier of this layer.
+ */
+inline QPointF Layer::moveSpeed() const
+{
+    return mMoveSpeed;
+}
+
+/**
+ * Sets this layer to be repeated horizontally or not.
+ */
+inline void Layer::setRepeatedX(const bool repeatX)
+{
+    mRepeatedX = repeatX;
+}
+
+/**
+ * Sets this layer to be repeated vertically or not.
+ */
+inline void Layer::setRepeatedY(const bool repeatY)
+{
+    mRepeatedY = repeatY;
+}
+
+/**
+ * Returns true if this layer is repeated horizontally.
+ */
+inline bool Layer::repeatedX() const
+{
+    return mRepeatedX;
+}
+
+/**
+ * Returns true if this layer is repeated vertically.
+ */
+inline bool Layer::repeatedY() const
+{
+    return mRepeatedY;
+}
 
 /**
  * An iterator for iterating over the layers of a map. When iterating forward,

--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -570,7 +570,7 @@ static void readLayerAttributes(Layer &layer,
     const QStringRef opacityRef = atts.value(QLatin1String("opacity"));
     const QStringRef visibleRef = atts.value(QLatin1String("visible"));
 
-    bool ok;
+    bool ok, ok2;
     const float opacity = opacityRef.toFloat(&ok);
     if (ok)
         layer.setOpacity(opacity);
@@ -582,7 +582,20 @@ static void readLayerAttributes(Layer &layer,
     const QPointF offset(atts.value(QLatin1String("offsetx")).toDouble(),
                          atts.value(QLatin1String("offsety")).toDouble());
 
+    QPointF moveSpeed(atts.value(QLatin1String("moveSpeedX")).toDouble(&ok),
+                            atts.value(QLatin1String("moveSpeedY")).toDouble(&ok2));
+
+    if(!ok) moveSpeed.setX(1.0);
+    if(!ok2) moveSpeed.setY(1.0);
+
+    QLatin1String yes("true");
+    const bool repeatX = atts.value(QLatin1String("repeatedX")).toInt();
+    const bool repeatY = atts.value(QLatin1String("repeatedY")).toInt();
+
     layer.setOffset(offset);
+    layer.setMoveSpeed(moveSpeed);
+    layer.setRepeatedX(repeatX);
+    layer.setRepeatedY(repeatY);
 }
 
 TileLayer *MapReaderPrivate::readTileLayer()

--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -487,6 +487,15 @@ void MapToVariantConverter::addLayerAttributes(QVariantMap &layerVariant,
         layerVariant[QLatin1String("offsety")] = offset.y();
     }
 
+    const QPointF moveSpeed = layer.moveSpeed();
+    const QPointF neutral(1.0, 1.0);
+    if (moveSpeed!=neutral) {
+        layerVariant[QLatin1String("moveSpeedX")] = moveSpeed.x();
+        layerVariant[QLatin1String("moveSpeedY")] = moveSpeed.y();
+    }
+    layerVariant[QLatin1String("repeatedX")] = layer.repeatedX();
+    layerVariant[QLatin1String("repeatedY")] = layer.repeatedY();
+
     addProperties(layerVariant, layer.properties());
 }
 

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -543,6 +543,16 @@ void MapWriterPrivate::writeLayerAttributes(QXmlStreamWriter &w,
         w.writeAttribute(QLatin1String("offsetx"), QString::number(offset.x()));
         w.writeAttribute(QLatin1String("offsety"), QString::number(offset.y()));
     }
+    const QPointF moveSpeed = layer.moveSpeed();
+    const QPointF neutral(1.0, 1.0);
+    if (moveSpeed!=neutral) {
+        w.writeAttribute(QLatin1String("moveSpeedX"), QString::number(moveSpeed.x()));
+        w.writeAttribute(QLatin1String("moveSpeedY"), QString::number(moveSpeed.y()));
+    }
+    if (layer.repeatedX())
+        w.writeAttribute(QLatin1String("repeatedX"), QLatin1String("1"));
+    if (layer.repeatedY())
+        w.writeAttribute(QLatin1String("repeatedY"), QLatin1String("1"));
 }
 
 void MapWriterPrivate::writeObjectGroup(QXmlStreamWriter &w,

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -229,6 +229,9 @@ void OrthogonalRenderer::drawTileLayer(QPainter *painter,
     int endX = layer->width() - 1;
     int endY = layer->height() - 1;
 
+    if(layer->repeatedX()) endX = map()->width();
+    if(layer->repeatedY()) endY = map()->height();
+
     if (!exposed.isNull()) {
         QMargins drawMargins = layer->drawMargins();
         drawMargins.setTop(drawMargins.top() - tileHeight);
@@ -241,10 +244,14 @@ void OrthogonalRenderer::drawTileLayer(QPainter *painter,
 
         rect.translate(-layerPos);
 
-        startX = qMax(qFloor(rect.x() / tileWidth), 0);
-        startY = qMax(qFloor(rect.y() / tileHeight), 0);
-        endX = qMin(qCeil(rect.right()) / tileWidth, endX);
-        endY = qMin(qCeil(rect.bottom()) / tileHeight, endY);
+        if(!layer->repeatedX()){
+            startX = qMax(qFloor(rect.x() / tileWidth), 0);
+            endX = qMin(qCeil(rect.right()) / tileWidth, endX);
+        }
+        if(!layer->repeatedY()){
+            startY = qMax(qFloor(rect.y() / tileHeight), 0);
+            endY = qMin(qCeil(rect.bottom()) / tileHeight, endY);
+        }
     }
 
     // Return immediately when there is nothing to draw

--- a/src/libtiled/tilelayer.cpp
+++ b/src/libtiled/tilelayer.cpp
@@ -112,6 +112,8 @@ QRegion TileLayer::region(std::function<bool (const Cell &)> condition) const
  */
 void Tiled::TileLayer::setCell(int x, int y, const Cell &cell)
 {
+    if(repeatedX()){ x %= width(); if(x<0) x+= width(); }
+    if(repeatedY()){ y %= height(); if(y<0) y+= height(); }
     Q_ASSERT(contains(x, y));
 
     Cell &existingCell = mGrid[x + y * mWidth];

--- a/src/libtiled/tilelayer.h
+++ b/src/libtiled/tilelayer.h
@@ -380,6 +380,8 @@ inline QRegion TileLayer::region() const
  */
 inline const Cell &TileLayer::cellAt(int x, int y) const
 {
+    if(repeatedX()){ x %= width(); if(x<0) x+= width(); }
+    if(repeatedY()){ y %= height(); if(x<0) y+= height(); }
     Q_ASSERT(contains(x, y));
     return mGrid.at(x + y * mWidth);
 }

--- a/src/libtiled/varianttomapconverter.cpp
+++ b/src/libtiled/varianttomapconverter.cpp
@@ -340,6 +340,13 @@ Layer *VariantToMapConverter::toLayer(const QVariant &variant)
         const QPointF offset(variantMap[QLatin1String("offsetx")].toDouble(),
                              variantMap[QLatin1String("offsety")].toDouble());
         layer->setOffset(offset);
+
+        const QPointF moveSpeed(variantMap[QLatin1String("moveSpeedX")].toDouble(),
+                             variantMap[QLatin1String("moveSpeedY")].toDouble());
+        layer->setMoveSpeed(moveSpeed);
+
+        layer->setRepeatedX(variantMap[QLatin1String("repeatedX")].toBool());
+        layer->setRepeatedY(variantMap[QLatin1String("repeatedY")].toBool());
     }
 
     return layer;

--- a/src/tiled/changelayer.cpp
+++ b/src/tiled/changelayer.cpp
@@ -101,6 +101,68 @@ void SetLayerOffset::setOffset(const QPointF &offset)
     mMapDocument->layerModel()->setLayerOffset(mLayer, offset);
 }
 
+SetLayerMoveSpeed::SetLayerMoveSpeed(MapDocument *mapDocument,
+                               Layer *layer,
+                               const QPointF &moveSpeed,
+                               QUndoCommand *parent)
+    : QUndoCommand(parent)
+    , mMapDocument(mapDocument)
+    , mLayer(layer)
+    , mOldOffset(layer->moveSpeed())
+    , mNewOffset(moveSpeed)
+{
+    setText(QCoreApplication::translate("Undo Commands",
+                                        "Change Layer Move Speed"));
+}
+
+void SetLayerMoveSpeed::setMoveSpeed(const QPointF &moveSpeed)
+{
+    mMapDocument->layerModel()->setLayerMoveSpeed(mLayer, moveSpeed);
+}
+
+SetLayerRepeatedX::SetLayerRepeatedX(MapDocument *mapDocument,
+                                 Layer *layer,
+                                 bool repeatedX)
+    : mMapDocument(mapDocument)
+    , mLayer(layer)
+    , mRepeatedX(repeatedX)
+{
+    if (repeatedX)
+        setText(QCoreApplication::translate("Undo Commands",
+                                            "Repeat Horizontally"));
+    else
+        setText(QCoreApplication::translate("Undo Commands",
+                                            "Dont Repeat Horizontally"));
+}
+
+void SetLayerRepeatedX::swap()
+{
+    const bool previousRepeatX = mLayer->repeatedX();
+    mMapDocument->layerModel()->setLayerRepeatedX(mLayer, mRepeatedX);
+    mRepeatedX = previousRepeatX;
+}
+
+SetLayerRepeatedY::SetLayerRepeatedY(MapDocument *mapDocument,
+                                 Layer *layer,
+                                 bool repeatedY)
+    : mMapDocument(mapDocument)
+    , mLayer(layer)
+    , mRepeatedY(repeatedY)
+{
+    if (repeatedY)
+        setText(QCoreApplication::translate("Undo Commands",
+                                            "Repeat Vertically"));
+    else
+        setText(QCoreApplication::translate("Undo Commands",
+                                            "Dont Repeat Vertically"));
+}
+
+void SetLayerRepeatedY::swap()
+{
+    const bool previousRepeatY = mLayer->repeatedY();
+    mMapDocument->layerModel()->setLayerRepeatedY(mLayer, mRepeatedY);
+    mRepeatedY = previousRepeatY;
+}
 
 } // namespace Internal
 } // namespace Tiled

--- a/src/tiled/changelayer.h
+++ b/src/tiled/changelayer.h
@@ -105,5 +105,72 @@ private:
     QPointF mNewOffset;
 };
 
+/**
+ * Used for changing the layer move speed.
+ */
+class SetLayerMoveSpeed : public QUndoCommand
+{
+public:
+    SetLayerMoveSpeed(MapDocument *mapDocument,
+                   Layer *layer,
+                   const QPointF &offset,
+                   QUndoCommand *parent = nullptr);
+
+    void undo() override { setMoveSpeed(mOldOffset); }
+    void redo() override { setMoveSpeed(mNewOffset); }
+
+    int id() const override { return Cmd_ChangeLayerOffset; }
+
+private:
+    void setMoveSpeed(const QPointF &moveSpeed);
+
+    MapDocument *mMapDocument;
+    Layer *mLayer;
+    QPointF mOldOffset;
+    QPointF mNewOffset;
+};
+
+/**
+ * Used for changing layer horizontal repetition.
+ */
+class SetLayerRepeatedX : public QUndoCommand
+{
+public:
+    SetLayerRepeatedX(MapDocument *mapDocument,
+                    Layer *layer,
+                    bool repeatedX);
+
+    void undo() override { swap(); }
+    void redo() override { swap(); }
+
+private:
+    void swap();
+
+    MapDocument *mMapDocument;
+    Layer *mLayer;
+    bool mRepeatedX;
+};
+
+/**
+ * Used for changing layer vertical repetition.
+ */
+class SetLayerRepeatedY : public QUndoCommand
+{
+public:
+    SetLayerRepeatedY(MapDocument *mapDocument,
+                    Layer *layer,
+                    bool repeatedY);
+
+    void undo() override { swap(); }
+    void redo() override { swap(); }
+
+private:
+    void swap();
+
+    MapDocument *mMapDocument;
+    Layer *mLayer;
+    bool mRepeatedY;
+};
+
 } // namespace Internal
 } // namespace Tiled

--- a/src/tiled/layermodel.cpp
+++ b/src/tiled/layermodel.cpp
@@ -342,6 +342,60 @@ void LayerModel::setLayerOffset(Layer *layer, const QPointF &offset)
 }
 
 /**
+ * Sets the move speed of the layer at the given index.
+ */
+void LayerModel::setLayerMoveSpeed(Layer *layer, const QPointF &moveSpeed)
+{
+    if (layer->moveSpeed() == moveSpeed)
+        return;
+
+    layer->setMoveSpeed(moveSpeed);
+    emit layerChanged(layer);
+}
+
+/**
+ * Sets whether the layer at the given index is horizontally repeated.
+ */
+void LayerModel::setLayerRepeatedX(Layer *layer, bool repeatedX)
+{
+    if (layer->repeatedX() == repeatedX)
+        return;
+
+    layer->setRepeatedX(repeatedX);
+
+    const QModelIndex modelIndex = index(layer);
+    emit dataChanged(modelIndex, modelIndex);
+    emit layerChanged(layer);
+}
+
+/**
+ * Sets whether the layer at the given index is vertically repeated.
+ */
+void LayerModel::setLayerRepeatedY(Layer *layer, bool repeatedY)
+{
+    if (layer->repeatedY() == repeatedY)
+        return;
+
+    layer->setRepeatedY(repeatedY);
+
+    const QModelIndex modelIndex = index(layer);
+    emit dataChanged(modelIndex, modelIndex);
+    emit layerChanged(layer);
+}
+
+/**
+ * Sets the dimensions of the layer at the given index.
+ */
+void LayerModel::setLayerSize(TileLayer *layer, const QSize &size)
+{
+    if (QSize(layer->width(), layer->height()) == size)
+        return;
+
+    layer->resize(size, QPoint());
+    emit layerChanged(layer);
+}
+
+/**
  * Renames the layer at the given index.
  */
 void LayerModel::renameLayer(Layer *layer, const QString &name)

--- a/src/tiled/layermodel.h
+++ b/src/tiled/layermodel.h
@@ -81,6 +81,10 @@ public:
     void setLayerVisible(Layer *layer, bool visible);
     void setLayerOpacity(Layer *layer, float opacity);
     void setLayerOffset(Layer *layer, const QPointF &offset);
+    void setLayerMoveSpeed(Layer *layer, const QPointF &moveSpeed);
+    void setLayerRepeatedX(Layer *layer, bool repeatedX);
+    void setLayerRepeatedY(Layer *layer, bool repeatedY);
+    void setLayerSize(TileLayer *layer, const QSize &size);
 
     void renameLayer(Layer *layer, const QString &name);
 

--- a/src/tiled/propertybrowser.h
+++ b/src/tiled/propertybrowser.h
@@ -150,7 +150,11 @@ private:
         TileProbabilityProperty,
         ColumnCountProperty,
         IdProperty,
-        CustomProperty
+        CustomProperty,
+        MoveSpeedXProperty,
+        MoveSpeedYProperty,
+        RepeatedXProperty,
+        RepeatedYProperty
     };
 
     void addMapProperties();


### PR DESCRIPTION
New layer properties handled(loading, saving, undo/redo...).
Changing layer dimensions directly plugged into changing width/height attributes.
Partially implemented rendering of repeated layers.

Known bugs/issues to solve:
- moving "camera" makes parts of repeated fragments of plane to disappear
- tile preview(eg. Stamp Brush) causes same thing to happen
- width/height attribute field loses focus upon clicking (+/-) buttons
- rescaling map changes all layers' dimensions(which should probably be optional)

TODO:
- use move speed as multiplier in rendering
- option to show layer margins?
- using tools on repeated layers, outside their bounds? (operating on repeated tiles affects te original ones)