### PR TITLE
Shortcut handler for changing toolTip text on Actions on toolbars

### DIFF
--- a/src/tiled/actionshortcuthandler.cpp
+++ b/src/tiled/actionshortcuthandler.cpp
@@ -1,0 +1,143 @@
+/* This class contains 3 Vector containers:
+ * mActionList contains a list of QActions. mDockWidgetList contains a list of DockWidgets
+ * mTooltipList constains a list of tooltips that are indexed to correspond with its Parent
+ * QAction in mActionList. EX: mToolTipList[0] is the original tooltip for mActionList[0].
+ *
+ * This singleton class can be accessed from anywhere by including its header file and using
+ * ActionShorcutHandler::getInstance() */
+
+#include "actionshortcuthandler.h"
+
+#include <QAction>
+#include <QDockWidget>
+#include <QToolBar>
+#include <QMenu>
+#include <QString>
+
+ActionShortcutHandler& ActionShortcutHandler::getInstance() {
+    static ActionShortcutHandler instance;
+    return instance;
+}
+ActionShortcutHandler::ActionShortcutHandler() {}
+
+/* Add all of our QActions to a vector */
+void ActionShortcutHandler::addAction(QAction *_newAction)
+{
+    /* Do not add duplicate actions */
+    if (!mActionList.contains(_newAction))
+    {
+        mActionList.append(_newAction);
+        QString str = _newAction->toolTip();
+
+        /* This takes off the existing shortcut text in tooltip if it is instantiated
+         * before being added to this list, this class takes care of the rest  */
+        if (str.contains(QLatin1String("(")) && str.contains(QLatin1String(")")))
+            mTooltipList.append(str.left(str.indexOf(QLatin1String("(")) - 1));
+        else
+            mTooltipList.append(str);
+    }
+}
+
+/* Add all our QActions to a vector, actions are added under these conditions:
+ * 1: the QAction toolTip is not empty || 2: the QAction is not a seperator */
+void ActionShortcutHandler::addActionList(const QVector<QAction*>& listToAdd)
+{
+    foreach(QAction* _action, listToAdd)
+    {
+        // Add each action to our ActionList only if it doesnt already exist
+        if (!mActionList.contains(_action))
+        {
+            if (!_action->toolTip().isEmpty() && !_action->isSeparator())
+            {
+                mActionList.append(_action);
+                QString str = _action->toolTip();
+                /* This takes off the existing shortcut text in tooltip if it is instantiated
+                 * before being added to this list, this class takes care of the rest  */
+                if (str.contains(QLatin1String("(")) && str.contains(QLatin1String(")")))
+                    mTooltipList.append(str.left(str.indexOf(QLatin1String("(")) - 1));
+                else
+                    mTooltipList.append(str);
+            }
+        }
+    }
+}
+
+/* Add all our QWidgets to a vector */
+void ActionShortcutHandler::addDockWidget(QDockWidget* _newWidget)
+{
+    if (!mWidgetList.contains(_newWidget))
+        mWidgetList.append(_newWidget);
+}
+
+/* Add an array of QWidgets to our current List */
+void ActionShortcutHandler::addDockWidgetList(const QVector<QDockWidget*>& listToAdd)
+{
+    foreach(QDockWidget *_widget, listToAdd)
+    {
+        // Add each widget to our action list only if it doesnt already exist
+        if (!mWidgetList.contains(_widget))
+            mWidgetList.append(_widget);
+    }
+}
+
+/* Run through each DockWidget in our widget list, for each DockWidget we need to
+ * grab its toolbar. Then from each toolbar we grab its set of actions. Finally,
+ * we add oll of that toolbars actions to our actionList */
+void ActionShortcutHandler::populateAListFromWList()
+{
+    foreach (QDockWidget* _widget, mWidgetList)
+    {
+        // Find all the childred of type QToolBar of this specific QDockWidget
+        QList<QToolBar*> _toolBars = _widget->findChildren<QToolBar*>();
+
+        // Add the actions of each toolBar in our newly create list of QToolbars
+        foreach (QToolBar* _aToolBar, _toolBars) {
+            addActionList(_aToolBar->actions().toVector());
+        }
+    }
+}
+
+/* Does the specified action already exist in our list? */
+bool ActionShortcutHandler::actionFound(QAction *_action) {
+    if (mActionList.contains(_action))
+        return true;
+    else
+        return false;
+}
+
+/* Return the list of QActions contained in mActionList */
+QVector<QAction*> ActionShortcutHandler::getActionList() {
+    return mActionList;
+}
+
+/* This method updates the shortcut text for the actions in our list based on
+ * their shortcuts, erases shortcut text if a shortcut no longer exists */
+void ActionShortcutHandler::updateAllActionShortcutText()
+{
+    int i = 0;
+    foreach(QAction *_mAction, mActionList)
+    {
+        i = mActionList.indexOf(_mAction);
+        // If the QAction has a shortcut we add it onto the end of the tooltip
+        if (!_mAction->shortcut().isEmpty())
+            _mAction->setToolTip(mTooltipList[i] + QLatin1String (" (") + _mAction->shortcut().toString()+ QLatin1String(")"));
+        else
+            _mAction->setToolTip(mTooltipList[i]);
+    }
+}
+
+/* Get the tooltip as set in our toolTip list, this is the QActions default
+ * tooltip text without the shortcut added */
+QString ActionShortcutHandler::getToolip(QAction *_mAction) {
+    return mTooltipList[mActionList.indexOf(_mAction)];
+}
+
+/* Update only one specific QAction toolTip */
+void ActionShortcutHandler::updateActionShortcutText(QAction* _mAction)
+{
+    int i = mActionList.indexOf(_mAction);
+    if (!_mAction->shortcut().isEmpty())
+        _mAction->setToolTip(mTooltipList[i] + QLatin1String (" (") + _mAction->shortcut().toString()+ QLatin1String(")"));
+    else
+        _mAction->setToolTip(mTooltipList[i]);
+}

