### PR TITLE
Allow setting working directory

### DIFF
--- a/src/tiled/command.cpp
+++ b/src/tiled/command.cpp
@@ -37,7 +37,7 @@ QString Command::finalWorkingDirectory() const
     finalWorkingDirectory = replaceVariables(finalWorkingDirectory, false);
 
     QString finalExecutable = replaceVariables(executable);
-    QFileInfo mFile(finalExecutable);   //Check if executable is a path or not
+    QFileInfo mFile(finalExecutable);
 
     finalWorkingDirectory.replace(QLatin1String("%executablepath"), mFile.absolutePath());
 

--- a/src/tiled/command.cpp
+++ b/src/tiled/command.cpp
@@ -32,7 +32,7 @@ using namespace Tiled::Internal;
 
 QString Command::finalCommand() const
 {
-    QString finalCommand = command;
+    QString finalCommand = QString(QLatin1String("%1 %2")).arg(executable).arg(arguments);
 
     // Perform variable replacement
     if (Document *document = DocumentManager::instance()->currentDocument()) {
@@ -82,7 +82,9 @@ QVariant Command::toQVariant() const
     QHash<QString, QVariant> hash;
     hash[QLatin1String("Enabled")] = isEnabled;
     hash[QLatin1String("Name")] = name;
-    hash[QLatin1String("Command")] = command;
+    hash[QLatin1String("Executable")] = executable;
+    hash[QLatin1String("Arguments")] = arguments;
+    hash[QLatin1String("WorkingDirectory")] = workingDirectory;
     hash[QLatin1String("Shortcut")] = shortcut;
     hash[QLatin1String("SaveBeforeExecute")] = saveBeforeExecute;
     return hash;
@@ -93,7 +95,9 @@ Command Command::fromQVariant(const QVariant &variant)
     const QHash<QString, QVariant> hash = variant.toHash();
 
     const QString namePref = QLatin1String("Name");
-    const QString commandPref = QLatin1String("Command");
+    const QString executablePref = QLatin1String("Executable");
+    const QString argumentsPref = QLatin1String("Arguments");
+    const QString workingDirectoryPref = QLatin1String("WorkingDirectory");
     const QString enablePref = QLatin1String("Enabled");
     const QString shortcutPref = QLatin1String("Shortcut");
     const QString saveBeforeExecutePref = QLatin1String("SaveBeforeExecute");
@@ -103,8 +107,12 @@ Command Command::fromQVariant(const QVariant &variant)
         command.isEnabled = hash[enablePref].toBool();
     if (hash.contains(namePref))
         command.name = hash[namePref].toString();
-    if (hash.contains(commandPref))
-        command.command = hash[commandPref].toString();
+    if (hash.contains(executablePref))
+        command.executable = hash[executablePref].toString();
+    if (hash.contains(argumentsPref))
+        command.arguments = hash[argumentsPref].toString();
+    if (hash.contains(workingDirectoryPref))
+        command.workingDirectory = hash[workingDirectoryPref].toString();
     if (hash.contains(shortcutPref))
         command.shortcut = hash[shortcutPref].value<QKeySequence>();
     if (hash.contains(saveBeforeExecutePref))

--- a/src/tiled/command.cpp
+++ b/src/tiled/command.cpp
@@ -34,7 +34,20 @@ QString Command::finalWorkingDirectory() const
 {
     QString finalWorkingDirectory = workingDirectory;
 
-    return replaceVariables(finalWorkingDirectory, true);
+    finalWorkingDirectory = replaceVariables(finalWorkingDirectory, false);
+
+    QString finalExecutable = replaceVariables(executable);
+    QFileInfo mFile(finalExecutable);   //Check if executable is a path or not
+
+    if (mFile.exists() && mFile.isFile()) {
+        finalWorkingDirectory.replace(QLatin1String("%executablepath"),
+                            QString(QLatin1String("%1")).arg(mFile.absolutePath()));
+    } else {
+        finalWorkingDirectory.replace(QLatin1String("%executablepath"),
+                            QString(QLatin1String("")));
+    }
+
+    return finalWorkingDirectory;
 }
 
 QString Command::finalCommand() const
@@ -44,7 +57,7 @@ QString Command::finalCommand() const
     return replaceVariables(finalCommand);
 }
 
-QString Command::replaceVariables(const QString &string, bool flag) const
+QString Command::replaceVariables(const QString &string, bool quotePaths) const
 {
     QString finalString = string;
 
@@ -77,20 +90,8 @@ QString Command::replaceVariables(const QString &string, bool flag) const
         }
     }
 
