### PR TITLE
Fixed relative paths in variants when symlinks are involved (fixed #1589)

### DIFF
--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -45,7 +45,7 @@ static QString colorToString(const QColor &color)
 
 QVariant MapToVariantConverter::toVariant(const Map &map, const QDir &mapDir)
 {
-    mMapDir = mapDir;
+    mMapDir = mapDir.canonicalPath();
     mGidMapper.clear();
 
     QVariantMap mapVariant;
@@ -94,7 +94,7 @@ QVariant MapToVariantConverter::toVariant(const Map &map, const QDir &mapDir)
 QVariant MapToVariantConverter::toVariant(const Tileset &tileset,
                                           const QDir &directory)
 {
-    mMapDir = directory;
+    mMapDir = directory.canonicalPath();
     return toVariant(tileset, 0);
 }
 


### PR DESCRIPTION
This PR addresses and fixes #1589.

Before this commit, the `source` variant could be messed up easily by having the tmx project as well as a tileset and its corresponding image in a directory that is really just a symlink.

In the process of exporting, `MapToVariantConverter` will at some point try to make a relative path between the output file and the tileset image.

Creating portable relative paths, however, only makes sense if the input paths are canonicalized, otherwise you may end up with garbage (refer to the example shown in the issue for details).