--- a/src/tiled/actionshortcuthandler.h
+++ b/src/tiled/actionshortcuthandler.h
@@ -1,0 +1,40 @@
+#include <QAction>
+#include <QVector>
+#include <QDockWidget>
+#include <QToolBar>
+#include <QKeySequence>
+
+
+#ifndef ACTIONSHORTCUTDISPLAY_H
+#define ACTIONSHORTCUTDISPLAY_H
+
+class ActionShortcutHandler
+{
+    public:
+        static ActionShortcutHandler& getInstance();
+
+        void addAction(QAction *_newAction); // Add a QActions to our vector
+        void addActionList(const QVector<QAction*>& listToAdd); // Add list of QActions to vector
+        void updateAllActionShortcutText(); // Reset shortcut text for entire list
+        void updateActionShortcutText(QAction *compareObj); // Update shortcut text for specific action
+        QVector<QAction*> getActionList();
+        void addDockWidgetList(const QVector<QDockWidget*>& listToAdd); // Add list of QDockWidgets
+        void addDockWidget(QDockWidget* _newWidget); // Add single QDockWidget
+        void populateAListFromWList(); // Populate Action list from Dock list
+        bool actionFound(QAction *_action); // Check for a specific action in the action list
+        QString getToolip(QAction *_mAction); // Return the original tool tip text of this action
+
+        /* Do not want these methods for Singleton class, ensure only
+           one instance ever exists */
+        ActionShortcutHandler(ActionShortcutHandler const&) = delete;
+        void operator=(ActionShortcutHandler const&) = delete;
+
+    private:
+        // This vector houses all of the created actions in our program
+        QVector<QAction*> mActionList;
+        QVector<QDockWidget*> mWidgetList;
+        QVector<QString> mTooltipList;
+        ActionShortcutHandler();
+};
+
+#endif // ACTIONSHORTCUTDISPLAY_H

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -70,6 +70,7 @@
 #include "undodock.h"
 #include "utils.h"
 #include "zoomable.h"
+#include "actionshortcuthandler.h" // ADDED - LOGAN SPENCER
 
 #ifdef Q_OS_MAC
 #include "macsupport.h"
@@ -461,6 +462,31 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
             this, SLOT(autoMappingWarning(bool)));
     connect(mAutomappingManager, SIGNAL(errorsOccurred(bool)),
             this, SLOT(autoMappingError(bool)));
+
+    /* ADDED BY LOGAN SPENCER - Adding actions into the Singleton class ActionShorcutHandler */
+    // This is an example of how actions are added one by one, manually
+    ActionShortcutHandler::getInstance().addAction(mUi->actionSave);
+    ActionShortcutHandler::getInstance().addAction(mUi->actionOpen);
+    ActionShortcutHandler::getInstance().addAction(mUi->actionHighlightCurrentLayer);
+    ActionShortcutHandler::getInstance().addAction(mUi->actionPaste);
+    ActionShortcutHandler::getInstance().addAction(mUi->actionZoomIn);
+    ActionShortcutHandler::getInstance().addAction(mUi->actionZoomOut);
+    ActionShortcutHandler::getInstance().addAction(redoAction);
+    ActionShortcutHandler::getInstance().addAction(undoAction);
+
+    // This adds all the actions found in the map editor toolbar (The main actions toolbar)
+    QList<QToolBar*> _bar = mapEditor->toolBars();
+    ActionShortcutHandler::getInstance().addActionList(_bar.at(1)->actions().toVector());
+
+    // This adds all of the actions found in the dock widgets.
+    /* *** For some reason, Add Property, Remove property, Rename Property,
+     *     Add Terrain, Remove terrain are all added multiple times. My code
+     *     for adding ensures that duplicates are not added, so I do now know
+     *     know where this stems from quite yet                             */
+    QList<QDockWidget*> dockWidgets = findChildren<QDockWidget*>();
+    ActionShortcutHandler::getInstance().addDockWidgetList(dockWidgets.toVector());           // LOGAN SPENCER - 3-24-2017
+    ActionShortcutHandler::getInstance().populateAListFromWList();
+    ActionShortcutHandler::getInstance().updateAllActionShortcutText();
 }
 
 MainWindow::~MainWindow()

