### PR TITLE
Added support for defining gm views with objects

### DIFF
--- a/src/plugins/gmx/gmxplugin.cpp
+++ b/src/plugins/gmx/gmxplugin.cpp
@@ -83,6 +83,26 @@ GmxPlugin::GmxPlugin()
 {
 }
 
+bool GmxPlugin::checkIfViewsDefined(LayerIterator iterator)
+{
+    while (const Layer *layer = iterator.next()) {
+
+        if (layer->layerType() != Layer::ObjectGroupType)
+            continue;
+
+        const ObjectGroup *objectLayer = static_cast<const ObjectGroup*>(layer);
+
+        for (const MapObject *object : objectLayer->objects()) {
+            const QString type = effectiveObjectType(object);
+            if (type == "view") {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 bool GmxPlugin::write(const Map *map, const QString &fileName)
 {
     SaveFile file(fileName);
@@ -111,24 +131,9 @@ bool GmxPlugin::write(const Map *map, const QString &fileName)
     writeProperty(stream, map, "persistent", false);
     writeProperty(stream, map, "clearDisplayBuffer", true);
     writeProperty(stream, map, "clearViewBackground", false);
-    // Check if views are defined
-    bool enableViews = false;
     LayerIterator iterator(map);
-    while (const Layer *layer = iterator.next()) {
-
-        if (layer->layerType() != Layer::ObjectGroupType)
-            continue;
-
-        const ObjectGroup *objectLayer = static_cast<const ObjectGroup*>(layer);
-
-          for (const MapObject *object : objectLayer->objects()) {
-            const QString type = effectiveObjectType(object);
-            if (type == "view") {
-                enableViews = true;
-                break;
-            }
-          }
-    }
+    // Check if views are defined
+    bool enableViews = checkIfViewsDefined(iterator);
     writeProperty(stream, map, "enableViews", enableViews);
 
     stream.writeTextElement("isometric", toString(map->orientation() == Map::Orientation::Isometric));
@@ -146,7 +151,7 @@ bool GmxPlugin::write(const Map *map, const QString &fileName)
 
             const ObjectGroup *objectLayer = static_cast<const ObjectGroup*>(layer);
 
-              for (const MapObject *object : objectLayer->objects()) {
+            for (const MapObject *object : objectLayer->objects()) {
                 const QString type = effectiveObjectType(object);
                 if (type != "view")
                     continue;

--- a/src/plugins/gmx/gmxplugin.cpp
+++ b/src/plugins/gmx/gmxplugin.cpp
@@ -110,8 +110,61 @@ bool GmxPlugin::write(const Map *map, const QString &fileName)
     writeProperty(stream, map, "speed", 30);
     writeProperty(stream, map, "persistent", false);
     writeProperty(stream, map, "clearDisplayBuffer", true);
+    writeProperty(stream, map, "clearViewBackground", false);
+    writeProperty(stream, map, "enableViews", false);
 
     stream.writeTextElement("isometric", toString(map->orientation() == Map::Orientation::Isometric));
+
+    // Write out views
+    // Last view in Object layer is the first view in the room
+    stream.writeStartElement("views");
+    LayerIterator iterator(map);
+    int viewCount = 0;
+    while (const Layer *layer = iterator.next()) {
+
+        if (layer->layerType() != Layer::ObjectGroupType)
+            continue;
+
+        const ObjectGroup *objectLayer = static_cast<const ObjectGroup*>(layer);
+
+          for (const MapObject *object : objectLayer->objects()) {
+            const QString type = effectiveObjectType(object);
+            if (type.isEmpty())
+                continue;
+            if (type.operator !=("view"))
+                continue;
+
+            // GM only has 8 views so drop anything more than that
+            if (viewCount > 7)
+                break;
+
+            viewCount++;
+            stream.writeStartElement("view");
+
+            stream.writeAttribute("visible", toString(object->isVisible()));
+            stream.writeAttribute("objName", QString(optionalProperty(object, "objName", QString(""))));
+            QPointF pos = object->position();
+            // Note: GM only supports ints for positioning
+            // so views could be off if user doesn't align to whole number
+            stream.writeAttribute("xview", QString::number(qRound(pos.x())));
+            stream.writeAttribute("yview", QString::number(qRound(pos.y())));
+            stream.writeAttribute("wview", QString::number(qRound(object->width())));
+            stream.writeAttribute("hview", QString::number(qRound(object->height())));
+            // Round these incase user adds properties as floats and not ints
+            stream.writeAttribute("xport", QString::number(qRound(optionalProperty(object, "xport", 0.0))));
+            stream.writeAttribute("yport", QString::number(qRound(optionalProperty(object, "yport", 0.0))));
+            stream.writeAttribute("wport", QString::number(qRound(optionalProperty(object, "wport", 1024.0))));
+            stream.writeAttribute("hport", QString::number(qRound(optionalProperty(object, "hport", 768.0))));
+            stream.writeAttribute("hborder", QString::number(qRound(optionalProperty(object, "hborder", 32.0))));
+            stream.writeAttribute("vborder", QString::number(qRound(optionalProperty(object, "vborder", 32.0))));
+            stream.writeAttribute("hspeed", QString::number(qRound(optionalProperty(object, "hspeed", -1.0))));
+            stream.writeAttribute("vspeed", QString::number(qRound(optionalProperty(object, "vspeed", -1.0))));
+
+            stream.writeEndElement();
+        }
+    }
+
+    stream.writeEndElement();
 
     stream.writeStartElement("instances");
 
@@ -119,7 +172,7 @@ bool GmxPlugin::write(const Map *map, const QString &fileName)
     int layerCount = 0;
 
     // Write out object instances
-    LayerIterator iterator(map);
+    iterator.toFront();
     while (const Layer *layer = iterator.next()) {
         ++layerCount;
 
@@ -131,6 +184,8 @@ bool GmxPlugin::write(const Map *map, const QString &fileName)
         for (const MapObject *object : objectLayer->objects()) {
             const QString type = effectiveObjectType(object);
             if (type.isEmpty())
+                continue;
+            if (type.operator ==("view"))
                 continue;
 
             stream.writeStartElement("instance");

--- a/src/plugins/gmx/gmxplugin.cpp
+++ b/src/plugins/gmx/gmxplugin.cpp
@@ -79,12 +79,9 @@ static QString effectiveObjectType(const MapObject *object)
     return QString();
 }
 
-GmxPlugin::GmxPlugin()
+static bool checkIfViewsDefined(const Map *map)
 {
-}
-
-bool GmxPlugin::checkIfViewsDefined(LayerIterator iterator)
-{
+    LayerIterator iterator(map);
     while (const Layer *layer = iterator.next()) {
 
         if (layer->layerType() != Layer::ObjectGroupType)
@@ -94,13 +91,16 @@ bool GmxPlugin::checkIfViewsDefined(LayerIterator iterator)
 
         for (const MapObject *object : objectLayer->objects()) {
             const QString type = effectiveObjectType(object);
-            if (type == "view") {
+            if (type == "view")
                 return true;
-            }
         }
     }
 
     return false;
+}
+
+GmxPlugin::GmxPlugin()
+{
 }
 
 bool GmxPlugin::write(const Map *map, const QString &fileName)
@@ -131,18 +131,18 @@ bool GmxPlugin::write(const Map *map, const QString &fileName)
     writeProperty(stream, map, "persistent", false);
     writeProperty(stream, map, "clearDisplayBuffer", true);
     writeProperty(stream, map, "clearViewBackground", false);
-    LayerIterator iterator(map);
+
     // Check if views are defined
-    bool enableViews = checkIfViewsDefined(iterator);
+    bool enableViews = checkIfViewsDefined(map);
     writeProperty(stream, map, "enableViews", enableViews);
 
     stream.writeTextElement("isometric", toString(map->orientation() == Map::Orientation::Isometric));
 
     // Write out views
     // Last view in Object layer is the first view in the room
+    LayerIterator iterator(map);
     if (enableViews) {
         stream.writeStartElement("views");
-        iterator.toFront();
         int viewCount = 0;
         while (const Layer *layer = iterator.next()) {
 

--- a/src/plugins/gmx/gmxplugin.h
+++ b/src/plugins/gmx/gmxplugin.h
@@ -24,6 +24,8 @@
 
 #include "gmx_global.h"
 
+#include "layer.h"
+
 namespace Gmx {
 
 class GMXSHARED_EXPORT GmxPlugin : public Tiled::WritableMapFormat
@@ -43,6 +45,7 @@ protected:
 
 private:
     QString mError;
+    bool checkIfViewsDefined(Tiled::LayerIterator iterator);
 };
 
 } // namespace Gmx

--- a/src/plugins/gmx/gmxplugin.h
+++ b/src/plugins/gmx/gmxplugin.h
@@ -24,8 +24,6 @@
 
 #include "gmx_global.h"
 
-#include "layer.h"
-
 namespace Gmx {
 
 class GMXSHARED_EXPORT GmxPlugin : public Tiled::WritableMapFormat
@@ -45,7 +43,6 @@ protected:
 
 private:
     QString mError;
-    bool checkIfViewsDefined(Tiled::LayerIterator iterator);
 };
 
 } // namespace Gmx


### PR DESCRIPTION
Okay this adds the ability to define views in game maker by creating an object in tiled.
Set it to the size you want your view. Make sure x,y,width,height, etc are all Ints because thats what GM uses. Numbers will be rounded but that could lead to unexpected results.

If this looks good i can add some better docs and maybe some screen shots
Basically create an object set type to "view"
properties can be defined on the object the match gms properties like so:

![igzo9iw](https://user-images.githubusercontent.com/531764/27475845-e43f5648-5806-11e7-9aec-978230560d0c.png)

Views must be enabled in the map properties since this config comes before views are defined unless you can think of a better way of auto detecting them. I didn't want to iterate through the layers again just to find out if the views were defined. But we could?
Map Properties:
![fq9h23d](https://user-images.githubusercontent.com/531764/27430942-cb011a8e-574a-11e7-8c78-a60fa8dad62e.png)
