### PR TITLE
MapItem: emit mapChanged() after calling refresh()

### DIFF
--- a/src/tiledquickplugin/mapitem.cpp
+++ b/src/tiledquickplugin/mapitem.cpp
@@ -44,9 +44,8 @@ void MapItem::setMap(Tiled::Map *map)
         return;
 
     mMap = map;
-    emit mapChanged();
-
     refresh();
+    emit mapChanged();
 }
 
 void MapItem::setVisibleArea(const QRectF &visibleArea)


### PR DESCRIPTION
This allows QML code to be guaranteed that MapItem has a renderer by
the time onMapChanged is called, which is necessary to be able to
e.g. set a transform using e.g. pixelToScreenCoords().