-    if (flag) {
-        QString finalExecutable = replaceVariables(executable);
-        QFileInfo mFile(finalExecutable);   //Check if executable is a path or not
-
-        if (mFile.exists() && mFile.isFile()) {
-            finalString.replace(QLatin1String("%executablepath"),
-                                QString(QLatin1String("%1")).arg(mFile.absolutePath()));
-        } else {
-            finalString.replace(QLatin1String("%executablepath"),
-                                QString(QLatin1String("")));
-        }
-
+    if (!quotePaths)
         finalString.replace(QLatin1String("\""), QString(QLatin1String("")));
-    }
 
     return finalString;
 }

--- a/src/tiled/command.cpp
+++ b/src/tiled/command.cpp
@@ -82,7 +82,18 @@ QString Command::replaceVariables(const QString &string, bool flag) const
                                  QString(QLatin1String("\"%1\"")).arg(currentObject->id()));
         }
 
-        // TODO: %executablename
+        if (flag) {
+            QString finalExecutable = replaceVariables(executable);
+            QFileInfo mFile(finalExecutable);   //Check if executable is a path or not
+
+            if (mFile.exists() && mFile.isFile()) {
+                finalString.replace(QLatin1String("%executablepath"),
+                                     QString(QLatin1String("%1")).arg(mFile.absolutePath()));
+            } else {
+                finalString.replace(QLatin1String("%executablepath"),
+                                     QString(QLatin1String("")));
+            }
+        }
     }
 
     return finalString;

--- a/src/tiled/command.cpp
+++ b/src/tiled/command.cpp
@@ -53,7 +53,7 @@ QString Command::replaceVariables(const QString &string, bool flag) const
         const QString fileName = document->fileName();
 
         finalString.replace(QLatin1String("%mapfile"),
-                             QString(QLatin1String("\"%1\"")).arg(fileName));
+                            QString(QLatin1String("\"%1\"")).arg(fileName));
 
         QFileInfo fileInfo(fileName);
         QString mapPath = fileInfo.absolutePath();
@@ -71,15 +71,15 @@ QString Command::replaceVariables(const QString &string, bool flag) const
         if (MapDocument *mapDocument = qobject_cast<MapDocument*>(document)) {
             if (const Layer *layer = mapDocument->currentLayer()) {
                 finalString.replace(QLatin1String("%layername"),
-                                     QString(QLatin1String("\"%1\"")).arg(layer->name()));
+                                    QString(QLatin1String("\"%1\"")).arg(layer->name()));
             }
         }
 
         if (MapObject *currentObject = dynamic_cast<MapObject *>(document->currentObject())) {
             finalString.replace(QLatin1String("%objecttype"),
-                                 QString(QLatin1String("\"%1\"")).arg(currentObject->type()));
+                                QString(QLatin1String("\"%1\"")).arg(currentObject->type()));
             finalString.replace(QLatin1String("%objectid"),
-                                 QString(QLatin1String("\"%1\"")).arg(currentObject->id()));
+                                QString(QLatin1String("\"%1\"")).arg(currentObject->id()));
         }
 
         if (flag) {
@@ -88,10 +88,10 @@ QString Command::replaceVariables(const QString &string, bool flag) const
 
             if (mFile.exists() && mFile.isFile()) {
                 finalString.replace(QLatin1String("%executablepath"),
-                                     QString(QLatin1String("%1")).arg(mFile.absolutePath()));
+                                    QString(QLatin1String("%1")).arg(mFile.absolutePath()));
             } else {
                 finalString.replace(QLatin1String("%executablepath"),
-                                     QString(QLatin1String("")));
+                                    QString(QLatin1String("")));
             }
         }
     }

--- a/src/tiled/command.cpp
+++ b/src/tiled/command.cpp
@@ -39,20 +39,14 @@ QString Command::finalWorkingDirectory() const
     QString finalExecutable = replaceVariables(executable);
     QFileInfo mFile(finalExecutable);   //Check if executable is a path or not
 
