### PR TITLE
Minimap in a resizing dialog

### DIFF
--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -300,9 +300,9 @@ void MapDocument::resizeMap(const QSize &size, const QPoint &offset, bool remove
         case Layer::ObjectGroupType: {
             ObjectGroup *objectGroup = static_cast<ObjectGroup*>(layer);
 
-            // Remove objects that will fall outside of the map
             for (MapObject *o : objectGroup->objects()) {
                 if (removeObjects && !visibleIn(visibleArea, o, mRenderer)) {
+                    // Remove objects that will fall outside of the map
                     new RemoveMapObject(this, o, command);
                 } else {
                     QPointF oldPos = o->position();

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -301,15 +301,13 @@ void MapDocument::resizeMap(const QSize &size, const QPoint &offset, bool remove
             ObjectGroup *objectGroup = static_cast<ObjectGroup*>(layer);
 
             // Remove objects that will fall outside of the map
-            if (removeObjects) {
-                for (MapObject *o : objectGroup->objects()) {
-                    if (!visibleIn(visibleArea, o, mRenderer)) {
-                        new RemoveMapObject(this, o, command);
-                    } else {
-                        QPointF oldPos = o->position();
-                        QPointF newPos = oldPos + pixelOffset;
-                        new MoveMapObject(this, o, newPos, oldPos, command);
-                    }
+            for (MapObject *o : objectGroup->objects()) {
+                if (removeObjects && !visibleIn(visibleArea, o, mRenderer)) {
+                    new RemoveMapObject(this, o, command);
+                } else {
+                    QPointF oldPos = o->position();
+                    QPointF newPos = oldPos + pixelOffset;
+                    new MoveMapObject(this, o, newPos, oldPos, command);
                 }
             }
             break;

--- a/src/tiled/minimap.cpp
+++ b/src/tiled/minimap.cpp
@@ -195,7 +195,7 @@ void MiniMap::renderMapToImage()
     if (imageSize.isEmpty())
         return;
 
-    mMiniMapRenderer->renderMinimapToImage(mMapImage, mRenderFlags);
+    mMiniMapRenderer->renderToImage(mMapImage, mRenderFlags);
 }
 
 void MiniMap::centerViewOnLocalPixel(QPoint centerPos, int delta)

--- a/src/tiled/minimap.cpp
+++ b/src/tiled/minimap.cpp
@@ -74,7 +74,7 @@ void MiniMap::setMapDocument(MapDocument *map)
     }
 
     mMapDocument = map;
-    mMiniMapRenderer->setMapDocument(mMapDocument);
+    mMiniMapRenderer.setMapDocument(mMapDocument);
 
     if (mMapDocument) {
         connect(mMapDocument->undoStack(), SIGNAL(indexChanged(int)),
@@ -195,7 +195,7 @@ void MiniMap::renderMapToImage()
     if (imageSize.isEmpty())
         return;
 
-    mMiniMapRenderer->renderToImage(mMapImage, mRenderFlags);
+    mMiniMapRenderer.renderToImage(mMapImage, mRenderFlags);
 }
 
 void MiniMap::centerViewOnLocalPixel(QPoint centerPos, int delta)

--- a/src/tiled/minimap.cpp
+++ b/src/tiled/minimap.cpp
@@ -46,7 +46,7 @@ MiniMap::MiniMap(QWidget *parent)
                    | MiniMapRenderer::DrawObjects
                    | MiniMapRenderer::DrawImages
                    | MiniMapRenderer::IgnoreInvisibleLayer)
-    , mMiniMapRenderer(MiniMapRenderer::miniMapRenderer())
+    , mMiniMapRenderer(MiniMapRenderer::instance())
 {
     setFrameStyle(QFrame::StyledPanel | QFrame::Sunken);
     setMinimumSize(50, 50);

--- a/src/tiled/minimap.cpp
+++ b/src/tiled/minimap.cpp
@@ -22,21 +22,13 @@
 #include "minimap.h"
 
 #include "documentmanager.h"
-#include "imagelayer.h"
 #include "map.h"
-#include "mapdocument.h"
-#include "mapobject.h"
-#include "mapobjectitem.h"
 #include "maprenderer.h"
 #include "mapview.h"
-#include "objectgroup.h"
-#include "preferences.h"
-#include "tilelayer.h"
 #include "utils.h"
 #include "zoomable.h"
 
 #include <QCursor>
-#include <QPainter>
 #include <QResizeEvent>
 #include <QScrollBar>
 #include <QUndoStack>

--- a/src/tiled/minimap.h
+++ b/src/tiled/minimap.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "minimaprenderer.h"
+
 #include <QFrame>
 #include <QImage>
 #include <QTimer>
@@ -35,21 +37,12 @@ class MiniMap : public QFrame
     Q_OBJECT
 
 public:
-    enum MiniMapRenderFlag {
-        DrawObjects             = 0x0001,
-        DrawTiles               = 0x0002,
-        DrawImages              = 0x0004,
-        IgnoreInvisibleLayer    = 0x0008,
-        DrawGrid                = 0x0010
-    };
-    Q_DECLARE_FLAGS(MiniMapRenderFlags, MiniMapRenderFlag)
-
     MiniMap(QWidget *parent);
 
     void setMapDocument(MapDocument *);
 
-    MiniMapRenderFlags renderFlags() const { return mRenderFlags; }
-    void setRenderFlags(MiniMapRenderFlags flags) { mRenderFlags = flags; }
+    MiniMapRenderer::MiniMapRenderFlags renderFlags() const { return mRenderFlags; }
+    void setRenderFlags(MiniMapRenderer::MiniMapRenderFlags flags) { mRenderFlags = flags; }
 
     QSize sizeHint() const override;
 
@@ -77,7 +70,8 @@ private:
     QPoint mDragOffset;
     bool mMouseMoveCursorState;
     bool mRedrawMapImage;
-    MiniMapRenderFlags mRenderFlags;
+    MiniMapRenderer::MiniMapRenderFlags mRenderFlags;
+    MiniMapRenderer* mMiniMapRenderer;
 
     QRect viewportRect() const;
     QPointF mapToScene(QPoint p) const;
@@ -88,5 +82,3 @@ private:
 
 } // namespace Internal
 } // namespace Tiled
-
-Q_DECLARE_OPERATORS_FOR_FLAGS(Tiled::Internal::MiniMap::MiniMapRenderFlags)

--- a/src/tiled/minimap.h
+++ b/src/tiled/minimap.h
@@ -41,8 +41,8 @@ public:
 
     void setMapDocument(MapDocument *);
 
-    MiniMapRenderer::MiniMapRenderFlags renderFlags() const { return mRenderFlags; }
-    void setRenderFlags(MiniMapRenderer::MiniMapRenderFlags flags) { mRenderFlags = flags; }
+    MiniMapRenderer::RenderFlags renderFlags() const { return mRenderFlags; }
+    void setRenderFlags(MiniMapRenderer::RenderFlags flags) { mRenderFlags = flags; }
 
     QSize sizeHint() const override;
 
@@ -70,7 +70,7 @@ private:
     QPoint mDragOffset;
     bool mMouseMoveCursorState;
     bool mRedrawMapImage;
-    MiniMapRenderer::MiniMapRenderFlags mRenderFlags;
+    MiniMapRenderer::RenderFlags mRenderFlags;
     MiniMapRenderer* mMiniMapRenderer;
 
     QRect viewportRect() const;

--- a/src/tiled/minimap.h
+++ b/src/tiled/minimap.h
@@ -71,7 +71,7 @@ private:
     bool mMouseMoveCursorState;
     bool mRedrawMapImage;
     MiniMapRenderer::RenderFlags mRenderFlags;
-    MiniMapRenderer* mMiniMapRenderer;
+    MiniMapRenderer& mMiniMapRenderer;
 
     QRect viewportRect() const;
     QPointF mapToScene(QPoint p) const;

--- a/src/tiled/minimaprenderer.cpp
+++ b/src/tiled/minimaprenderer.cpp
@@ -1,0 +1,117 @@
+#include "minimaprenderer.h"
+
+#include "imagelayer.h"
+#include "mapobject.h"
+#include "mapobjectitem.h"
+#include "maprenderer.h"
+#include "objectgroup.h"
+#include "preferences.h"
+#include "tilelayer.h"
+
+#include <QPainter>
+
+using namespace Tiled;
+using namespace Tiled::Internal;
+
+MiniMapRenderer* MiniMapRenderer::miniMapRenderer()
+{
+    static MiniMapRenderer* singletonRenderer = new MiniMapRenderer();
+    return singletonRenderer;
+}
+
+static bool objectLessThan(const MapObject *a, const MapObject *b)
+{
+    return a->y() < b->y();
+}
+
+void MiniMapRenderer::renderMinimapToImage(QImage& image, const MiniMapRenderFlags minimapRenderFlags) const
+{
+    MapRenderer *renderer = mMapDocument->renderer();
+
+    bool drawObjects = minimapRenderFlags.testFlag(MiniMapRenderFlag::DrawObjects);
+    bool drawTiles = minimapRenderFlags.testFlag(MiniMapRenderFlag::DrawTiles);
+    bool drawImages = minimapRenderFlags.testFlag(MiniMapRenderFlag::DrawImages);
+    bool drawTileGrid = minimapRenderFlags.testFlag(MiniMapRenderFlag::DrawGrid);
+    bool visibleLayersOnly = minimapRenderFlags.testFlag(MiniMapRenderFlag::IgnoreInvisibleLayer);
+
+    // Remember the current render flags
+    const Tiled::RenderFlags renderFlags = renderer->flags();
+    renderer->setFlag(ShowTileObjectOutlines, false);
+
+    QSize mapSize = renderer->mapSize();
+    QMargins margins = mMapDocument->map()->computeLayerOffsetMargins();
+    mapSize.setWidth(mapSize.width() + margins.left() + margins.right());
+    mapSize.setHeight(mapSize.height() + margins.top() + margins.bottom());
+
+    // Determine the largest possible scale
+    qreal scale = qMin((qreal) image.width() / mapSize.width(),
+                       (qreal) image.height() / mapSize.height());
+
+    image.fill(Qt::transparent);
+    QPainter painter(&image);
+    painter.setRenderHints(QPainter::SmoothPixmapTransform);
+    painter.setTransform(QTransform::fromScale(scale, scale));
+    painter.translate(margins.left(), margins.top());
+    renderer->setPainterScale(scale);
+
+    LayerIterator iterator(mMapDocument->map());
+    while (const Layer *layer = iterator.next()) {
+        if (visibleLayersOnly && layer->isHidden())
+            continue;
+
+        const auto offset = layer->totalOffset();
+
+        painter.setOpacity(layer->effectiveOpacity());
+        painter.translate(offset);
+
+        const TileLayer *tileLayer = dynamic_cast<const TileLayer*>(layer);
+        const ObjectGroup *objGroup = dynamic_cast<const ObjectGroup*>(layer);
+        const ImageLayer *imageLayer = dynamic_cast<const ImageLayer*>(layer);
+
+        if (tileLayer && drawTiles) {
+            renderer->drawTileLayer(&painter, tileLayer);
+        } else if (objGroup && drawObjects) {
+            QList<MapObject*> objects = objGroup->objects();
+
+            if (objGroup->drawOrder() == ObjectGroup::TopDownOrder)
+                qStableSort(objects.begin(), objects.end(), objectLessThan);
+
+            foreach (const MapObject *object, objects) {
+                if (object->isVisible()) {
+                    if (object->rotation() != qreal(0)) {
+                        QPointF origin = renderer->pixelToScreenCoords(object->position());
+                        painter.save();
+                        painter.translate(origin);
+                        painter.rotate(object->rotation());
+                        painter.translate(-origin);
+                    }
+
+                    const QColor color = MapObjectItem::objectColor(object);
+                    renderer->drawMapObject(&painter, object, color);
+
+                    if (object->rotation() != qreal(0))
+                        painter.restore();
+                }
+            }
+        } else if (imageLayer && drawImages) {
+            renderer->drawImageLayer(&painter, imageLayer);
+        }
+
+        painter.translate(-offset);
+    }
+
+    if (drawTileGrid) {
+        Preferences *prefs = Preferences::instance();
+        renderer->drawGrid(&painter, QRectF(QPointF(), renderer->mapSize()),
+                           prefs->gridColor());
+    }
+
+    renderer->setFlags(renderFlags);
+}
+
+void MiniMapRenderer::setMapDocument(MapDocument* map)
+{
+    mMapDocument = map;
+}
+
+MiniMapRenderer::MiniMapRenderer() {}

--- a/src/tiled/minimaprenderer.cpp
+++ b/src/tiled/minimaprenderer.cpp
@@ -13,7 +13,7 @@
 using namespace Tiled;
 using namespace Tiled::Internal;
 
-MiniMapRenderer* MiniMapRenderer::miniMapRenderer()
+MiniMapRenderer* MiniMapRenderer::instance()
 {
     static MiniMapRenderer* singletonRenderer = new MiniMapRenderer();
     return singletonRenderer;

--- a/src/tiled/minimaprenderer.cpp
+++ b/src/tiled/minimaprenderer.cpp
@@ -117,4 +117,10 @@ void MiniMapRenderer::setMapDocument(MapDocument* map)
     mMapDocument = map;
 }
 
-MiniMapRenderer::MiniMapRenderer() {}
+MiniMapRenderer::MiniMapRenderer()
+{
+}
+
+MiniMapRenderer::~MiniMapRenderer()
+{
+}

--- a/src/tiled/minimaprenderer.cpp
+++ b/src/tiled/minimaprenderer.cpp
@@ -1,3 +1,25 @@
+/*
+ * minimaprenderer.cpp
+ * Copyright 2017, Yuriy Natarov <natarur@gmail.com>
+ * Copyright 2012, Christoph Schnackenberg <bluechs@gmx.de>
+ * Copyright 2012, Thorbjørn Lindeijer <thorbjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "minimaprenderer.h"
 
 #include "imagelayer.h"
@@ -24,21 +46,21 @@ static bool objectLessThan(const MapObject *a, const MapObject *b)
     return a->y() < b->y();
 }
 
-void MiniMapRenderer::renderMinimapToImage(QImage& image, const MiniMapRenderFlags minimapRenderFlags) const
+void MiniMapRenderer::renderToImage(QImage& image, RenderFlags renderFlags) const
 {
     if (!mMapDocument)
         return;
     
     MapRenderer *renderer = mMapDocument->renderer();
 
-    bool drawObjects = minimapRenderFlags.testFlag(MiniMapRenderFlag::DrawObjects);
-    bool drawTiles = minimapRenderFlags.testFlag(MiniMapRenderFlag::DrawTiles);
-    bool drawImages = minimapRenderFlags.testFlag(MiniMapRenderFlag::DrawImages);
-    bool drawTileGrid = minimapRenderFlags.testFlag(MiniMapRenderFlag::DrawGrid);
-    bool visibleLayersOnly = minimapRenderFlags.testFlag(MiniMapRenderFlag::IgnoreInvisibleLayer);
+    bool drawObjects = renderFlags.testFlag(RenderFlag::DrawObjects);
+    bool drawTiles = renderFlags.testFlag(RenderFlag::DrawTiles);
+    bool drawImages = renderFlags.testFlag(RenderFlag::DrawImages);
+    bool drawTileGrid = renderFlags.testFlag(RenderFlag::DrawGrid);
+    bool visibleLayersOnly = renderFlags.testFlag(RenderFlag::IgnoreInvisibleLayer);
 
     // Remember the current render flags
-    const Tiled::RenderFlags renderFlags = renderer->flags();
+    const Tiled::RenderFlags rendererFlags = renderer->flags();
     renderer->setFlag(ShowTileObjectOutlines, false);
 
     QSize mapSize = renderer->mapSize();
@@ -109,7 +131,7 @@ void MiniMapRenderer::renderMinimapToImage(QImage& image, const MiniMapRenderFla
                            prefs->gridColor());
     }
 
-    renderer->setFlags(renderFlags);
+    renderer->setFlags(rendererFlags);
 }
 
 void MiniMapRenderer::setMapDocument(MapDocument* map)

--- a/src/tiled/minimaprenderer.cpp
+++ b/src/tiled/minimaprenderer.cpp
@@ -26,6 +26,9 @@ static bool objectLessThan(const MapObject *a, const MapObject *b)
 
 void MiniMapRenderer::renderMinimapToImage(QImage& image, const MiniMapRenderFlags minimapRenderFlags) const
 {
+    if (!mMapDocument)
+        return;
+    
     MapRenderer *renderer = mMapDocument->renderer();
 
     bool drawObjects = minimapRenderFlags.testFlag(MiniMapRenderFlag::DrawObjects);

--- a/src/tiled/minimaprenderer.cpp
+++ b/src/tiled/minimaprenderer.cpp
@@ -35,9 +35,9 @@
 using namespace Tiled;
 using namespace Tiled::Internal;
 
-MiniMapRenderer* MiniMapRenderer::instance()
+MiniMapRenderer& MiniMapRenderer::instance()
 {
-    static MiniMapRenderer* singletonRenderer = new MiniMapRenderer();
+    static MiniMapRenderer singletonRenderer;
     return singletonRenderer;
 }
 

--- a/src/tiled/minimaprenderer.h
+++ b/src/tiled/minimaprenderer.h
@@ -41,11 +41,14 @@ public:
 
     Q_DECLARE_FLAGS(MiniMapRenderFlags, MiniMapRenderFlag)
 
-    static MiniMapRenderer* miniMapRenderer();
+    static MiniMapRenderer* instance();
     void renderMinimapToImage(QImage& image, const MiniMapRenderFlags minimapRenderFlags) const;
     void setMapDocument(MapDocument* map);
 private:
     MiniMapRenderer();
+    ~MiniMapRenderer();
+    MiniMapRenderer(MiniMapRenderer const&) = delete;
+    MiniMapRenderer& operator= (MiniMapRenderer const&) = delete;
 
     MapDocument* mMapDocument;
 };

--- a/src/tiled/minimaprenderer.h
+++ b/src/tiled/minimaprenderer.h
@@ -19,7 +19,6 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #pragma once
 
 #include "mapdocument.h"

--- a/src/tiled/minimaprenderer.h
+++ b/src/tiled/minimaprenderer.h
@@ -42,7 +42,7 @@ public:
 
     Q_DECLARE_FLAGS(RenderFlags, RenderFlag)
 
-    static MiniMapRenderer* instance();
+    static MiniMapRenderer& instance();
     void renderToImage(QImage& image, RenderFlags renderFlags) const;
     void setMapDocument(MapDocument* map);
 private:

--- a/src/tiled/minimaprenderer.h
+++ b/src/tiled/minimaprenderer.h
@@ -1,0 +1,57 @@
+/*
+ * minimaprenderer.h
+ * Copyright 2017, Yuriy Natarov <natarur@gmail.com>
+ * Based on a minimap by Christoph Schnackenberg and Thorbjørn Lindeijer
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#pragma once
+
+#include "mapdocument.h"
+
+#include <QImage>
+
+namespace Tiled {
+namespace Internal {
+
+class MiniMapRenderer
+{
+public:
+    enum MiniMapRenderFlag {
+        DrawObjects             = 0x0001,
+        DrawTiles               = 0x0002,
+        DrawImages              = 0x0004,
+        IgnoreInvisibleLayer    = 0x0008,
+        DrawGrid                = 0x0010
+    };
+
+    Q_DECLARE_FLAGS(MiniMapRenderFlags, MiniMapRenderFlag)
+
+    static MiniMapRenderer* miniMapRenderer();
+    void renderMinimapToImage(QImage& image, const MiniMapRenderFlags minimapRenderFlags) const;
+    void setMapDocument(MapDocument* map);
+private:
+    MiniMapRenderer();
+
+    MapDocument* mMapDocument;
+};
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(Tiled::Internal::MiniMapRenderer::MiniMapRenderFlags)
+
+} // namespace Internal
+} // namespace Tiled

--- a/src/tiled/minimaprenderer.h
+++ b/src/tiled/minimaprenderer.h
@@ -1,7 +1,8 @@
 /*
  * minimaprenderer.h
  * Copyright 2017, Yuriy Natarov <natarur@gmail.com>
- * Based on a minimap by Christoph Schnackenberg and Thorbjørn Lindeijer
+ * Copyright 2012, Christoph Schnackenberg <bluechs@gmx.de>
+ * Copyright 2012, Thorbjørn Lindeijer <thorbjorn@lindeijer.nl>
  *
  * This file is part of Tiled.
  *
@@ -31,7 +32,7 @@ namespace Internal {
 class MiniMapRenderer
 {
 public:
-    enum MiniMapRenderFlag {
+    enum RenderFlag {
         DrawObjects             = 0x0001,
         DrawTiles               = 0x0002,
         DrawImages              = 0x0004,
@@ -39,10 +40,10 @@ public:
         DrawGrid                = 0x0010
     };
 
-    Q_DECLARE_FLAGS(MiniMapRenderFlags, MiniMapRenderFlag)
+    Q_DECLARE_FLAGS(RenderFlags, RenderFlag)
 
     static MiniMapRenderer* instance();
-    void renderMinimapToImage(QImage& image, const MiniMapRenderFlags minimapRenderFlags) const;
+    void renderToImage(QImage& image, RenderFlags renderFlags) const;
     void setMapDocument(MapDocument* map);
 private:
     MiniMapRenderer();
@@ -53,7 +54,7 @@ private:
     MapDocument* mMapDocument;
 };
 
-Q_DECLARE_OPERATORS_FOR_FLAGS(Tiled::Internal::MiniMapRenderer::MiniMapRenderFlags)
+Q_DECLARE_OPERATORS_FOR_FLAGS(Tiled::Internal::MiniMapRenderer::RenderFlags)
 
 } // namespace Internal
 } // namespace Tiled

--- a/src/tiled/resizehelper.cpp
+++ b/src/tiled/resizehelper.cpp
@@ -136,7 +136,7 @@ void ResizeHelper::paintEvent(QPaintEvent *)
 
     painter.setOpacity(0.5);
     QImage minimap = QImage(oldRect.width() * mScale, oldRect.height() * mScale, QImage::Format_ARGB32_Premultiplied);
-    mMiniMapRenderer->renderMinimapToImage(minimap, MiniMapRenderer::DrawObjects
+    mMiniMapRenderer->renderToImage(minimap, MiniMapRenderer::DrawObjects
                                            | MiniMapRenderer::DrawImages
                                            | MiniMapRenderer::DrawTiles
                                            | MiniMapRenderer::IgnoreInvisibleLayer);

--- a/src/tiled/resizehelper.cpp
+++ b/src/tiled/resizehelper.cpp
@@ -189,14 +189,14 @@ void ResizeHelper::recalculateScale()
     if (_size.isEmpty())
         return;
 
-    const int width = std::max(mNewSize.width(), mOldSize.width());
+    const int width = qMax(mNewSize.width(), mOldSize.width());
 
-    const int height = std::max(mNewSize.height(), mOldSize.height());
+    const int height = qMax(mNewSize.height(), mOldSize.height());
 
     // Pick the smallest scale
     const double scaleW = _size.width() / (double) width;
     const double scaleH = _size.height() / (double) height;
-    mScale = std::min(scaleW, scaleH);
+    mScale = qMin(scaleW, scaleH);
 
     update();
 }

--- a/src/tiled/resizehelper.cpp
+++ b/src/tiled/resizehelper.cpp
@@ -154,6 +154,15 @@ void ResizeHelper::mouseMoveEvent(QMouseEvent *event)
     }
 }
 
+void ResizeHelper::wheelEvent(QWheelEvent *event)
+{
+    if (event->delta() > 0)// zooming in
+        mZoom += 0.2;
+    else
+        mZoom -= 0.2;
+    recalculateScale();
+}
+
 void ResizeHelper::resizeEvent(QResizeEvent *)
 {
     recalculateScale();
@@ -177,7 +186,16 @@ void ResizeHelper::recalculateScale()
     // Pick the smallest scale
     const double scaleW = _size.width() / (double) width;
     const double scaleH = _size.height() / (double) height;
-    const double newScale = qMin(scaleW, scaleH);
+    double newScale = qMin(scaleW, scaleH);
+
+    const double maxScaleW = _size.width() / (double) mNewSize.width();
+    const double maxScaleH = _size.height() / (double) mNewSize.height();
+    const double maxScaleAdd = qMin(maxScaleW, maxScaleH) - newScale;
+
+    mZoom = qMin(mZoom, maxScaleAdd);
+    mZoom = qMax(mZoom, 0.0);
+
+    newScale += mZoom;
 
     if (newScale != mScale) {
         mScale = newScale;

--- a/src/tiled/resizehelper.cpp
+++ b/src/tiled/resizehelper.cpp
@@ -28,7 +28,7 @@ using namespace Tiled::Internal;
 
 ResizeHelper::ResizeHelper(QWidget *parent)
     : QWidget(parent)
-    , mMiniMapRenderer(MiniMapRenderer::miniMapRenderer())
+    , mMiniMapRenderer(MiniMapRenderer::instance())
 {
     setMinimumSize(20, 20);
     setOldSize(QSize(1, 1));

--- a/src/tiled/resizehelper.cpp
+++ b/src/tiled/resizehelper.cpp
@@ -28,6 +28,7 @@ using namespace Tiled::Internal;
 
 ResizeHelper::ResizeHelper(QWidget *parent)
     : QWidget(parent)
+    , mMiniMapRenderer(MiniMapRenderer::miniMapRenderer())
 {
     setMinimumSize(20, 20);
     setOldSize(QSize(1, 1));
@@ -122,10 +123,13 @@ void ResizeHelper::paintEvent(QPaintEvent *)
 
     pen.setColor(Qt::white);
 
-    painter.setPen(pen);
-    painter.setBrush(Qt::white);
     painter.setOpacity(0.5);
-    painter.drawRect(oldRect);
+    QImage minimap = QImage(oldRect.width() * mScale, oldRect.height() * mScale, QImage::Format_ARGB32_Premultiplied);
+    mMiniMapRenderer->renderMinimapToImage(minimap, MiniMapRenderer::DrawObjects
+                                           | MiniMapRenderer::DrawImages
+                                           | MiniMapRenderer::DrawTiles
+                                           | MiniMapRenderer::IgnoreInvisibleLayer);
+    painter.drawImage(oldRect, minimap);
 
     pen.setColor(Qt::black);
     pen.setStyle(Qt::DashLine);

--- a/src/tiled/resizehelper.cpp
+++ b/src/tiled/resizehelper.cpp
@@ -28,6 +28,7 @@ using namespace Tiled::Internal;
 ResizeHelper::ResizeHelper(QWidget *parent)
     : QWidget(parent)
     , mMiniMapRenderer(MiniMapRenderer::instance())
+    , mZoom(0)
 {
     setMinimumSize(20, 20);
     setOldSize(QSize(1, 1));

--- a/src/tiled/resizehelper.cpp
+++ b/src/tiled/resizehelper.cpp
@@ -172,13 +172,9 @@ void ResizeHelper::recalculateScale()
     if (_size.isEmpty())
         return;
 
-    const int width = (mOldSize.width() < mNewSize.width()) ?
-        mNewSize.width() :
-        2 * mOldSize.width() - mNewSize.width();
+    const int width = mNewSize.width();
 
-    const int height = (mOldSize.height() < mNewSize.height()) ?
-        mNewSize.height() :
-        2 * mOldSize.height() - mNewSize.height();
+    const int height = mNewSize.height();
 
     // Pick the smallest scale
     const double scaleW = _size.width() / (double) width;

--- a/src/tiled/resizehelper.cpp
+++ b/src/tiled/resizehelper.cpp
@@ -167,7 +167,7 @@ void ResizeHelper::mouseMoveEvent(QMouseEvent *event)
 
     if (pos != mMouseAnchorPoint) {
         QPoint shift((pos.x() - mMouseAnchorPoint.x()) / mScale,
-                         (pos.y() - mMouseAnchorPoint.y()) / mScale);
+                     (pos.y() - mMouseAnchorPoint.y()) / mScale);
         if (mOldSize.width() > mNewSize.width())
             shift.setX(-shift.x());
         if (mOldSize.height() > mNewSize.height())

--- a/src/tiled/resizehelper.cpp
+++ b/src/tiled/resizehelper.cpp
@@ -177,13 +177,16 @@ void ResizeHelper::recalculateScale()
     // Pick the smallest scale
     const double scaleW = _size.width() / (double) width;
     const double scaleH = _size.height() / (double) height;
-    mScale = qMin(scaleW, scaleH);
+    const double newScale = qMin(scaleW, scaleH);
 
-    mMinimap = QImage(mOldSize * mScale, QImage::Format_ARGB32_Premultiplied);
-    mMiniMapRenderer->renderToImage(mMinimap, MiniMapRenderer::DrawObjects
-                                           | MiniMapRenderer::DrawImages
-                                           | MiniMapRenderer::DrawTiles
-                                           | MiniMapRenderer::IgnoreInvisibleLayer);
+    if (newScale != mScale) {
+        mScale = newScale;
+        mMinimap = QImage(mOldSize * mScale, QImage::Format_ARGB32_Premultiplied);
+        mMiniMapRenderer->renderToImage(mMinimap, MiniMapRenderer::DrawObjects
+                                               | MiniMapRenderer::DrawImages
+                                               | MiniMapRenderer::DrawTiles
+                                               | MiniMapRenderer::IgnoreInvisibleLayer);
+    }
 
     update();
 }

--- a/src/tiled/resizehelper.cpp
+++ b/src/tiled/resizehelper.cpp
@@ -135,12 +135,7 @@ void ResizeHelper::paintEvent(QPaintEvent *)
     pen.setColor(Qt::white);
 
     painter.setOpacity(0.5);
-    QImage minimap = QImage(oldRect.width() * mScale, oldRect.height() * mScale, QImage::Format_ARGB32_Premultiplied);
-    mMiniMapRenderer->renderToImage(minimap, MiniMapRenderer::DrawObjects
-                                           | MiniMapRenderer::DrawImages
-                                           | MiniMapRenderer::DrawTiles
-                                           | MiniMapRenderer::IgnoreInvisibleLayer);
-    painter.drawImage(oldRect, minimap);
+    painter.drawImage(oldRect, mMinimap);
 
     pen.setColor(Qt::black);
     pen.setStyle(Qt::DashLine);
@@ -197,6 +192,12 @@ void ResizeHelper::recalculateScale()
     const double scaleW = _size.width() / (double) width;
     const double scaleH = _size.height() / (double) height;
     mScale = qMin(scaleW, scaleH);
+
+    mMinimap = QImage(mOldSize * mScale, QImage::Format_ARGB32_Premultiplied);
+    mMiniMapRenderer->renderToImage(mMinimap, MiniMapRenderer::DrawObjects
+                                           | MiniMapRenderer::DrawImages
+                                           | MiniMapRenderer::DrawTiles
+                                           | MiniMapRenderer::IgnoreInvisibleLayer);
 
     update();
 }

--- a/src/tiled/resizehelper.cpp
+++ b/src/tiled/resizehelper.cpp
@@ -172,13 +172,9 @@ void ResizeHelper::recalculateScale()
     if (_size.isEmpty())
         return;
 
-    const int width = mNewSize.width();
-
-    const int height = mNewSize.height();
-
     // Pick the smallest scale
-    const double scaleW = _size.width() / (double) width;
-    const double scaleH = _size.height() / (double) height;
+    const double scaleW = _size.width() / (double) mNewSize.width();
+    const double scaleH = _size.height() / (double) mNewSize.height();
     mScale = (scaleW < scaleH) ? scaleW : scaleH;
 
     update();

--- a/src/tiled/resizehelper.cpp
+++ b/src/tiled/resizehelper.cpp
@@ -201,7 +201,7 @@ void ResizeHelper::recalculateScale()
     if (newScale != mScale) {
         mScale = newScale;
         mMinimap = QImage(mOldSize * mScale, QImage::Format_ARGB32_Premultiplied);
-        mMiniMapRenderer->renderToImage(mMinimap, MiniMapRenderer::DrawObjects
+        mMiniMapRenderer.renderToImage(mMinimap, MiniMapRenderer::DrawObjects
                                                | MiniMapRenderer::DrawImages
                                                | MiniMapRenderer::DrawTiles
                                                | MiniMapRenderer::IgnoreInvisibleLayer);

--- a/src/tiled/resizehelper.h
+++ b/src/tiled/resizehelper.h
@@ -110,7 +110,7 @@ private:
 
     MiniMapRenderer* mMiniMapRenderer;
     QImage mMinimap;
-    double mZoom = 0;
+    double mZoom;
 };
 
 } // namespace Internal

--- a/src/tiled/resizehelper.h
+++ b/src/tiled/resizehelper.h
@@ -108,7 +108,7 @@ private:
     bool mDragging;
     double mScale;
 
-    MiniMapRenderer* mMiniMapRenderer;
+    MiniMapRenderer& mMiniMapRenderer;
     QImage mMinimap;
     double mZoom;
 };

--- a/src/tiled/resizehelper.h
+++ b/src/tiled/resizehelper.h
@@ -90,6 +90,8 @@ protected:
 
     void mouseMoveEvent(QMouseEvent *event) override;
 
+    void wheelEvent(QWheelEvent *event) override;
+
     void resizeEvent(QResizeEvent *event) override;
 
     void recalculateScale();
@@ -108,6 +110,7 @@ private:
 
     MiniMapRenderer* mMiniMapRenderer;
     QImage mMinimap;
+    double mZoom = 0;
 };
 
 } // namespace Internal

--- a/src/tiled/resizehelper.h
+++ b/src/tiled/resizehelper.h
@@ -107,6 +107,7 @@ private:
     double mScale;
 
     MiniMapRenderer* mMiniMapRenderer;
+    QImage mMinimap;
 };
 
 } // namespace Internal

--- a/src/tiled/resizehelper.h
+++ b/src/tiled/resizehelper.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "minimaprenderer.h"
+
 #include <QPoint>
 #include <QSize>
 #include <QWidget>
@@ -103,6 +105,8 @@ private:
     QPoint mOrigOffset;
     bool mDragging;
     double mScale;
+
+    MiniMapRenderer* mMiniMapRenderer;
 };
 
 } // namespace Internal

--- a/src/tiled/tiled.pro
+++ b/src/tiled/tiled.pro
@@ -164,6 +164,7 @@ SOURCES += aboutdialog.cpp \
     mapview.cpp \
     minimap.cpp \
     minimapdock.cpp \
+    minimaprenderer.cpp \
     movelayer.cpp \
     movemapobject.cpp \
     movemapobjecttogroup.cpp \
@@ -333,6 +334,7 @@ HEADERS += aboutdialog.h \
     mapview.h \
     minimapdock.h \
     minimap.h \
+    minimaprenderer.h \
     movelayer.h \
     movemapobject.h \
     movemapobjecttogroup.h \

--- a/src/tiled/tiled.qbs
+++ b/src/tiled/tiled.qbs
@@ -244,6 +244,8 @@ QtGuiApplication {
         "minimapdock.cpp",
         "minimapdock.h",
         "minimap.h",
+        "minimaprenderer.cpp",
+        "minimaprenderer.h",
         "movelayer.cpp",
         "movelayer.h",
         "movemapobject.cpp",


### PR DESCRIPTION
I think it is useful to allow a user to see what exactly is going to be removed while resizing and visually estimate the proportions.
 
- Rendering of a minimap is now located in a singleton, which can be accessed from both an editor and a resizing window. Maybe it is not a perfect architecture solution, but at lest it works. Waiting for a feedback regarding it.
- I think now there is no reason to scale the preview when the old rect goes outside the view, so a user can see a more detailed picture of a map.