--- a/src/tiled/mainwindow.ui
+++ b/src/tiled/mainwindow.ui
@@ -41,7 +41,7 @@
      <x>0</x>
      <y>0</y>
      <width>553</width>
-     <height>19</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/src/tiled/preferencesdialog.h
+++ b/src/tiled/preferencesdialog.h
@@ -21,6 +21,9 @@
 #pragma once
 
 #include <QDialog>
+#include <QVector>
+#include <QKeySequence>
+#include <QMap>
 
 class QModelIndex;
 
@@ -49,18 +52,27 @@ protected:
 private slots:
     void languageSelected(int index);
 
+    void on_resetButton_clicked();
+    void on_keySequenceEdit_editingFinished();
+    void on_scWidget_itemSelectionChanged();
+
 private:
     void fromPreferences();
 
     void retranslateUi();
 
     void styleComboChanged(int index);
+    void addItem(QString name, QString key);
 
     void autoUpdateToggled(bool checked);
     void checkForUpdates();
 
     Ui::PreferencesDialog *mUi;
     QStringList mLanguages;
+
+    // Keyboard Shortcut Handlers
+    QVector<QKeySequence> originalKeySequences;
+    QMap<QString ,QAction*> itemIndex; // Stores QAction pointers by keys of their text.
 };
 
 

--- a/src/tiled/preferencesdialog.ui
+++ b/src/tiled/preferencesdialog.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>4</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -368,6 +368,89 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tab_4">
+      <attribute name="title">
+       <string>Keyboard</string>
+      </attribute>
+      <widget class="QGroupBox" name="groupBox_6">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>381</width>
+         <height>271</height>
+        </rect>
+       </property>
+       <property name="title">
+        <string>Keyboard Shortcuts</string>
+       </property>
+       <widget class="QTreeWidget" name="scWidget">
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>30</y>
+          <width>361</width>
+          <height>231</height>
+         </rect>
+        </property>
+        <attribute name="headerDefaultSectionSize">
+         <number>150</number>
+        </attribute>
+        <attribute name="headerMinimumSectionSize">
+         <number>80</number>
+        </attribute>
+        <attribute name="headerStretchLastSection">
+         <bool>true</bool>
+        </attribute>
+        <column>
+         <property name="text">
+          <string>Command</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Key Shortcut</string>
+         </property>
+        </column>
+       </widget>
+      </widget>
+      <widget class="QKeySequenceEdit" name="keySequenceEdit">
+       <property name="geometry">
+        <rect>
+         <x>80</x>
+         <y>290</y>
+         <width>201</width>
+         <height>21</height>
+        </rect>
+       </property>
+      </widget>
+      <widget class="QPushButton" name="resetButton">
+       <property name="geometry">
+        <rect>
+         <x>290</x>
+         <y>290</y>
+         <width>81</width>
+         <height>21</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Reset</string>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_6">
+       <property name="geometry">
+        <rect>
+         <x>20</x>
+         <y>290</y>
+         <width>51</width>
+         <height>21</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Shortcut:</string>
+       </property>
+      </widget>
+     </widget>
     </widget>
    </item>
    <item>
@@ -390,7 +473,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>tabWidget</tabstop>
   <tabstop>enableDtd</tabstop>
   <tabstop>reloadTilesetImages</tabstop>
   <tabstop>openLastFiles</tabstop>

--- a/src/tiled/tiled.qbs
+++ b/src/tiled/tiled.qbs
@@ -67,6 +67,8 @@ QtGuiApplication {
         "abstracttool.h",
         "actionmanager.cpp",
         "actionmanager.h",
+        "actionshortcuthandler.cpp",
+        "actionshortcuthandler.h",
         "addpropertydialog.cpp",
         "addpropertydialog.h",
         "addpropertydialog.ui",
@@ -480,7 +482,12 @@ QtGuiApplication {
         condition: qbs.targetOS.contains("linux")
         qbs.install: true
         qbs.installDir: "share/applications"
-        files: [ "../../tiled.desktop" ]
+        files: [
+            "../../tiled.desktop",
+            "shortcutdialog.cpp",
+            "shortcutdialog.h",
+            "shortcutdialog.ui",
+        ]
     }
 
     Group {


### PR DESCRIPTION
This is the shortcuthandler addition. This is a Singleton class implimentation so only one can exist. 

This class houses a list of QWidgets and a list of QActions. These can be added one by one or an existing list can be appended to them.

UpdateActionShortcut methods is a string modifying method for the actions tool tips. This method is not complete, but I will be working on it.

Currently all actions are added at the end of the mainwindow constructor. These 4 lines, the include "", and the new class are the only changes.