### PR TITLE
Implement .tbin file format

### DIFF
--- a/src/plugins/plugins.qbs
+++ b/src/plugins/plugins.qbs
@@ -10,6 +10,7 @@ Project {
         "lua",
         "python",
         "replicaisland",
+        "tbin",
         "tengine",
         "tmw",
         "gmx"

--- a/src/plugins/tbin/plugin.json
+++ b/src/plugins/tbin/plugin.json
@@ -1,0 +1,1 @@
+{ "defaultEnable": true }

--- a/src/plugins/tbin/plugin.json
+++ b/src/plugins/tbin/plugin.json
@@ -1,1 +1,1 @@
-{ "defaultEnable": true }
+{ "defaultEnable": false }

--- a/src/plugins/tbin/tbin.pro
+++ b/src/plugins/tbin/tbin.pro
@@ -1,6 +1,6 @@
 include(../plugin.pri)
 
-DEFINES += JSON_LIBRARY
+DEFINES += TBIN_LIBRARY
 
 SOURCES += tbinplugin.cpp \
     tbin/Map.cpp
@@ -11,4 +11,5 @@ HEADERS += tbin_global.h \
     tbin/Map.hpp \
     tbin/PropertyValue.hpp \
     tbin/Tile.hpp \
-    tbin/TileSheet.hpp
+    tbin/TileSheet.hpp \
+    tbin/FakeSfml.hpp

--- a/src/plugins/tbin/tbin.pro
+++ b/src/plugins/tbin/tbin.pro
@@ -1,0 +1,14 @@
+include(../plugin.pri)
+
+DEFINES += JSON_LIBRARY
+
+SOURCES += tbinplugin.cpp \
+    tbin/Map.cpp
+
+HEADERS += tbin_global.h \
+    tbinplugin.h \
+    tbin/Layer.hpp \
+    tbin/Map.hpp \
+    tbin/PropertyValue.hpp \
+    tbin/Tile.hpp \
+    tbin/TileSheet.hpp

--- a/src/plugins/tbin/tbin.qbs
+++ b/src/plugins/tbin/tbin.qbs
@@ -14,5 +14,6 @@ TiledPlugin {
         "tbin/PropertyValue.hpp",
         "tbin/Tile.hpp",
         "tbin/TileSheet.hpp",
+        "tbin/FakeSfml.hpp",
     ]
 }

--- a/src/plugins/tbin/tbin.qbs
+++ b/src/plugins/tbin/tbin.qbs
@@ -1,0 +1,18 @@
+import qbs 1.0
+
+TiledPlugin {
+    cpp.defines: ["TBIN_LIBRARY"]
+
+    files: [
+        "tbin_global.h"
+        "tbinplugin.cpp",
+        "tbinplugin.h",
+        "plugin.json",
+        "tbin/Layer.hpp",
+        "tbin/Map.cpp",
+        "tbin/Map.hpp",
+        "tbin/PropertyValue.hpp",
+        "tbin/Tile.hpp",
+        "tbin/TileSheet.hpp",
+    ]
+}