-    if (mFile.exists() && mFile.isFile()) {
-        finalWorkingDirectory.replace(QLatin1String("%executablepath"),
-                            mFile.absolutePath());
-    } else {
-        finalWorkingDirectory.replace(QLatin1String("%executablepath"),
-                            QString(QLatin1String("")));
-    }
+    finalWorkingDirectory.replace(QLatin1String("%executablepath"), mFile.absolutePath());
 
     return finalWorkingDirectory;
 }
 
 QString Command::finalCommand() const
 {
-    QString finalCommand = QString(QLatin1String("%1 %2")).arg(executable).arg(arguments);
+    QString finalCommand = QString(QLatin1String("%1 %2")).arg(executable, arguments);
 
     return replaceVariables(finalCommand);
 }

--- a/src/tiled/command.cpp
+++ b/src/tiled/command.cpp
@@ -58,15 +58,9 @@ QString Command::replaceVariables(const QString &string, bool flag) const
         QFileInfo fileInfo(fileName);
         QString mapPath = fileInfo.absolutePath();
 
-        if (flag) {
-            finalString.replace(
-                QLatin1String("%mappath"),
-                QString(QLatin1String("%1")).arg(mapPath));
-        } else {
-            finalString.replace(
-                QLatin1String("%mappath"),
-                QString(QLatin1String("\"%1\"")).arg(mapPath));
-        }
+        finalString.replace(
+            QLatin1String("%mappath"),
+            QString(QLatin1String("\"%1\"")).arg(mapPath));
 
         if (MapDocument *mapDocument = qobject_cast<MapDocument*>(document)) {
             if (const Layer *layer = mapDocument->currentLayer()) {
@@ -81,19 +75,21 @@ QString Command::replaceVariables(const QString &string, bool flag) const
             finalString.replace(QLatin1String("%objectid"),
                                 QString(QLatin1String("\"%1\"")).arg(currentObject->id()));
         }
+    }
 
