### PR TITLE
Adjusted dash length in object selection rectangle

### DIFF
--- a/src/tiled/objectselectionitem.cpp
+++ b/src/tiled/objectselectionitem.cpp
@@ -196,9 +196,10 @@ void MapObjectOutline::paint(QPainter *painter,
     painter->setPen(pen);
     painter->drawLines(lines, 4);
 
-    // Draw a black dashed line above above the white line
+    // Draw a black dashed line above the white line
     pen.setColor(Qt::black);
-    pen.setStyle(Qt::DashLine);
+    pen.setCapStyle(Qt::FlatCap);
+    pen.setDashPattern({5, 5});
     pen.setDashOffset(mOffset);
     painter->setPen(pen);
     painter->drawLines(lines, 4);


### PR DESCRIPTION
Used a custom dash line and flat cap to make the black and white dashes have the exact same length, also fixed a typo in the comment.

The chosen length is 5 pixels, but other lengths like 4 or 6 pixels also look fine.