### PR TITLE
Add qml.qrc for tiledquick's QML files

### DIFF
--- a/src/tiledquick/main.cpp
+++ b/src/tiledquick/main.cpp
@@ -17,9 +17,7 @@ int main(int argc, char *argv[])
 
     QQmlApplicationEngine engine;
     engine.addImportPath(qmlDir);
-
-    QString mainQml(qmlDir + QStringLiteral("/tiledquick/main.qml"));
-    engine.load(QUrl::fromLocalFile(mainQml));
+    engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
 
     return app.exec();
 }

--- a/src/tiledquick/qml.qrc
+++ b/src/tiledquick/qml.qrc
@@ -1,0 +1,6 @@
+<RCC>
+    <qresource prefix="/">
+        <file>DragArea.qml</file>
+        <file>main.qml</file>
+    </qresource>
+</RCC>

--- a/src/tiledquick/tiledquick.pro
+++ b/src/tiledquick/tiledquick.pro
@@ -21,3 +21,6 @@ QML_IMPORT_PATH =
 
 # Default rules for deployment.
 include(deployment.pri)
+
+RESOURCES += \
+    qml.qrc


### PR DESCRIPTION
This avoids the need to mess around with import paths for the
application's QML files.