--- a/src/plugins/tbin/tbin.qbs
+++ b/src/plugins/tbin/tbin.qbs
@@ -4,7 +4,7 @@ TiledPlugin {
     cpp.defines: ["TBIN_LIBRARY"]
 
     files: [
-        "tbin_global.h"
+        "tbin_global.h",
         "tbinplugin.cpp",
         "tbinplugin.h",
         "plugin.json",

--- a/src/plugins/tbin/tbin/FakeSfml.hpp
+++ b/src/plugins/tbin/tbin/FakeSfml.hpp
@@ -1,0 +1,11 @@
+#ifndef FAKESFML_HPP
+#define FAKESFML_HPP
+
+namespace sf
+{
+    typedef int Int32;
+    typedef unsigned char Uint8;
+    struct Vector2i { Int32 x; Int32 y };
+}
+
+#endif // FAKESFML_HPP

--- a/src/plugins/tbin/tbin/FakeSfml.hpp
+++ b/src/plugins/tbin/tbin/FakeSfml.hpp
@@ -5,7 +5,14 @@ namespace sf
 {
     typedef int Int32;
     typedef unsigned char Uint8;
-    struct Vector2i { Int32 x; Int32 y };
+    struct Vector2i
+    {
+        Int32 x;
+        Int32 y;
+
+        Vector2i() : x(0),y(0) {}
+        Vector2i( Int32 x, Int32 y ) : x(x), y(y) {}
+    };
 }
 
 #endif // FAKESFML_HPP

--- a/src/plugins/tbin/tbin/Layer.hpp
+++ b/src/plugins/tbin/tbin/Layer.hpp
@@ -1,0 +1,27 @@
+#ifndef TBIN_LAYER_HPP
+#define TBIN_LAYER_HPP
+
+#include <SFML/System/Vector2.hpp>
+#include <string>
+#include <vector>
+
+#include "fakeSfml.hpp"
+#include "tbin/PropertyValue.hpp"
+#include "tbin/Tile.hpp"
+
+namespace tbin
+{
+    struct Layer
+    {
+        public:
+            std::string id;
+            bool visible;
+            std::string desc;
+            sf::Vector2i layerSize;
+            sf::Vector2i tileSize;
+            Properties props;
+            std::vector< Tile > tiles;
+    };
+}
+
+#endif // TBIN_LAYER_HPP

--- a/src/plugins/tbin/tbin/Layer.hpp
+++ b/src/plugins/tbin/tbin/Layer.hpp
@@ -1,3 +1,28 @@
+/*
+ * TBIN
+ * Copyright 2017, Chase Warrington <spacechase0.and.cat@gmail.com>
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #ifndef TBIN_LAYER_HPP
 #define TBIN_LAYER_HPP
 

--- a/src/plugins/tbin/tbin/Layer.hpp
+++ b/src/plugins/tbin/tbin/Layer.hpp
@@ -1,13 +1,13 @@
 #ifndef TBIN_LAYER_HPP
 #define TBIN_LAYER_HPP
 
-#include <SFML/System/Vector2.hpp>
+//#include <SFML/System/Vector2.hpp>
 #include <string>
 #include <vector>
 
-#include "fakeSfml.hpp"
-#include "tbin/PropertyValue.hpp"
-#include "tbin/Tile.hpp"
+#include "FakeSfml.hpp"
+#include "PropertyValue.hpp"
+#include "Tile.hpp"
 
 namespace tbin
 {

--- a/src/plugins/tbin/tbin/Map.cpp
+++ b/src/plugins/tbin/tbin/Map.cpp
@@ -1,0 +1,381 @@
+#include "tbin/Map.hpp"
+
+#include <fstream>
+#include <stdexcept>
+
+#include "FakeSfml.hpp"
+
+namespace tbin
+{
+    template< typename T >
+    T read( std::istream& in )
+    {
+        T t;
+        in.read( reinterpret_cast< char* >( &t ), sizeof( T ) );
+        return t;
+    }
+
+    template<>
+    sf::Vector2i read< sf::Vector2i >( std::istream& in )
+    {
+        sf::Int32 x = read< sf::Int32 >( in );
+        sf::Int32 y = read< sf::Int32 >( in );
+        return sf::Vector2i( x, y );
+    }
+
+    template<>
+    std::string read< std::string >( std::istream& in )
+    {
+        auto len = read< sf::Int32 >( in );
+        std::string str( len, 0 );
+        in.read( &str[ 0 ], len );
+        return str;
+    }
+
+    template< typename T >
+    void write( std::ostream& out, const T& t )
+    {
+        out.write( reinterpret_cast< const char* >( &t ), sizeof( T ) );
+    }
+
+    template<>
+    void write< sf::Vector2i >( std::ostream& out, const sf::Vector2i& vec )
+    {
+        write< sf::Int32 >( out, vec.x );
+        write< sf::Int32 >( out, vec.y );
+    }
+
+    template<>
+    void write< std::string >( std::ostream& out, const std::string& str )
+    {
+        write< sf::Int32 >( out, str.length() );
+        out.write( &str[ 0 ], str.length() );
+    }
+
+    Properties readProperties( std::istream& in )
+    {
+        Properties ret;
+
+        int count = read< sf::Int32 >( in );
+        for ( int i = 0; i < count; ++i )
+        {
+            std::string key;
+            PropertyValue value;
+
+            key = read< std::string >( in );
+            value.type = static_cast< PropertyValue::Type >( read< sf::Uint8 >( in ) );
+            switch ( value.type )
+            {
+                case PropertyValue::Bool:    value.data.b  = read< sf::Uint8   >( in ) > 0; break;
+                case PropertyValue::Integer: value.data.i  = read< sf::Int32   >( in );     break;
+                case PropertyValue::Float:   value.data.f  = read< float       >( in );     break;
+                case PropertyValue::String:  value.dataStr = read< std::string >( in );     break;
+                default: throw std::invalid_argument( util::format( "Bad property type: $", static_cast< int >( value.type ) ) );
+            }
+
+            ret[ key ] = value;
+        }
+
+
+        return std::move( ret );
+    }
+
+    void writeProperties( std::ostream& out, const Properties& props )
+    {
+        write< sf::Int32 >( out, props.size() );
+        for ( const auto& prop : props )
+        {
+            write( out, prop.first );
+            write< sf::Uint8 >( out, prop.second.type );
+            switch ( prop.second.type )
+            {
+                case PropertyValue::Bool: write< sf::Uint8 >( out, prop.second.data.b ? 1 : 0 ); break;
+                case PropertyValue::Integer: write( out, prop.second.data.i ); break;
+                case PropertyValue::Float: write( out, prop.second.data.f ); break;
+                case PropertyValue::String: write( out, prop.second.dataStr ); break;
+                default: throw std::invalid_argument( util::format( "Bad property type: $", prop.second.type ) );
+            }
+        }
+    }
+
+    TileSheet readTilesheet( std::istream& in )
+    {
+        TileSheet ret;
+        ret.id = read< std::string >( in );
+        ret.desc = read< std::string >( in );
+        ret.image = read< std::string >( in );
+        ret.sheetSize = read< sf::Vector2i >( in );
+        ret.tileSize = read< sf::Vector2i >( in );
+        ret.margin = read< sf::Vector2i >( in );
+        ret.spacing = read< sf::Vector2i >( in );
+        ret.props = readProperties( in );
+        return std::move( ret );
+    }
+
+    void writeTilesheet( std::ostream& out, const TileSheet& ts )
+    {
+        write( out, ts.id );
+        write( out, ts.desc );
+        write( out, ts.image );
+        write( out, ts.sheetSize );
+        write( out, ts.tileSize );
+        write( out, ts.margin );
+        write( out, ts.spacing );
+        writeProperties( out, ts.props );
+    }
+
+    Tile readStaticTile( std::istream& in, const std::string& currTilesheet )
+    {
+        Tile ret;
+        ret.tilesheet = currTilesheet;
+        ret.staticData.tileIndex = read< sf::Int32 >( in );
+        ret.staticData.blendMode = read< sf::Uint8 >( in );
+        ret.props = readProperties( in );
+        return std::move( ret );
+    }
+
+    void writeStaticTile( std::ostream& out, const Tile& tile )
+    {
+        write( out, tile.staticData.tileIndex );
+        write( out, tile.staticData.blendMode );
+        writeProperties( out, tile.props );
+    }
+
+    Tile readAnimatedTile( std::istream& in )
+    {
+        Tile ret;
+        ret.animatedData.frameInterval = read< sf::Int32 >( in );
+
+        int frameCount = read< sf::Int32 >( in );
+        ret.animatedData.frames.reserve( frameCount );
+        std::string currTilesheet;
+        for ( int i = 0; i < frameCount; )
+        {
+            char c = in.get();
+            switch ( c )
+            {
+                case 'T':
+                    currTilesheet = read< std::string >( in );
+                    break;
+                case 'S':
+                    ret.animatedData.frames.push_back( readStaticTile( in, currTilesheet ) );
+                    ++i;
+                    break;
+                default:
+                    throw std::invalid_argument( util::format( "Bad layer tile data: $", c ) );
+            }
+        }
+
+        ret.props = readProperties( in );
+
+        return std::move( ret );
+    }
+
+    void writeAnimatedTile( std::ostream& out, const Tile& tile )
+    {
+        write( out, tile.animatedData.frameInterval );
+        write( out, tile.animatedData.frames.size() );
+
+        std::string currTilesheet;
+        for ( const Tile& tile : tile.animatedData.frames )
+        {
+            if ( tile.tilesheet != currTilesheet )
+            {
+                write< sf::Uint8 >( out, 'T' );
+                write( out, tile.tilesheet );
+                currTilesheet = tile.tilesheet;
+            }
+
+            write< sf::Uint8 >( out, 'S' );
+            writeStaticTile( out, tile );
+        }
+    }
+
+    Layer readLayer( std::istream& in )
+    {
+        Layer ret;
+        ret.id = read< std::string >( in );
+        ret.visible = read< sf::Uint8 >( in ) > 0;
+        ret.desc = read< std::string >( in );
+        ret.layerSize = read< sf::Vector2i >( in );
+        ret.tileSize = read< sf::Vector2i >( in );
+        ret.props = readProperties( in );
+
+        Tile nullTile; nullTile.staticData.tileIndex = -1;
+        ret.tiles.resize( ret.layerSize.x * ret.layerSize.y, nullTile );
+
+        std::string currTilesheet = "";
+        for ( int iy = 0; iy < ret.layerSize.y; ++iy )
+        {
+            int ix = 0;
+            while ( ix < ret.layerSize.x )
+            {
+                sf::Uint8 c = read< sf::Uint8 >( in );
+                switch ( c )
+                {
+                    case 'N':
+                        ix += read< sf::Int32 >( in );
+                        break;
+                    case 'S':
+                        ret.tiles[ ix + iy * ret.layerSize.x ] = std::move( readStaticTile( in, currTilesheet ) );
+                        ++ix;
+                        break;
+                    case 'A':
+                        ret.tiles[ ix + iy * ret.layerSize.x ] = std::move( readAnimatedTile( in ) );
+                        ++ix;
+                        break;
+                    case 'T':
+                        currTilesheet = read< std::string >( in );
+                        break;
+                    default:
+                        throw std::invalid_argument( util::format( "Bad layer tile data: $ @ $", static_cast< int >( c ), in.tellg() - 1 ) );
+                }
+            }
+        }
+
+        return std::move( ret );
+    }
+
+    void writeLayer( std::ostream& out, const Layer& layer )
+    {
+        write( out, layer.id );
+        write< sf::Uint8 >( out, layer.visible ? 1 : 0 );
+        write( out, layer.desc );
+        write( out, layer.layerSize );
+        write( out, layer.tileSize );
+        writeProperties( out, layer.props );
+
+        std::string currTilesheet = "";
+        for ( int iy = 0; iy < layer.layerSize.y; ++iy )
+        {
+            sf::Int32 nulls = 0;
+            for ( int ix = 0; ix < layer.layerSize.x; ++ix )
+            {
+                const Tile& tile = layer.tiles[ ix + iy * layer.layerSize.x ];
+
+                if ( tile.isNullTile() )
+                {
+                    ++nulls;
+                    continue;
+                }
+
+                if ( nulls > 0 )
+                {
+                    write< sf::Uint8 >( out, 'N' );
+                    write( out, nulls );
+                    nulls = 0;
+                }
+
+                if ( tile.tilesheet != currTilesheet )
+                {
+                    write< sf::Uint8 >( out, 'T' );
+                    write( out, tile.tilesheet );
+                    currTilesheet = tile.tilesheet;
+                }
+
+                if ( tile.animatedData.frames.size() == 0 )
+                {
+                    write< sf::Uint8 >( out, 'S' );
+                    writeStaticTile( out, tile );
+                }
+                else
+                {
+                    write< sf::Uint8 >( out, 'A' );
+                    writeAnimatedTile( out, tile );
+                }
+            }
+
+            if ( nulls > 0 )
+            {
+                write< sf::Uint8 >( out, 'N' );
+                write( out, nulls );
+            }
+        }
+    }
+
+    constexpr const char* MAGIC_1_0 = "tBIN10";
+
+    bool Map::loadFromFile( const std::string& path )
+    {
+        std::ifstream file( path, std::ifstream::binary );
+        if ( !file )
+        {
+            throw std::runtime_error( "Failed to open file." );
+            return false;
+        }
+
+        return loadFromStream( file );
+    }
+
+    bool Map::loadFromStream( std::istream& in )
+    {
+        in.exceptions( std::ifstream::failbit );
+
+        std::string magic( 6, '\0' );
+        in.read( &magic[ 0 ], 6 );
+        if ( magic != MAGIC_1_0 )
+        {
+            throw std::runtime_error( "File is not a tbin file." );
+            return false;
+        }
+
+        std::string id = read< std::string >( in );
+        std::string desc = read< std::string >( in );
+        Properties props = readProperties( in );
+
+        std::vector< TileSheet > tilesheets;
+        int tilesheetCount = read< sf::Int32 >( in );
+        for ( int i = 0; i < tilesheetCount; ++i )
+        {
+            tilesheets.push_back( readTilesheet( in ) );
+        }
+
+        std::vector< Layer > layers;
+        int layerCount = read< sf::Int32 >( in );
+        for ( int i = 0; i < layerCount; ++i )
+        {
+            layers.push_back( readLayer( in ) );
+        }
+
+        std::swap( this->id, id );
+        std::swap( this->desc, desc );
+        std::swap( this->props, props );
+        std::swap( this->tilesheets, tilesheets );
+        std::swap( this->layers, layers );
+
+        return true;
+    }
+
+    bool Map::saveToFile( const std::string& path ) const
+    {
+        std::ofstream file( path, std::ofstream::binary | std::ofstream::trunc );
+        if ( !file )
+        {
+            throw std::runtime_error( "Failed to open file." );
+            return false;
+        }
+
+        return saveToStream( file );
+    }
+
+    bool Map::saveToStream( std::ostream& out ) const
+    {
+        out.exceptions( std::ifstream::failbit );
+
+        out.write( MAGIC_1_0, 6 );
+
+        write( out, id );
+        write( out, desc );
+        writeProperties( out, props );
+
+        write< sf::Int32 >( out, tilesheets.size() );
+        for ( const TileSheet& ts : tilesheets )
+            writeTilesheet( out, ts );
+
+        write< sf::Int32 >( out, layers.size() );
+        for ( const Layer& layer : layers )
+            writeLayer( out, layer );
+
+        return true;
+    }
+}

--- a/src/plugins/tbin/tbin/Map.cpp
+++ b/src/plugins/tbin/tbin/Map.cpp
@@ -178,13 +178,13 @@ namespace tbin
         write< sf::Int32 >( out, tile.animatedData.frames.size() );
 
         std::string currTilesheet;
-        for ( const Tile& tile : tile.animatedData.frames )
+        for ( const Tile& frame : tile.animatedData.frames )
         {
-            if ( tile.tilesheet != currTilesheet )
+            if ( frame.tilesheet != currTilesheet )
             {
                 write< sf::Uint8 >( out, 'T' );
-                write( out, tile.tilesheet );
-                currTilesheet = tile.tilesheet;
+                write( out, frame.tilesheet );
+                currTilesheet = frame.tilesheet;
             }
 
             write< sf::Uint8 >( out, 'S' );

--- a/src/plugins/tbin/tbin/Map.cpp
+++ b/src/plugins/tbin/tbin/Map.cpp
@@ -190,6 +190,8 @@ namespace tbin
             write< sf::Uint8 >( out, 'S' );
             writeStaticTile( out, tile );
         }
+
+        writeProperties( out, tile.props );
     }
 
     Layer readLayer( std::istream& in )

--- a/src/plugins/tbin/tbin/Map.cpp
+++ b/src/plugins/tbin/tbin/Map.cpp
@@ -71,7 +71,7 @@ namespace tbin
                 case PropertyValue::Integer: value.data.i  = read< sf::Int32   >( in );     break;
                 case PropertyValue::Float:   value.data.f  = read< float       >( in );     break;
                 case PropertyValue::String:  value.dataStr = read< std::string >( in );     break;
-                default: throw std::invalid_argument( "Bad property type: " + std::to_string( value.type ) );
+                default: throw std::invalid_argument( QT_TR_NOOP( "Bad property type: " + std::to_string( value.type ) ) );
             }
 
             ret[ key ] = value;
@@ -94,7 +94,7 @@ namespace tbin
                 case PropertyValue::Integer: write( out, prop.second.data.i ); break;
                 case PropertyValue::Float: write( out, prop.second.data.f ); break;
                 case PropertyValue::String: write( out, prop.second.dataStr ); break;
-                default: throw std::invalid_argument( "Bad property type: " + std::to_string( prop.second.type ) );
+                default: throw std::invalid_argument( QT_TR_NOOP( "Bad property type" ) );
             }
         }
     }
@@ -163,7 +163,7 @@ namespace tbin
                     ++i;
                     break;
                 default:
-                    throw std::invalid_argument( "Bad layer tile data: " + std::to_string( c ) );
+                    throw std::invalid_argument( QT_TR_NOOP( "Bad layer tile data" ) );
             }
         }
 
@@ -231,7 +231,7 @@ namespace tbin
                         currTilesheet = read< std::string >( in );
                         break;
                     default:
-                        throw std::invalid_argument( "Bad layer tile data: " + std::to_string( static_cast< int >( c ) ) + " @ " + std::to_string( in.tellg() - 1 ) );
+                        throw std::invalid_argument( QT_TR_NOOP( "Bad layer tile data" ) );
                 }
             }
         }
@@ -303,7 +303,7 @@ namespace tbin
         std::ifstream file( path, std::ifstream::binary );
         if ( !file )
         {
-            throw std::runtime_error( "Failed to open file." );
+            throw std::runtime_error( QT_TR_NOOP( "Failed to open file." ) );
             return false;
         }
 
@@ -318,7 +318,7 @@ namespace tbin
         in.read( &magic[ 0 ], 6 );
         if ( magic != MAGIC_1_0 )
         {
-            throw std::runtime_error( "File is not a tbin file." );
+            throw std::runtime_error( QT_TR_NOOP( "File is not a tbin file." ) );
             return false;
         }
 
@@ -354,7 +354,7 @@ namespace tbin
         std::ofstream file( path, std::ofstream::binary | std::ofstream::trunc );
         if ( !file )
         {
-            throw std::runtime_error( "Failed to open file." );
+            throw std::runtime_error( QT_TR_NOOP( "Failed to open file." ) );
             return false;
         }
 

--- a/src/plugins/tbin/tbin/Map.cpp
+++ b/src/plugins/tbin/tbin/Map.cpp
@@ -78,7 +78,7 @@ namespace tbin
         }
 
 
-        return std::move( ret );
+        return ret;
     }
 
     void writeProperties( std::ostream& out, const Properties& props )
@@ -110,7 +110,7 @@ namespace tbin
         ret.margin = read< sf::Vector2i >( in );
         ret.spacing = read< sf::Vector2i >( in );
         ret.props = readProperties( in );
-        return std::move( ret );
+        return ret;
     }
 
     void writeTilesheet( std::ostream& out, const TileSheet& ts )
@@ -132,7 +132,7 @@ namespace tbin
         ret.staticData.tileIndex = read< sf::Int32 >( in );
         ret.staticData.blendMode = read< sf::Uint8 >( in );
         ret.props = readProperties( in );
-        return std::move( ret );
+        return ret;
     }
 
     void writeStaticTile( std::ostream& out, const Tile& tile )
@@ -169,7 +169,7 @@ namespace tbin
 
         ret.props = readProperties( in );
 
-        return std::move( ret );
+        return ret;
     }
 
     void writeAnimatedTile( std::ostream& out, const Tile& tile )
@@ -236,7 +236,7 @@ namespace tbin
             }
         }
 
-        return std::move( ret );
+        return ret;
     }
 
     void writeLayer( std::ostream& out, const Layer& layer )

--- a/src/plugins/tbin/tbin/Map.cpp
+++ b/src/plugins/tbin/tbin/Map.cpp
@@ -71,7 +71,7 @@ namespace tbin
                 case PropertyValue::Integer: value.data.i  = read< sf::Int32   >( in );     break;
                 case PropertyValue::Float:   value.data.f  = read< float       >( in );     break;
                 case PropertyValue::String:  value.dataStr = read< std::string >( in );     break;
-                default: throw std::invalid_argument( QT_TR_NOOP( "Bad property type: " + std::to_string( value.type ) ) );
+                default: throw std::invalid_argument( QT_TR_NOOP( "Bad property type" ) );
             }
 
             ret[ key ] = value;
@@ -175,7 +175,7 @@ namespace tbin
     void writeAnimatedTile( std::ostream& out, const Tile& tile )
     {
         write( out, tile.animatedData.frameInterval );
-        write( out, tile.animatedData.frames.size() );
+        write< sf::Int32 >( out, tile.animatedData.frames.size() );
 
         std::string currTilesheet;
         for ( const Tile& tile : tile.animatedData.frames )

--- a/src/plugins/tbin/tbin/Map.cpp
+++ b/src/plugins/tbin/tbin/Map.cpp
@@ -245,11 +245,11 @@ namespace tbin
                         ix += read< sf::Int32 >( in );
                         break;
                     case 'S':
-                        ret.tiles[ ix + iy * ret.layerSize.x ] = std::move( readStaticTile( in, currTilesheet ) );
+                        ret.tiles[ ix + iy * ret.layerSize.x ] = readStaticTile( in, currTilesheet );
                         ++ix;
                         break;
                     case 'A':
-                        ret.tiles[ ix + iy * ret.layerSize.x ] = std::move( readAnimatedTile( in ) );
+                        ret.tiles[ ix + iy * ret.layerSize.x ] = readAnimatedTile( in );
                         ++ix;
                         break;
                     case 'T':

--- a/src/plugins/tbin/tbin/Map.cpp
+++ b/src/plugins/tbin/tbin/Map.cpp
@@ -1,7 +1,8 @@
-#include "tbin/Map.hpp"
+#include "Map.hpp"
 
 #include <fstream>
 #include <stdexcept>
+#include <QDebug>
 
 #include "FakeSfml.hpp"
 
@@ -70,7 +71,7 @@ namespace tbin
                 case PropertyValue::Integer: value.data.i  = read< sf::Int32   >( in );     break;
                 case PropertyValue::Float:   value.data.f  = read< float       >( in );     break;
                 case PropertyValue::String:  value.dataStr = read< std::string >( in );     break;
-                default: throw std::invalid_argument( util::format( "Bad property type: $", static_cast< int >( value.type ) ) );
+                default: throw std::invalid_argument( "Bad property type: " + std::to_string( value.type ) );
             }
 
             ret[ key ] = value;
@@ -93,7 +94,7 @@ namespace tbin
                 case PropertyValue::Integer: write( out, prop.second.data.i ); break;
                 case PropertyValue::Float: write( out, prop.second.data.f ); break;
                 case PropertyValue::String: write( out, prop.second.dataStr ); break;
-                default: throw std::invalid_argument( util::format( "Bad property type: $", prop.second.type ) );
+                default: throw std::invalid_argument( "Bad property type: " + std::to_string( prop.second.type ) );
             }
         }
     }
@@ -162,7 +163,7 @@ namespace tbin
                     ++i;
                     break;
                 default:
-                    throw std::invalid_argument( util::format( "Bad layer tile data: $", c ) );
+                    throw std::invalid_argument( "Bad layer tile data: " + std::to_string( c ) );
             }
         }
 
@@ -228,7 +229,7 @@ namespace tbin
                         currTilesheet = read< std::string >( in );
                         break;
                     default:
-                        throw std::invalid_argument( util::format( "Bad layer tile data: $ @ $", static_cast< int >( c ), in.tellg() - 1 ) );
+                        throw std::invalid_argument( "Bad layer tile data: " + std::to_string( static_cast< int >( c ) ) + " @ " + std::to_string( in.tellg() - 1 ) );
                 }
             }
         }

--- a/src/plugins/tbin/tbin/Map.cpp
+++ b/src/plugins/tbin/tbin/Map.cpp
@@ -296,7 +296,7 @@ namespace tbin
         }
     }
 
-    constexpr const char* MAGIC_1_0 = "tBIN10";
+    Q_DECL_CONSTEXPR const char* MAGIC_1_0 = "tBIN10";
 
     bool Map::loadFromFile( const std::string& path )
     {

--- a/src/plugins/tbin/tbin/Map.cpp
+++ b/src/plugins/tbin/tbin/Map.cpp
@@ -1,3 +1,28 @@
+/*
+ * TBIN
+ * Copyright 2017, Chase Warrington <spacechase0.and.cat@gmail.com>
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #include "Map.hpp"
 
 #include <fstream>

--- a/src/plugins/tbin/tbin/Map.hpp
+++ b/src/plugins/tbin/tbin/Map.hpp
@@ -1,3 +1,28 @@
+/*
+ * TBIN
+ * Copyright 2017, Chase Warrington <spacechase0.and.cat@gmail.com>
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #ifndef TBIN_MAP_HPP
 #define TBIN_MAP_HPP
 

--- a/src/plugins/tbin/tbin/Map.hpp
+++ b/src/plugins/tbin/tbin/Map.hpp
@@ -6,9 +6,9 @@
 #include <string>
 #include <vector>
 
-#include "tbin/Layer.hpp"
-#include "tbin/PropertyValue.hpp"
-#include "tbin/TileSheet.hpp"
+#include "Layer.hpp"
+#include "PropertyValue.hpp"
+#include "TileSheet.hpp"
 
 namespace tbin
 {

--- a/src/plugins/tbin/tbin/Map.hpp
+++ b/src/plugins/tbin/tbin/Map.hpp
@@ -1,0 +1,32 @@
+#ifndef TBIN_MAP_HPP
+#define TBIN_MAP_HPP
+
+#include <istream>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "tbin/Layer.hpp"
+#include "tbin/PropertyValue.hpp"
+#include "tbin/TileSheet.hpp"
+
+namespace tbin
+{
+    class Map
+    {
+        public:
+            bool loadFromFile( const std::string& path );
+            bool loadFromStream( std::istream& in );
+            
+            bool saveToFile( const std::string& path ) const;
+            bool saveToStream( std::ostream& out ) const;
+            
+            std::string id;
+            std::string desc;
+            Properties props;
+            std::vector< TileSheet > tilesheets;
+            std::vector< Layer > layers;
+    };
+}
+
+#endif // TBIN_MAP_HPP

--- a/src/plugins/tbin/tbin/PropertyValue.hpp
+++ b/src/plugins/tbin/tbin/PropertyValue.hpp
@@ -1,0 +1,34 @@
+#ifndef TBIN_PROPERTYVALUE_HPP
+#define TBIN_PROPERTYVALUE_HPP
+
+#include <map>
+#include <SFML/Config.hpp>
+#include <string>
+
+namespace tbin
+{
+    struct PropertyValue
+    {
+        public:
+            enum Type
+            {
+                Bool    = 0,
+                Integer = 1,
+                Float   = 2,
+                String  = 3,
+            };
+
+            Type type;
+            union
+            {
+                bool b;
+                sf::Int32 i;
+                float f;
+            } data;
+            std::string dataStr;
+    };
+
+    typedef std::map< std::string, PropertyValue > Properties;
+}
+
+#endif // TBIN_PROPERTYVALUE_HPP

--- a/src/plugins/tbin/tbin/PropertyValue.hpp
+++ b/src/plugins/tbin/tbin/PropertyValue.hpp
@@ -1,3 +1,28 @@
+/*
+ * TBIN
+ * Copyright 2017, Chase Warrington <spacechase0.and.cat@gmail.com>
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #ifndef TBIN_PROPERTYVALUE_HPP
 #define TBIN_PROPERTYVALUE_HPP
 

--- a/src/plugins/tbin/tbin/PropertyValue.hpp
+++ b/src/plugins/tbin/tbin/PropertyValue.hpp
@@ -2,8 +2,10 @@
 #define TBIN_PROPERTYVALUE_HPP
 
 #include <map>
-#include <SFML/Config.hpp>
+//#include <SFML/Config.hpp>
 #include <string>
+
+#include "FakeSfml.hpp"
 
 namespace tbin
 {

--- a/src/plugins/tbin/tbin/Tile.hpp
+++ b/src/plugins/tbin/tbin/Tile.hpp
@@ -1,10 +1,11 @@
 #ifndef TBIN_TILE_HPP
 #define TBIN_TILE_HPP
 
-#include <SFML/Config.hpp>
+//#include <SFML/Config.hpp>
 #include <vector>
 
-#include "tbin/PropertyValue.hpp"
+#include "FakeSfml.hpp"
+#include "PropertyValue.hpp"
 
 namespace tbin
 {

--- a/src/plugins/tbin/tbin/Tile.hpp
+++ b/src/plugins/tbin/tbin/Tile.hpp
@@ -1,0 +1,42 @@
+#ifndef TBIN_TILE_HPP
+#define TBIN_TILE_HPP
+
+#include <SFML/Config.hpp>
+#include <vector>
+
+#include "tbin/PropertyValue.hpp"
+
+namespace tbin
+{
+    struct Tile
+    {
+        public:
+            enum Type
+            {
+                Null,
+                Static,
+                Animated,
+            };
+            
+            std::string tilesheet;
+            
+            struct
+            {
+                sf::Int32 tileIndex;
+                sf::Uint8 blendMode;
+            } staticData;
+            
+            struct
+            {
+                sf::Int32 frameInterval;
+                std::vector< Tile > frames;
+            } animatedData;
+            
+            Properties props;
+            
+            inline bool isNullTile() const { return staticData.tileIndex == -1 && animatedData.frames.size() == 0; }
+    };
+}
+
+#endif // TBIN_TILE_HPP
+                    

--- a/src/plugins/tbin/tbin/Tile.hpp
+++ b/src/plugins/tbin/tbin/Tile.hpp
@@ -1,3 +1,28 @@
+/*
+ * TBIN
+ * Copyright 2017, Chase Warrington <spacechase0.and.cat@gmail.com>
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #ifndef TBIN_TILE_HPP
 #define TBIN_TILE_HPP
 

--- a/src/plugins/tbin/tbin/TileSheet.hpp
+++ b/src/plugins/tbin/tbin/TileSheet.hpp
@@ -1,3 +1,28 @@
+/*
+ * TBIN
+ * Copyright 2017, Chase Warrington <spacechase0.and.cat@gmail.com>
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #ifndef TBIN_TILESHEET_HPP
 #define TBIN_TILESHEET_HPP
 

--- a/src/plugins/tbin/tbin/TileSheet.hpp
+++ b/src/plugins/tbin/tbin/TileSheet.hpp
@@ -1,0 +1,25 @@
+#ifndef TBIN_TILESHEET_HPP
+#define TBIN_TILESHEET_HPP
+
+#include <SFML/System/Vector2.hpp>
+#include <string>
+
+#include "tbin/PropertyValue.hpp"
+
+namespace tbin
+{
+    struct TileSheet
+    {
+        public:
+            std::string id;
+            std::string desc;
+            std::string image;
+            sf::Vector2i sheetSize;
+            sf::Vector2i tileSize;
+            sf::Vector2i margin;
+            sf::Vector2i spacing;
+            Properties props;
+    };
+}
+
+#endif // TBIN_TILESHEET_HPP

--- a/src/plugins/tbin/tbin/TileSheet.hpp
+++ b/src/plugins/tbin/tbin/TileSheet.hpp
@@ -1,10 +1,11 @@
 #ifndef TBIN_TILESHEET_HPP
 #define TBIN_TILESHEET_HPP
 
-#include <SFML/System/Vector2.hpp>
+//#include <SFML/System/Vector2.hpp>
 #include <string>
 
-#include "tbin/PropertyValue.hpp"
+#include "FakeSfml.hpp"
+#include "PropertyValue.hpp"
 
 namespace tbin
 {

--- a/src/plugins/tbin/tbin_global.h
+++ b/src/plugins/tbin/tbin_global.h
@@ -1,0 +1,29 @@
+/*
+ * Tbin Tiled Plugin
+ * Copyright 2017, Chase Warrington <spacechase0.and.cat@gmail.com>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QtCore/qglobal.h>
+
+#if defined(TBIN_LIBRARY)
+#  define TBINSHARED_EXPORT Q_DECL_EXPORT
+#else
+#  define TBINSHARED_EXPORT Q_DECL_IMPORT
+#endif

--- a/src/plugins/tbin/tbinplugin.cpp
+++ b/src/plugins/tbin/tbinplugin.cpp
@@ -21,47 +21,108 @@
 #include "tbinplugin.h"
 
 #include "tbin/Map.hpp"
+#include "map.h"
+#include "tile.h"
 
+#include <map>
 #include <QFile>
 #include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QTextStream>
+#include <QDebug>
 #include <sstream>
+
+namespace
+{
+    void doProperties( Tiled::Object* obj, const tbin::Properties& props )
+    {
+        for ( const std::pair< std::string, tbin::PropertyValue >& prop : props )
+        {
+            switch ( prop.second.type )
+            {
+                case tbin::PropertyValue::String:
+                    obj->setProperty( prop.first.c_str(), QVariant( prop.second.dataStr.c_str() ) );
+                    break;
+
+                case tbin::PropertyValue::Bool:
+                    obj->setProperty( prop.first.c_str(), QVariant( prop.second.data.b ) );
+                    break;
+
+                case tbin::PropertyValue::Float:
+                    obj->setProperty( prop.first.c_str(), QVariant( prop.second.data.f ) );
+                    break;
+
+                case tbin::PropertyValue::Integer:
+                    obj->setProperty( prop.first.c_str(), QVariant( prop.second.data.i ) );
+                    break;
+            }
+        }
+    }
+}
 
 namespace Tbin {
 
-void JsonPlugin::initialize()
+void TbinPlugin::initialize()
 {
     addObject(new TbinMapFormat(this));
 }
 
 
 TbinMapFormat::TbinMapFormat(QObject *parent)
-    : mSubFormat(subFormat)
-{}
+{
+}
 
 Tiled::Map *TbinMapFormat::read(const QString &fileName)
 {
     QFile file(fileName);
-    if (!file.open(QIODevice::ReadOnly | QIODevice::Binary)) {
+    if (!file.open(QIODevice::ReadOnly)) {
         mError = tr("Could not open file for reading.");
         return nullptr;
     }
 
     QByteArray contents = file.readAll();
-    QString data( contents );
-    std::istringstream ss( data.toStdString() );
+    std::istringstream ss( std::string( contents.constData(), contents.length() ) );
 
     tbin::Map tmap;
-    Tiled::Map* map = new Tiled::Map();
+    Tiled::Map* map;
     try
     {
         tmap.loadFromStream( ss );
+        map = new Tiled::Map( Tiled::Map::Orthogonal, tmap.layers[ 0 ].layerSize.x, tmap.layers[ 0 ].layerSize.y, tmap.layers[ 0 ].tileSize.x, tmap.layers[ 0 ].tileSize.y );
+
+        int currFirstGid = 1;
+        std::map< std::string, int > gids;
+        for ( const tbin::TileSheet& ttilesheet : tmap.tilesheets )
+        {
+            if ( ttilesheet.spacing.x != ttilesheet.spacing.y )
+                throw std::invalid_argument( "Tilesheet must have equal spacings" );
+            if ( ttilesheet.margin.x != ttilesheet.margin.y )
+                throw std::invalid_argument( "Tilesheet must have equal margins" );
+
+            auto tilesheet = Tiled::Tileset::create( ttilesheet.id.c_str(), ttilesheet.tileSize.x, ttilesheet.tileSize.y, ttilesheet.spacing.x, ttilesheet.margin.x );
+            tilesheet->setImageSource( ttilesheet.image.c_str() );
+            doProperties( tilesheet.data(), ttilesheet.props );
+
+            QList<Tiled::Tile*> tiles;
+            for ( int i = 0; i < ttilesheet.sheetSize.x * ttilesheet.sheetSize.y; ++i )
+            {
+                tiles.append( new Tiled::Tile( i, tilesheet.data() ) );
+            }
+            tilesheet->addTiles( tiles );
+
+            map->addTileset( tilesheet );
+            gids.insert( std::make_pair( ttilesheet.id, currFirstGid ) );
+            currFirstGid += ttilesheet.sheetSize.x * ttilesheet.sheetSize.y;
+        }
+        for ( const tbin::Layer& tlayer : tmap.layers )
+        {
+
+        }
     }
     catch ( std::exception& e )
     {
-        mError = "Exception: " + e.what();
+        mError = QString("Exception: ") + e.what();
     }
 
     return map;

--- a/src/plugins/tbin/tbinplugin.cpp
+++ b/src/plugins/tbin/tbinplugin.cpp
@@ -1,5 +1,5 @@
 /*
- * JSON Tiled Plugin
+ * TBIN Tiled Plugin
  * Copyright 2017, Chase Warrington <spacechase0.and.cat@gmail.com>
  *
  * This file is part of Tiled.
@@ -31,11 +31,6 @@
 #include <cmath>
 #include <fstream>
 #include <map>
-#include <QFile>
-#include <QFileInfo>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QTextStream>
 #include <QDebug>
 #include <sstream>
 

--- a/src/plugins/tbin/tbinplugin.cpp
+++ b/src/plugins/tbin/tbinplugin.cpp
@@ -86,7 +86,7 @@ namespace
                 prop.type = tbin::PropertyValue::String;
                 prop.dataStr = it.value().toString().toStdString();
             }
-            else throw std::invalid_argument("Unsupported property type");
+            else throw std::invalid_argument(QT_TR_NOOP("Unsupported property type"));
             props.insert(std::make_pair(it.key().toStdString(), prop));
         }
     }
@@ -130,9 +130,9 @@ Tiled::Map *TbinMapFormat::read(const QString &fileName)
             tmapTilesheetMapping[ttilesheet.id] = i;
 
             if (ttilesheet.spacing.x != ttilesheet.spacing.y)
-                throw std::invalid_argument("Tilesheet must have equal spacings.");
+                throw std::invalid_argument(QT_TR_NOOP("Tilesheet must have equal spacings."));
             if (ttilesheet.margin.x != ttilesheet.margin.y)
-                throw std::invalid_argument("Tilesheet must have equal margins.");
+                throw std::invalid_argument(QT_TR_NOOP("Tilesheet must have equal margins."));
 
             auto tilesheet = Tiled::Tileset::create(ttilesheet.id.c_str(), ttilesheet.tileSize.x, ttilesheet.tileSize.y, ttilesheet.spacing.x, ttilesheet.margin.x);
             tilesheet->setImageSource(ttilesheet.image.c_str());
@@ -152,7 +152,7 @@ Tiled::Map *TbinMapFormat::read(const QString &fileName)
         for (const tbin::Layer& tlayer : tmap.layers)
         {
             if (tlayer.tileSize.x != tmap.layers[0].tileSize.x || tlayer.tileSize.y != tmap.layers[0].tileSize.y)
-                throw std::invalid_argument("Different tile sizes per layer are not supported.");
+                throw std::invalid_argument(QT_TR_NOOP("Different tile sizes per layer are not supported."));
 
             Tiled::TileLayer* layer = new Tiled::TileLayer(tlayer.id.c_str(), 0, 0, tlayer.layerSize.x, tlayer.layerSize.y);
             tbinToTiledProperties(tlayer.props, layer);
@@ -176,7 +176,7 @@ Tiled::Map *TbinMapFormat::read(const QString &fileName)
                     {
                         if (tframe.isNullTile() || tframe.animatedData.frames.size() > 0 ||
                              tframe.tilesheet != tfirstTile.tilesheet)
-                            throw std::invalid_argument("Invalid animation frame.");
+                            throw std::invalid_argument(QT_TR_NOOP("Invalid animation frame."));
 
                         Tiled::Frame frame;
                         frame.tileId = tframe.staticData.tileIndex;
@@ -292,7 +292,7 @@ bool TbinMapFormat::write(const Tiled::Map *map, const QString &fileName)
             }
             else
             {
-                throw std::invalid_argument("Only object and tile layers supported.");
+                throw std::invalid_argument(QT_TR_NOOP("Only object and tile layers supported."));
             }
         }
 
@@ -321,7 +321,7 @@ bool TbinMapFormat::write(const Tiled::Map *map, const QString &fileName)
     }
     catch (std::exception& e)
     {
-        mError = tr((std::string("Exception: ") + e.what()).c_str());
+        mError = tr("Exception: %1").arg(tr(e.what()));
         return false;
     }
 

--- a/src/plugins/tbin/tbinplugin.cpp
+++ b/src/plugins/tbin/tbinplugin.cpp
@@ -209,8 +209,8 @@ bool TbinMapFormat::write(const Tiled::Map *map, const QString &fileName)
             ttilesheet.image = QFileInfo( fileName ).dir().relativeFilePath( tilesheet->imageSource() ).replace( "/", "\\" ).toStdString();
             ttilesheet.margin.x = ttilesheet.margin.y = tilesheet->margin();
             ttilesheet.spacing.x = ttilesheet.spacing.y = tilesheet->tileSpacing();
-            ttilesheet.sheetSize.x = tilesheet->gridSize().width();
-            ttilesheet.sheetSize.y = tilesheet->gridSize().height();
+            ttilesheet.sheetSize.x = tilesheet->columnCount();
+            ttilesheet.sheetSize.y = tilesheet->rowCount();
             ttilesheet.tileSize.x = tilesheet->tileSize().width();
             ttilesheet.tileSize.y = tilesheet->tileSize().height();
             tiledToTbinProperties(map, tmap.props);

--- a/src/plugins/tbin/tbinplugin.cpp
+++ b/src/plugins/tbin/tbinplugin.cpp
@@ -206,7 +206,7 @@ bool TbinMapFormat::write(const Tiled::Map *map, const QString &fileName)
         for(const Tiled::SharedTileset& tilesheet : map->tilesets()) {
             tbin::TileSheet ttilesheet;
             ttilesheet.id = tilesheet->name().toStdString();
-            ttilesheet.image = tilesheet->imageSource().toStdString();
+            ttilesheet.image = QFileInfo( fileName ).dir().relativeFilePath( tilesheet->imageSource() ).replace( "/", "\\" ).toStdString();
             ttilesheet.margin.x = ttilesheet.margin.y = tilesheet->margin();
             ttilesheet.spacing.x = ttilesheet.spacing.y = tilesheet->tileSpacing();
             ttilesheet.sheetSize.x = tilesheet->gridSize().width();
@@ -244,6 +244,7 @@ bool TbinMapFormat::write(const Tiled::Map *map, const QString &fileName)
                             ttile.tilesheet = tile->tileset()->name().toStdString();
                             if (tile->frames().size() == 0) {
                                 ttile.staticData.tileIndex = tile->id();
+                                ttile.staticData.blendMode = 0;
                             }
                             else {
 
@@ -253,6 +254,7 @@ bool TbinMapFormat::write(const Tiled::Map *map, const QString &fileName)
                                     tbin::Tile tframe;
                                     tframe.tilesheet = ttile.tilesheet;
                                     tframe.staticData.tileIndex = frame.tileId;
+                                    tframe.staticData.blendMode = 0;
                                     ttile.animatedData.frames.push_back(tframe);
                                 }
                             }

--- a/src/plugins/tbin/tbinplugin.cpp
+++ b/src/plugins/tbin/tbinplugin.cpp
@@ -128,7 +128,13 @@ Tiled::Map *TbinMapFormat::read(const QString &fileName)
             QDir dir(fileName);
             dir.cdUp();
             tilesheet->setImageSource(QDir::cleanPath(dir.filePath(QString::fromStdString(ttilesheet.image))));
-            tilesheet->loadImage();
+            if (!tilesheet->loadImage()) {
+                QList<Tiled::Tile*> tiles;
+                for (int i = 0; i < ttilesheet.sheetSize.x * ttilesheet.sheetSize.y; ++i) {
+                    tiles.append(new Tiled::Tile(i, tilesheet.data()));
+                }
+                tilesheet->addTiles(tiles);
+            }
             tbinToTiledProperties(ttilesheet.props, tilesheet.data());
 
             // TODO: Per-tile properties, investigate syntax

--- a/src/plugins/tbin/tbinplugin.cpp
+++ b/src/plugins/tbin/tbinplugin.cpp
@@ -39,10 +39,8 @@ namespace
 {
     void tbinToTiledProperties(const tbin::Properties& props, Tiled::Object* obj)
     {
-        for (const std::pair< std::string, tbin::PropertyValue >& prop : props)
-        {
-            switch (prop.second.type)
-            {
+        for (const std::pair< std::string, tbin::PropertyValue >& prop : props) {
+            switch (prop.second.type) {
                 case tbin::PropertyValue::String:
                     obj->setProperty(prop.first.c_str(), QVariant(prop.second.dataStr.c_str()));
                     break;
@@ -64,26 +62,21 @@ namespace
 
     void tiledToTbinProperties(const Tiled::Object* obj, tbin::Properties& props)
     {
-        for (auto it = obj->properties().cbegin(); it != obj->properties().cend(); ++it)
-        {
+        for (auto it = obj->properties().cbegin(); it != obj->properties().cend(); ++it) {
             tbin::PropertyValue prop;
-            if (it.value().type() == QVariant::Bool)
-            {
+            if (it.value().type() == QVariant::Bool) {
                 prop.type = tbin::PropertyValue::Bool;
                 prop.data.b = it.value().toBool();
             }
-            else if (it.value().type() == QMetaType::Float)
-            {
+            else if (it.value().type() == QMetaType::Float) {
                 prop.type = tbin::PropertyValue::Float;
                 prop.data.f = it.value().toFloat();
             }
-            else if (it.value().type() == QVariant::Int)
-            {
+            else if (it.value().type() == QVariant::Int) {
                 prop.type = tbin::PropertyValue::Integer;
                 prop.data.i = it.value().toInt();
             }
-            else if (it.value().type() == QVariant::String)
-            {
+            else if (it.value().type() == QVariant::String) {
                 prop.type = tbin::PropertyValue::String;
                 prop.dataStr = it.value().toString().toStdString();
             }
@@ -122,8 +115,7 @@ Tiled::Map *TbinMapFormat::read(const QString &fileName)
         tbinToTiledProperties(tmap.props, map);
 
         std::map< std::string, int > tmapTilesheetMapping;
-        for (std::size_t i = 0; i < tmap.tilesheets.size(); ++i)
-        {
+        for (std::size_t i = 0; i < tmap.tilesheets.size(); ++i) {
             const tbin::TileSheet& ttilesheet = tmap.tilesheets[i];
             tmapTilesheetMapping[ttilesheet.id] = i;
 
@@ -143,16 +135,14 @@ Tiled::Map *TbinMapFormat::read(const QString &fileName)
 
             map->addTileset(tilesheet);
         }
-        for (const tbin::Layer& tlayer : tmap.layers)
-        {
+        for (const tbin::Layer& tlayer : tmap.layers) {
             if (tlayer.tileSize.x != tmap.layers[0].tileSize.x || tlayer.tileSize.y != tmap.layers[0].tileSize.y)
                 throw std::invalid_argument(QT_TR_NOOP("Different tile sizes per layer are not supported."));
 
             Tiled::TileLayer* layer = new Tiled::TileLayer(tlayer.id.c_str(), 0, 0, tlayer.layerSize.x, tlayer.layerSize.y);
             tbinToTiledProperties(tlayer.props, layer);
             Tiled::ObjectGroup* objects = new Tiled::ObjectGroup(tlayer.id.c_str(), 0, 0);
-            for (std::size_t i = 0; i < tlayer.tiles.size(); ++i)
-            {
+            for (std::size_t i = 0; i < tlayer.tiles.size(); ++i) {
                 const tbin::Tile& ttile = tlayer.tiles[i];
                 int ix = i % tlayer.layerSize.x;
                 int iy = i / tlayer.layerSize.x;
@@ -161,13 +151,11 @@ Tiled::Map *TbinMapFormat::read(const QString &fileName)
                     continue;
 
                 Tiled::Cell cell;
-                if (ttile.animatedData.frames.size() > 0)
-                {
+                if (ttile.animatedData.frames.size() > 0) {
                     tbin::Tile tfirstTile = ttile.animatedData.frames[0];
                     Tiled::Tile* firstTile = map->tilesetAt(tmapTilesheetMapping[tfirstTile.tilesheet])->tileAt(tfirstTile.staticData.tileIndex);
                     QVector<Tiled::Frame> frames;
-                    for (const tbin::Tile& tframe : ttile.animatedData.frames)
-                    {
+                    for (const tbin::Tile& tframe : ttile.animatedData.frames) {
                         if (tframe.isNullTile() || tframe.animatedData.frames.size() > 0 ||
                              tframe.tilesheet != tfirstTile.tilesheet)
                             throw std::invalid_argument(QT_TR_NOOP("Invalid animation frame."));
@@ -180,14 +168,12 @@ Tiled::Map *TbinMapFormat::read(const QString &fileName)
                     firstTile->setFrames(frames);
                     cell = Tiled::Cell(firstTile);
                 }
-                else
-                {
+                else {
                     cell = Tiled::Cell(map->tilesetAt(tmapTilesheetMapping[ttile.tilesheet])->tileAt(ttile.staticData.tileIndex));
                 }
                 layer->setCell(ix, iy, cell);
 
-                if (ttile.props.size() > 0)
-                {
+                if (ttile.props.size() > 0) {
                     Tiled::MapObject* obj = new Tiled::MapObject("TileData", "", QPointF(ix * tlayer.tileSize.x, iy * tlayer.tileSize.y), QSizeF(1 * tlayer.tileSize.x, 1 * tlayer.tileSize.y));
                     tbinToTiledProperties(ttile.props, obj);
                     objects->addObject(obj);
@@ -197,8 +183,7 @@ Tiled::Map *TbinMapFormat::read(const QString &fileName)
             map->addLayer(objects);
         }
     }
-    catch (std::exception& e)
-    {
+    catch (std::exception& e) {
         mError = tr((std::string("Exception: ") + e.what()).c_str());
     }
 
@@ -207,14 +192,12 @@ Tiled::Map *TbinMapFormat::read(const QString &fileName)
 
 bool TbinMapFormat::write(const Tiled::Map *map, const QString &fileName)
 {
-    try
-    {
+    try {
         tbin::Map tmap;
         //tmap.id = map->name();
         tiledToTbinProperties(map, tmap.props);
 
-        for(const Tiled::SharedTileset& tilesheet : map->tilesets())
-        {
+        for(const Tiled::SharedTileset& tilesheet : map->tilesets()) {
             tbin::TileSheet ttilesheet;
             ttilesheet.id = tilesheet->name().toStdString();
             ttilesheet.image = tilesheet->imageSource().toStdString();
@@ -233,14 +216,11 @@ bool TbinMapFormat::write(const Tiled::Map *map, const QString &fileName)
 
         std::vector< Tiled::ObjectGroup* > objGroups;
         std::map< std::string, tbin::Layer* > tileLayerIdMap;
-        for (Tiled::Layer* rawLayer : map->layers())
-        {
-            if (Tiled::ObjectGroup* layer = rawLayer->asObjectGroup())
-            {
+        for (Tiled::Layer* rawLayer : map->layers()) {
+            if (Tiled::ObjectGroup* layer = rawLayer->asObjectGroup()) {
                 objGroups.push_back(layer);
             }
-            else if (Tiled::TileLayer* layer = rawLayer->asTileLayer())
-            {
+            else if (Tiled::TileLayer* layer = rawLayer->asTileLayer()) {
                 tbin::Layer tlayer;
                 tlayer.id = layer->name().toStdString();
                 tlayer.layerSize.x = layer->size().width();
@@ -248,27 +228,21 @@ bool TbinMapFormat::write(const Tiled::Map *map, const QString &fileName)
                 tlayer.tileSize.x = map->tileSize().width();
                 tlayer.tileSize.y = map->tileSize().height();
                 //tlayer.visible = ???;
-                for (int iy = 0; iy < tlayer.layerSize.y; ++iy)
-                {
-                    for (int ix = 0; ix < tlayer.layerSize.x; ++ix)
-                    {
+                for (int iy = 0; iy < tlayer.layerSize.y; ++iy) {
+                    for (int ix = 0; ix < tlayer.layerSize.x; ++ix) {
                         Tiled::Cell cell = layer->cellAt(ix, iy);
                         tbin::Tile ttile;
                         ttile.staticData.tileIndex = -1;
 
-                        if (Tiled::Tile *tile = cell.tile())
-                        {
+                        if (Tiled::Tile *tile = cell.tile()) {
                             ttile.tilesheet = tile->tileset()->name().toStdString();
-                            if (tile->frames().size() == 0)
-                            {
+                            if (tile->frames().size() == 0) {
                                 ttile.staticData.tileIndex = tile->id();
                             }
-                            else
-                            {
+                            else {
 
                                 // TODO: Check all frame durations are the same
-                                for (Tiled::Frame frame : tile->frames())
-                                {
+                                for (Tiled::Frame frame : tile->frames()) {
                                     ttile.animatedData.frameInterval = frame.duration;
                                     tbin::Tile tframe;
                                     tframe.tilesheet = ttile.tilesheet;
@@ -284,16 +258,13 @@ bool TbinMapFormat::write(const Tiled::Map *map, const QString &fileName)
                 tmap.layers.push_back(std::move(tlayer));
                 tileLayerIdMap[tmap.layers.back().id] = &tmap.layers.back();
             }
-            else
-            {
+            else {
                 throw std::invalid_argument(QT_TR_NOOP("Only object and tile layers supported."));
             }
         }
 
-        for (Tiled::ObjectGroup* objs : objGroups)
-        {
-            for (Tiled::MapObject* obj : objs->objects())
-            {
+        for (Tiled::ObjectGroup* objs : objGroups) {
+            for (Tiled::MapObject* obj : objs->objects()) {
                if (obj->name() != "TileData" || obj->size().width() != 1 || obj->size().height() != 1 ||
                     obj->position().x() != std::floor(obj->position().x()) || obj->position().y() != std::floor(obj->position().y()))
                    continue;
@@ -305,8 +276,7 @@ bool TbinMapFormat::write(const Tiled::Map *map, const QString &fileName)
         }
 
         std::ofstream file(fileName.toStdString(), std::ios::trunc | std::ios::binary);
-        if (!file)
-        {
+        if (!file) {
             mError = tr("Could not open file for writing");
             return false;
         }

--- a/src/plugins/tbin/tbinplugin.cpp
+++ b/src/plugins/tbin/tbinplugin.cpp
@@ -1,0 +1,99 @@
+/*
+ * JSON Tiled Plugin
+ * Copyright 2017, Chase Warrington <spacechase0.and.cat@gmail.com>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "tbinplugin.h"
+
+#include "tbin/Map.hpp"
+
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QTextStream>
+#include <sstream>
+
+namespace Tbin {
+
+void JsonPlugin::initialize()
+{
+    addObject(new TbinMapFormat(this));
+}
+
+
+TbinMapFormat::TbinMapFormat(QObject *parent)
+    : mSubFormat(subFormat)
+{}
+
+Tiled::Map *TbinMapFormat::read(const QString &fileName)
+{
+    QFile file(fileName);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Binary)) {
+        mError = tr("Could not open file for reading.");
+        return nullptr;
+    }
+
+    QByteArray contents = file.readAll();
+    QString data( contents );
+    std::istringstream ss( data.toStdString() );
+
+    tbin::Map tmap;
+    Tiled::Map* map = new Tiled::Map();
+    try
+    {
+        tmap.loadFromStream( ss );
+    }
+    catch ( std::exception& e )
+    {
+        mError = "Exception: " + e.what();
+    }
+
+    return map;
+}
+
+bool TbinMapFormat::write(const Tiled::Map *map, const QString &fileName)
+{
+    // ...
+
+    return false;
+}
+
+QString TbinMapFormat::nameFilter() const
+{
+    return tr("Tbin map files (*.tbin)");
+}
+
+QString TbinMapFormat::shortName() const
+{
+    return QLatin1String("tbin");
+}
+
+bool TbinMapFormat::supportsFile(const QString &fileName) const
+{
+    // ...
+
+    return false;
+}
+
+QString TbinMapFormat::errorString() const
+{
+    return mError;
+}
+
+} // namespace Tbin

--- a/src/plugins/tbin/tbinplugin.cpp
+++ b/src/plugins/tbin/tbinplugin.cpp
@@ -70,7 +70,7 @@ namespace
                 prop.type = tbin::PropertyValue::Bool;
                 prop.data.b = it.value().toBool();
             }
-            else if (it.value().type() == QMetaType::Float) {
+            else if ((QMetaType::Type)it.value().type() == QMetaType::Float) {
                 prop.type = tbin::PropertyValue::Float;
                 prop.data.f = it.value().toFloat();
             }
@@ -96,7 +96,7 @@ void TbinPlugin::initialize()
 }
 
 
-TbinMapFormat::TbinMapFormat(QObject *parent)
+TbinMapFormat::TbinMapFormat(QObject *)
 {
 }
 
@@ -109,7 +109,7 @@ Tiled::Map *TbinMapFormat::read(const QString &fileName)
     }
 
     tbin::Map tmap;
-    Tiled::Map* map;
+    Tiled::Map* map = nullptr;
     try
     {
         tmap.loadFromStream(file);

--- a/src/plugins/tbin/tbinplugin.cpp
+++ b/src/plugins/tbin/tbinplugin.cpp
@@ -140,19 +140,16 @@ Tiled::Map *TbinMapFormat::read(const QString &fileName)
             tbinToTiledProperties(ttilesheet.props, tilesheet.data());
 
             for (auto prop : ttilesheet.props) {
-                qInfo() << prop.first.c_str();
                 if (prop.first[0] != '@')
                     continue;
 
                 QStringList strs = QString(prop.first.c_str()).split('@');
-                qInfo() << strs[1];
                 if (strs[1] == "TileIndex") {
                     int index = strs[2].toInt();
                     tbin::Properties dummyProps;
                     dummyProps.insert(std::make_pair(strs[3].toStdString(), prop.second));
                     Tiled::Tile* tile = tilesheet->tileAt(index);
                     tbinToTiledProperties(dummyProps, tile);
-                    qInfo() << index << ' ' << strs[3] << "\n";
                 }
                 // TODO: 'AutoTile' ?
                 // Purely for map making. Appears to be similar to terrains

--- a/src/plugins/tbin/tbinplugin.cpp
+++ b/src/plugins/tbin/tbinplugin.cpp
@@ -238,7 +238,6 @@ bool TbinMapFormat::write(const Tiled::Map *map, const QString &fileName)
             for (auto tile : tilesheet->tiles()) {
                 Tiled::Object obj(Tiled::Object::TileType);
                 auto props = tile->properties();
-                qInfo() << props.size();
                 for (auto it = props.begin(); it != props.end(); ++it) {
                     obj.setProperty("@TileIndex@" + QString::number(tile->id()) + "@" + it.key(), it.value());
                 }

--- a/src/plugins/tbin/tbinplugin.h
+++ b/src/plugins/tbin/tbinplugin.h
@@ -63,7 +63,6 @@ public:
 
 protected:
     QString mError;
-    SubFormat mSubFormat;
 };
 
 } // namespace Json

--- a/src/plugins/tbin/tbinplugin.h
+++ b/src/plugins/tbin/tbinplugin.h
@@ -1,0 +1,69 @@
+/*
+ * JSON Tiled Plugin
+ * Copyright 2017, Chase Warrington <spacechase0.and.cat@gmail.com>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "tbin_global.h"
+
+#include "mapformat.h"
+#include "plugin.h"
+
+#include <QObject>
+
+namespace Tiled {
+class Map;
+}
+
+namespace Tbin {
+
+class TBINSHARED_EXPORT TbinPlugin : public Tiled::Plugin
+{
+    Q_OBJECT
+    Q_INTERFACES(Tiled::Plugin)
+    Q_PLUGIN_METADATA(IID "org.mapeditor.Plugin" FILE "plugin.json")
+
+public:
+    void initialize() override;
+};
+
+
+class TBINSHARED_EXPORT TbinMapFormat : public Tiled::MapFormat
+{
+    Q_OBJECT
+    Q_INTERFACES(Tiled::MapFormat)
+
+public:
+    TbinMapFormat(QObject *parent = nullptr);
+
+    Tiled::Map *read(const QString &fileName) override;
+    bool supportsFile(const QString &fileName) const override;
+
+    bool write(const Tiled::Map *map, const QString &fileName) override;
+
+    QString nameFilter() const override;
+    QString shortName() const override;
+    QString errorString() const override;
+
+protected:
+    QString mError;
+    SubFormat mSubFormat;
+};
+
+} // namespace Json

--- a/src/plugins/tbin/tbinplugin.h
+++ b/src/plugins/tbin/tbinplugin.h
@@ -1,5 +1,5 @@
 /*
- * JSON Tiled Plugin
+ * TBIN Tiled Plugin
  * Copyright 2017, Chase Warrington <spacechase0.and.cat@gmail.com>
  *
  * This file is part of Tiled.


### PR DESCRIPTION
(#1560)

At the moment, loading is fully implemented (except tilesheet tile properties - they're stored as properties on the tilesheet with tbins, I forgot about that (EDIT: And it looks like individual tile properties are currently stored in the tilesheet?)) besides needing to manually fix tilesheet image sources. (It says it can't find it in '.', do I need to put the full path?)

Next I'm going to do saving, and then take out `FakeSfml.hpp` and fix things to use the primitive types directly, as well as `QPointI` (?) instead of `sf::Vector2i` (plus any other cleanup wanted).