### PR TITLE
Fixed objects offsetting while resizing

### DIFF
--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -348,16 +348,14 @@ void MapDocument::resizeMap(const QSize &size, const QPoint &offset, bool remove
         case Layer::ObjectGroupType: {
             ObjectGroup *objectGroup = static_cast<ObjectGroup*>(layer);
 
-            // Remove objects that will fall outside of the map
-            if (removeObjects) {
-                for (MapObject *o : objectGroup->objects()) {
-                    if (!visibleIn(visibleArea, o, mRenderer)) {
-                        new RemoveMapObject(this, o, command);
-                    } else {
-                        QPointF oldPos = o->position();
-                        QPointF newPos = oldPos + pixelOffset;
-                        new MoveMapObject(this, o, newPos, oldPos, command);
-                    }
+            for (MapObject *o : objectGroup->objects()) {
+                if (removeObjects && !visibleIn(visibleArea, o, mRenderer)) {
+                    // Remove objects that will fall outside of the map
+                    new RemoveMapObject(this, o, command);
+                } else {
+                    QPointF oldPos = o->position();
+                    QPointF newPos = oldPos + pixelOffset;
+                    new MoveMapObject(this, o, newPos, oldPos, command);
                 }
             }
             break;


### PR DESCRIPTION
Objects were not offseted if the "Remove objects outside of the map" was not set