### PR TITLE
Copy qmldir for in-source builds as well

### DIFF
--- a/src/tiledquickplugin/tiledquickplugin.pro
+++ b/src/tiledquickplugin/tiledquickplugin.pro
@@ -49,13 +49,12 @@ HEADERS += \
 
 OTHER_FILES = qmldir
 
-!equals(_PRO_FILE_PWD_, $$OUT_PWD) {
-    copy_qmldir.target = $$OUT_PWD/$$DESTDIR/qmldir
-    copy_qmldir.depends = $$_PRO_FILE_PWD_/qmldir
-    copy_qmldir.commands = $(COPY_FILE) \"$$replace(copy_qmldir.depends, /, $$QMAKE_DIR_SEP)\" \"$$replace(copy_qmldir.target, /, $$QMAKE_DIR_SEP)\"
-    QMAKE_EXTRA_TARGETS += copy_qmldir
-    PRE_TARGETDEPS += $$copy_qmldir.target
-}
+# Copy qmldir to "qml" directory, making sure to respect shadow builds.
+copy_qmldir.target = $$OUT_PWD/$$DESTDIR/qmldir
+copy_qmldir.depends = $$_PRO_FILE_PWD_/qmldir
+copy_qmldir.commands = $(COPY_FILE) \"$$replace(copy_qmldir.depends, /, $$QMAKE_DIR_SEP)\" \"$$replace(copy_qmldir.target, /, $$QMAKE_DIR_SEP)\"
+QMAKE_EXTRA_TARGETS += copy_qmldir
+PRE_TARGETDEPS += $$copy_qmldir.target
 
 qmldir.files = qmldir
 unix {


### PR DESCRIPTION
Applications that want to use quicktiledplugin will be expecting
the qmldir to be with all of the other plugin-related files.