-        if (flag) {
-            QString finalExecutable = replaceVariables(executable);
-            QFileInfo mFile(finalExecutable);   //Check if executable is a path or not
+    if (flag) {
+        QString finalExecutable = replaceVariables(executable);
+        QFileInfo mFile(finalExecutable);   //Check if executable is a path or not
 
-            if (mFile.exists() && mFile.isFile()) {
-                finalString.replace(QLatin1String("%executablepath"),
-                                    QString(QLatin1String("%1")).arg(mFile.absolutePath()));
-            } else {
-                finalString.replace(QLatin1String("%executablepath"),
-                                    QString(QLatin1String("")));
-            }
+        if (mFile.exists() && mFile.isFile()) {
+            finalString.replace(QLatin1String("%executablepath"),
+                                QString(QLatin1String("%1")).arg(mFile.absolutePath()));
+        } else {
+            finalString.replace(QLatin1String("%executablepath"),
+                                QString(QLatin1String("")));
         }
+
+        finalString.replace(QLatin1String("\""), QString(QLatin1String("")));
     }
 
     return finalString;

--- a/src/tiled/command.h
+++ b/src/tiled/command.h
@@ -64,7 +64,7 @@ struct Command
 
     QString finalWorkingDirectory() const;
 
-    QString replaceVariables(const QString &string, bool flag = false) const;
+    QString replaceVariables(const QString &string, bool quotePaths = true) const;
 
     /**
      * Executes the command in the operating system shell or terminal

--- a/src/tiled/command.h
+++ b/src/tiled/command.h
@@ -64,6 +64,8 @@ struct Command
 
     QString finalWorkingDirectory() const;
 
+    QString replaceVariables(const QString &string, bool flag = false) const;
+
     /**
      * Executes the command in the operating system shell or terminal
      * application.

--- a/src/tiled/command.h
+++ b/src/tiled/command.h
@@ -36,18 +36,24 @@ struct Command
 {
     Command(bool isEnabled = true,
             QString name = QString(),
-            QString command = QString(),
+            QString executable = QString(),
+            QString arguments = QString(),
+            QString workingDirectory = QString(),
             QKeySequence shortcut = QKeySequence(),
             bool saveBeforeExecute = true)
         : isEnabled(isEnabled)
         , name(std::move(name))
-        , command(std::move(command))
+        , executable(std::move(executable))
+        , arguments(std::move(arguments))
+        , workingDirectory(std::move(workingDirectory))
         , shortcut(shortcut)
         , saveBeforeExecute(saveBeforeExecute) {}
 
     bool isEnabled;
     QString name;
-    QString command;
+    QString executable;
+    QString arguments;
+    QString workingDirectory;
     QKeySequence shortcut;
     bool saveBeforeExecute;
 

--- a/src/tiled/command.h
+++ b/src/tiled/command.h
@@ -64,7 +64,7 @@ struct Command
 
     QString finalWorkingDirectory() const;
 
-    QString replaceVariables(const QString &string, bool quotePaths = true) const;
+    QString replaceVariables(const QString &string, bool quoteValues = true) const;
 
     /**
      * Executes the command in the operating system shell or terminal

--- a/src/tiled/command.h
+++ b/src/tiled/command.h
@@ -62,6 +62,8 @@ struct Command
      */
     QString finalCommand() const;
 
+    QString finalWorkingDirectory() const;
+
     /**
      * Executes the command in the operating system shell or terminal
      * application.
@@ -94,6 +96,7 @@ private:
 
     QString mName;
     QString mFinalCommand;
+    QString mFinalWorkingDirectory;
 
 #ifdef Q_OS_MAC
     QTemporaryFile mFile;

--- a/src/tiled/commanddatamodel.cpp
+++ b/src/tiled/commanddatamodel.cpp
@@ -49,11 +49,13 @@ CommandDataModel::CommandDataModel(QObject *parent)
         // warning when clicking the command button for the first time
         Command command(false);
 #ifdef Q_OS_LINUX
-        command.command = QLatin1String("gedit %mapfile");
+        command.executable = QLatin1String("gedit");
+        command.arguments = QLatin1String("%mapfile");
 #elif defined(Q_OS_MAC)
-        command.command = QLatin1String("open -t %mapfile");
+        command.executable = QLatin1String("open");
+        command.arguments = QLatin1String("-t %mapfile");
 #endif
-        if (!command.command.isEmpty()) {
+        if (!command.executable.isEmpty()) {
             command.name = tr("Open in text editor");
             mCommands.push_back(command);
         }
@@ -400,7 +402,7 @@ bool CommandDataModel::dropMimeData(const QMimeData *data, Qt::DropAction, int,
                 if (dstRow == mCommands.size()) {
                     append(Command(addr->isEnabled,
                                    tr("%1 (copy)").arg(addr->name),
-                                   addr->command));
+                                   addr->executable, addr->arguments));
                     return true;
                 }
             }
@@ -423,12 +425,28 @@ bool CommandDataModel::dropMimeData(const QMimeData *data, Qt::DropAction, int,
     return false;
 }
 
-void CommandDataModel::setCommand(const QModelIndex &index, const QString &value)
+void CommandDataModel::setExecutable(const QModelIndex &index, const QString &value)
 {
     const bool isNormalRow = index.row() < mCommands.size();
 
     if (isNormalRow)
-        mCommands[index.row()].command = value;
+        mCommands[index.row()].executable = value;
+}
+
+void CommandDataModel::setArguments(const QModelIndex &index, const QString &value)
+{
+    const bool isNormalRow = index.row() < mCommands.size();
+
+    if (isNormalRow)
+        mCommands[index.row()].arguments = value;
+}
+
+void CommandDataModel::setWorkingDirectory(const QModelIndex &index, const QString &value)
+{
+    const bool isNormalRow = index.row() < mCommands.size();
+
+    if (isNormalRow)
+        mCommands[index.row()].workingDirectory = value;
 }
 
 void CommandDataModel::setShortcut(const QModelIndex &index, const QKeySequence &value)

--- a/src/tiled/commanddatamodel.h
+++ b/src/tiled/commanddatamodel.h
@@ -127,7 +127,9 @@ public:
     bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row,
                       int column, const QModelIndex &parent) override;
 
-    void setCommand(const QModelIndex &index, const QString &value);
+    void setExecutable(const QModelIndex &index, const QString &value);
+    void setArguments(const QModelIndex &index, const QString &value);
+    void setWorkingDirectory(const QModelIndex &index, const QString &value);
     void setShortcut(const QModelIndex &index, const QKeySequence &value);
     void setSaveBeforeExecute(const QModelIndex &index, bool value);
 

--- a/src/tiled/commanddialog.cpp
+++ b/src/tiled/commanddialog.cpp
@@ -52,13 +52,19 @@ CommandDialog::CommandDialog(QWidget *parent)
     connect(mUi->keySequenceEdit, &QKeySequenceEdit::keySequenceChanged, 
             this, &CommandDialog::setShortcut);
 
-    connect(mUi->commandEdit, &QLineEdit::textChanged,
-            this, &CommandDialog::setCommand);
+    connect(mUi->executableEdit, &QLineEdit::textChanged,
+            this, &CommandDialog::setExecutable);
+
+    connect(mUi->argumentsEdit, &QLineEdit::textChanged,
+            this, &CommandDialog::setArguments);
+
+    connect(mUi->workingDirectoryEdit, &QLineEdit::textChanged,
+            this, &CommandDialog::setWorkingDirectory);
 
     connect(mUi->treeView->selectionModel(), &QItemSelectionModel::currentChanged, 
             this, &CommandDialog::updateWidgets);
 
-    connect(mUi->browseButton, &QPushButton::clicked,
+    connect(mUi->exBrowseButton, &QPushButton::clicked,
             this, &CommandDialog::openFileDialog);
 }
 
@@ -91,11 +97,25 @@ void CommandDialog::setSaveBeforeExecute(int state)
         mUi->treeView->model()->setSaveBeforeExecute(current, state);
 }
 
-void CommandDialog::setCommand(const QString &text)
+void CommandDialog::setExecutable(const QString &text)
 {
     const QModelIndex &current = mUi->treeView->currentIndex();
     if (current.row() < mUi->treeView->model()->rowCount())
-        mUi->treeView->model()->setCommand(current, text);
+        mUi->treeView->model()->setExecutable(current, text);
+}
+
+void CommandDialog::setArguments(const QString &text)
+{
+    const QModelIndex &current = mUi->treeView->currentIndex();
+    if (current.row() < mUi->treeView->model()->rowCount())
+        mUi->treeView->model()->setArguments(current, text);
+}
+
+void CommandDialog::setWorkingDirectory(const QString &text)
+{
+    const QModelIndex &current = mUi->treeView->currentIndex();
+    if (current.row() < mUi->treeView->model()->rowCount())
+        mUi->treeView->model()->setWorkingDirectory(current, text);
 }
 
 void CommandDialog::updateWidgets(const QModelIndex &current, const QModelIndex &)
@@ -103,19 +123,25 @@ void CommandDialog::updateWidgets(const QModelIndex &current, const QModelIndex 
     bool enable = (current.row() < mUi->treeView->model()->rowCount() - 1);
 
     mUi->saveBox->setEnabled(enable);
-    mUi->commandEdit->setEnabled(enable);
-    mUi->browseButton->setEnabled(enable);
+    mUi->executableEdit->setEnabled(enable);
+    mUi->argumentsEdit->setEnabled(enable);
+    mUi->workingDirectoryEdit->setEnabled(enable);
+    mUi->exBrowseButton->setEnabled(enable);
     mUi->keySequenceEdit->setEnabled(enable);
     mUi->clearButton->setEnabled(enable);
     mUi->saveBox->setEnabled(enable);
 
     if (enable) {
         const Command command = mUi->treeView->model()->command(current);
-        mUi->commandEdit->setText(command.command);
+        mUi->executableEdit->setText(command.executable);
+        mUi->argumentsEdit->setText(command.arguments);
+        mUi->workingDirectoryEdit->setText(command.workingDirectory);
         mUi->keySequenceEdit->setKeySequence(command.shortcut);
         mUi->saveBox->setChecked(command.saveBeforeExecute);
     } else {
-        mUi->commandEdit->clear();
+        mUi->executableEdit->clear();
+        mUi->argumentsEdit->clear();
+        mUi->workingDirectoryEdit->clear();
         mUi->keySequenceEdit->clear();
     }
 }
@@ -127,7 +153,7 @@ void CommandDialog::openFileDialog()
     QString executableName = QFileDialog::getOpenFileName(this, caption, dir);
 
     if (!executableName.isEmpty())
-        mUi->commandEdit->setText(executableName);
+        mUi->executableEdit->setText(executableName);
 }
 
 CommandTreeView::CommandTreeView(QWidget *parent)

--- a/src/tiled/commanddialog.cpp
+++ b/src/tiled/commanddialog.cpp
@@ -65,7 +65,10 @@ CommandDialog::CommandDialog(QWidget *parent)
             this, &CommandDialog::updateWidgets);
 
     connect(mUi->exBrowseButton, &QPushButton::clicked,
-            this, &CommandDialog::openFileDialog);
+            this, &CommandDialog::browseExecutable);
+
+    connect(mUi->wdBrowseButton, &QPushButton::clicked,
+            this, &CommandDialog::browseWorkingDirectory);
 }
 
 CommandDialog::~CommandDialog()
@@ -146,7 +149,7 @@ void CommandDialog::updateWidgets(const QModelIndex &current, const QModelIndex 
     }
 }
 
-void CommandDialog::openFileDialog()
+void CommandDialog::browseExecutable()
 {
     QString caption = tr("Select Executable");
     QString dir = QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation);
@@ -154,6 +157,17 @@ void CommandDialog::openFileDialog()
 
     if (!executableName.isEmpty())
         mUi->executableEdit->setText(executableName);
+}
+
+void CommandDialog::browseWorkingDirectory()
+{
+    QString caption = tr("Select Working Directory");
+    QString dir = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
+    QString workingDirectoryName = QFileDialog::getExistingDirectory(this, caption, dir,
+                            QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+
+    if (!workingDirectoryName.isEmpty())
+        mUi->workingDirectoryEdit->setText(workingDirectoryName);
 }
 
 CommandTreeView::CommandTreeView(QWidget *parent)

--- a/src/tiled/commanddialog.h
+++ b/src/tiled/commanddialog.h
@@ -51,7 +51,11 @@ public slots:
 
     void setSaveBeforeExecute(int state);
 
-    void setCommand(const QString &text);
+    void setExecutable(const QString &text);
+
+    void setArguments(const QString &text);
+
+    void setWorkingDirectory(const QString &text);
 
     void updateWidgets(const QModelIndex &current, const QModelIndex&);
 

--- a/src/tiled/commanddialog.h
+++ b/src/tiled/commanddialog.h
@@ -59,7 +59,9 @@ public slots:
 
     void updateWidgets(const QModelIndex &current, const QModelIndex&);
 
-    void openFileDialog();
+    void browseExecutable();
+
+    void browseWorkingDirectory();
 
 private:
     Ui::CommandDialog *mUi;

--- a/src/tiled/commanddialog.ui
+++ b/src/tiled/commanddialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>701</width>
+    <width>857</width>
     <height>273</height>
    </rect>
   </property>
@@ -47,6 +47,9 @@
    </item>
    <item row="0" column="1">
     <layout class="QGridLayout" name="gridLayout">
+     <item row="1" column="1" colspan="2">
+      <widget class="QLineEdit" name="argumentsEdit"/>
+     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="label_2">
        <property name="sizePolicy">
@@ -61,20 +64,20 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QLineEdit" name="commandEdit">
+      <widget class="QLineEdit" name="executableEdit">
        <property name="inputMask">
         <string/>
        </property>
       </widget>
      </item>
      <item row="0" column="2">
-      <widget class="QPushButton" name="browseButton">
+      <widget class="QPushButton" name="exBrowseButton">
        <property name="text">
         <string>Browse...</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="label">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -87,7 +90,7 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="3" column="1">
       <widget class="QKeySequenceEdit" name="keySequenceEdit">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -97,21 +100,21 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="2">
+     <item row="3" column="2">
       <widget class="QPushButton" name="clearButton">
        <property name="text">
         <string>Clear</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="0" colspan="3">
+     <item row="5" column="0" colspan="3">
       <widget class="QCheckBox" name="saveBox">
        <property name="text">
         <string>&amp;Save map before executing</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="0" colspan="3">
+     <item row="6" column="0" colspan="3">
       <spacer name="verticalSpacer">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -123,6 +126,30 @@
         </size>
        </property>
       </spacer>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Arguments:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Working Directory:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="workingDirectoryEdit"/>
+     </item>
+     <item row="2" column="2">
+      <widget class="QPushButton" name="wdBrowseButton">
+       <property name="text">
+        <string>Browse...</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
This addresses #941. I've also split 'Command' to 'Executable' and 'Arguments'. I've shown the design in the issue and one of the reasons for this was `..the "Browse" button to choose the executable currently resets the command line arguments.`

A screenshot of what I've done:
![tiled-wd](https://cloud.githubusercontent.com/assets/2878908/26557409/d9dd8072-44be-11e7-81a9-d1d354ab5886.png)