### PR TITLE
Introduced TilesetDocumentsModel and its sort-filter model companion

### DIFF
--- a/src/libtiled/tileset.h
+++ b/src/libtiled/tileset.h
@@ -620,3 +620,5 @@ inline bool Tileset::imageLoaded() const
 }
 
 } // namespace Tiled
+
+Q_DECLARE_METATYPE(Tiled::SharedTileset)

--- a/src/tiled/documentmanager.h
+++ b/src/tiled/documentmanager.h
@@ -52,6 +52,7 @@ class MapEditor;
 class MapScene;
 class MapView;
 class TilesetDocument;
+class TilesetDocumentsModel;
 
 /**
  * This class controls the open documents.
@@ -169,11 +170,10 @@ public:
      */
     const QList<Document*> &documents() const { return mDocuments; }
 
-    const QList<TilesetDocument*> &tilesetDocuments() const;
+    TilesetDocumentsModel *tilesetDocumentsModel() const;
 
     TilesetDocument *findTilesetDocument(const SharedTileset &tileset) const;
     TilesetDocument *findTilesetDocument(const QString &fileName) const;
-    TilesetDocument *findOrCreateTilesetDocument(const SharedTileset &tileset);
 
     /**
      * Opens the document for the given \a tileset.
@@ -254,7 +254,7 @@ private:
     void removeFromTilesetDocument(const SharedTileset &tileset, MapDocument *mapDocument);
 
     QList<Document*> mDocuments;
-    QList<TilesetDocument*> mTilesetDocuments;
+    TilesetDocumentsModel *mTilesetDocumentsModel;
 
     QWidget *mWidget;
     QWidget *mNoEditorWidget;
@@ -276,12 +276,9 @@ private:
     static DocumentManager *mInstance;
 };
 
-/**
- * Returns all open tileset documents, either embedded or external.
- */
-inline const QList<TilesetDocument *> &DocumentManager::tilesetDocuments() const
+inline TilesetDocumentsModel *DocumentManager::tilesetDocumentsModel() const
 {
-    return mTilesetDocuments;
+    return mTilesetDocumentsModel;
 }
 
 } // namespace Tiled::Internal

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -53,7 +53,6 @@
 #include "rotatemapobject.h"
 #include "staggeredrenderer.h"
 #include "terrain.h"
-#include "terrainmodel.h"
 #include "tile.h"
 #include "tilelayer.h"
 #include "tilesetdocument.h"
@@ -73,7 +72,6 @@ MapDocument::MapDocument(Map *map, const QString &fileName)
     , mLayerModel(new LayerModel(this))
     , mRenderer(nullptr)
     , mMapObjectModel(new MapObjectModel(this))
-    , mTerrainModel(new TerrainModel(this, this))
 {
     mCurrentObject = map;
 

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -50,7 +50,6 @@ namespace Internal {
 
 class LayerModel;
 class MapObjectModel;
-class TerrainModel;
 class TileSelectionModel;
 
 /**
@@ -161,8 +160,6 @@ public:
     LayerModel *layerModel() const { return mLayerModel; }
 
     MapObjectModel *mapObjectModel() const { return mMapObjectModel; }
-
-    TerrainModel *terrainModel() const { return mTerrainModel; }
 
     /**
      * Returns the map renderer.
@@ -283,10 +280,6 @@ signals:
     void tilesetTileOffsetChanged(Tileset *tileset);
     void tileTypeChanged(Tile *tile);
     void tileImageSourceChanged(Tile *tile);
-    void tilesetTerrainAboutToBeAdded(Tileset *tileset, int terrainId);
-    void tilesetTerrainAdded(Tileset *tileset, int terrainId);
-    void tilesetTerrainAboutToBeRemoved(Tileset *tileset, Terrain *terrain);
-    void tilesetTerrainRemoved(Tileset *tileset, Terrain *terrain);
 
 private slots:
     void onObjectsRemoved(const QList<MapObject*> &objects);
@@ -320,7 +313,6 @@ private:
     MapRenderer *mRenderer;
     Layer* mCurrentLayer;
     MapObjectModel *mMapObjectModel;
-    TerrainModel *mTerrainModel;
 };
 
 

--- a/src/tiled/terrainbrush.cpp
+++ b/src/tiled/terrainbrush.cpp
@@ -22,7 +22,9 @@
 
 #include "terrainbrush.h"
 
+#include "addremovetileset.h"
 #include "brushitem.h"
+#include "containerhelpers.h"
 #include "geometry.h"
 #include "mapdocument.h"
 #include "mapscene.h"
@@ -231,6 +233,10 @@ void TerrainBrush::doPaint(bool mergeable)
     PaintTileLayer *paint = new PaintTileLayer(mapDocument(), tileLayer,
                                                stamp->x(), stamp->y(),
                                                stamp, brushItem()->tileRegion());
+
+    if (mTerrain && !contains(mapDocument()->map()->tilesets(), mTerrain->tileset()))
+        new AddTileset(mapDocument(), mTerrain->tileset()->sharedPointer(), paint);
+
     paint->setMergeable(mergeable);
     mapDocument()->undoStack()->push(paint);
     emit mapDocument()->regionEdited(brushItem()->tileRegion(), tileLayer);

--- a/src/tiled/terraindock.cpp
+++ b/src/tiled/terraindock.cpp
@@ -30,6 +30,7 @@
 #include "terrainmodel.h"
 #include "terrainview.h"
 #include "tilesetdocument.h"
+#include "tilesetdocumentsmodel.h"
 #include "tilesetterrainmodel.h"
 #include "utils.h"
 
@@ -106,6 +107,8 @@ TerrainDock::TerrainDock(QWidget *parent)
     , mRemoveTerrainType(new QAction(this))
     , mDocument(nullptr)
     , mCurrentTerrain(nullptr)
+    , mTilesetDocumentsFilterModel(new TilesetDocumentsFilterModel(this))
+    , mTerrainModel(new TerrainModel(mTilesetDocumentsFilterModel, this))
     , mProxyModel(new TerrainFilterModel(this))
     , mInitializing(false)
 {
@@ -168,36 +171,23 @@ TerrainDock::~TerrainDock()
 {
 }
 
-static QAbstractItemModel *terrainModel(Document *document)
-{
-    switch (document->type()) {
-    case Document::MapDocumentType:
-        return static_cast<MapDocument*>(document)->terrainModel();
-    case Document::TilesetDocumentType:
-        return static_cast<TilesetDocument*>(document)->terrainModel();
-    }
-    return nullptr;
-}
-
 void TerrainDock::setDocument(Document *document)
 {
     if (mDocument == document)
         return;
 
     // Clear all connections to the previous document
-    if (mDocument) {
-        terrainModel(mDocument)->disconnect(this);
-        mDocument->disconnect(this);
-    }
+    if (auto tilesetDocument = qobject_cast<TilesetDocument*>(mDocument))
+        tilesetDocument->terrainModel()->disconnect(this);
 
     mDocument = document;
     mInitializing = true;
 
     if (auto mapDocument = qobject_cast<MapDocument*>(document)) {
-        TerrainModel *terrainModel = mapDocument->terrainModel();
+        mTilesetDocumentsFilterModel->setMapDocument(mapDocument);
 
         mProxyModel->setEnabled(true);
-        mProxyModel->setSourceModel(terrainModel);
+        mProxyModel->setSourceModel(mTerrainModel);
         mTerrainView->expandAll();
 
         setCurrentTerrain(firstTerrain(mapDocument));
@@ -331,11 +321,10 @@ QModelIndex TerrainDock::terrainIndex(Terrain *terrain) const
 {
     QModelIndex sourceIndex;
 
-    if (auto mapDocument = qobject_cast<MapDocument*>(mDocument)) {
-        sourceIndex = mapDocument->terrainModel()->index(terrain);
-    } else if (auto tilesetDocument = qobject_cast<TilesetDocument*>(mDocument)) {
+    if (mDocument->type() == Document::MapDocumentType)
+        sourceIndex = mTerrainModel->index(terrain);
+    else if (auto tilesetDocument = qobject_cast<TilesetDocument*>(mDocument))
         sourceIndex = tilesetDocument->terrainModel()->index(terrain);
-    }
 
     return mProxyModel->mapFromSource(sourceIndex);
 }

--- a/src/tiled/terraindock.h
+++ b/src/tiled/terraindock.h
@@ -38,8 +38,10 @@ namespace Internal {
 
 class Document;
 class TerrainFilterModel;
+class TerrainModel;
 class TerrainView;
 class TilesetDocument;
+class TilesetDocumentsFilterModel;
 
 /**
  * The dock widget that displays the terrains. Also keeps track of the
@@ -50,11 +52,7 @@ class TerrainDock : public QDockWidget
     Q_OBJECT
 
 public:
-    /**
-     * Constructor.
-     */
     TerrainDock(QWidget *parent = nullptr);
-
     ~TerrainDock();
 
     /**
@@ -109,6 +107,8 @@ private:
     TerrainView *mTerrainView;
     QPushButton *mEraseTerrainButton;
     Terrain *mCurrentTerrain;
+    TilesetDocumentsFilterModel *mTilesetDocumentsFilterModel;
+    TerrainModel *mTerrainModel;
     TerrainFilterModel *mProxyModel;
 
     bool mInitializing;

--- a/src/tiled/terrainmodel.h
+++ b/src/tiled/terrainmodel.h
@@ -32,7 +32,7 @@ class Terrain;
 
 namespace Internal {
 
-class MapDocument;
+class TilesetDocument;
 
 /**
  * A model providing a tree view on the terrain types available on a map.
@@ -49,9 +49,9 @@ public:
     /**
      * Constructor.
      *
-     * @param mapDocument the map to manage terrains for
+     * @param tilesetDocumentsModel a model of a list of tileset documents
      */
-    TerrainModel(MapDocument *mapDocument,
+    TerrainModel(QAbstractItemModel *tilesetDocumentsModel,
                  QObject *parent = nullptr);
 
     ~TerrainModel();
@@ -71,17 +71,12 @@ public:
      */
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 
-    /**
-     * Returns the number of columns.
-     */
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 
-    /**
-     * Returns the data stored under the given <i>role</i> for the item
-     * referred to by the <i>index</i>.
-     */
     QVariant data(const QModelIndex &index,
                   int role = Qt::DisplayRole) const override;
+
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
 
     /**
      * Returns the tileset at the given \a index, or 0 if there is no tileset.
@@ -94,19 +89,20 @@ public:
     Terrain *terrainAt(const QModelIndex &index) const;
 
 private slots:
-    void tilesetAboutToBeAdded(int index);
-    void tilesetAdded();
-    void tilesetAboutToBeRemoved(int index);
-    void tilesetRemoved();
-    void tilesetChanged(Tileset *tileset);
+    void onTilesetRowsInserted(const QModelIndex &parent, int first, int last);
+    void onTilesetRowsAboutToBeRemoved(const QModelIndex &parent, int first, int last);
+    void onTilesetRowsMoved(const QModelIndex &parent, int start, int end, const QModelIndex &destination, int row);
+    void onTilesetLayoutChanged(const QList<QPersistentModelIndex> &parents, QAbstractItemModel::LayoutChangeHint hint);
+    void onTilesetDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
 
-    void terrainAboutToBeAdded(Tileset *tileset, int terrainId);
-    void terrainAdded(Tileset *tileset);
-    void terrainAboutToBeRemoved(Tileset *tileset, Terrain *terrain);
-    void terrainRemoved(Tileset *tileset);
+    void onTerrainAboutToBeAdded(Tileset *tileset, int terrainId);
+    void onTerrainAdded(Tileset *tileset);
+    void onTerrainAboutToBeRemoved(Terrain *terrain);
+    void onTerrainRemoved(Terrain *terrain);
 
 private:
-    MapDocument *mMapDocument;
+    QAbstractItemModel *mTilesetDocumentsModel;
+    QList<TilesetDocument*> mTilesetDocuments;
 };
 
 } // namespace Internal

--- a/src/tiled/tiled.pro
+++ b/src/tiled/tiled.pro
@@ -224,6 +224,7 @@ SOURCES += aboutdialog.cpp \
     tilesetchanges.cpp \
     tilesetdock.cpp \
     tilesetdocument.cpp \
+    tilesetdocumentsmodel.cpp \
     tileseteditor.cpp \
     tilesetmodel.cpp \
     tilesetparametersedit.cpp \
@@ -397,6 +398,7 @@ HEADERS += aboutdialog.h \
     tilesetchanges.h \
     tilesetdock.h \
     tilesetdocument.h \
+    tilesetdocumentsmodel.h \
     tileseteditor.h \
     tilesetmodel.h \
     tilesetparametersedit.h \

--- a/src/tiled/tiled.qbs
+++ b/src/tiled/tiled.qbs
@@ -377,6 +377,8 @@ QtGuiApplication {
         "tilesetdock.h",
         "tilesetdocument.cpp",
         "tilesetdocument.h",
+        "tilesetdocumentsmodel.cpp",
+        "tilesetdocumentsmodel.h",
         "tileseteditor.cpp",
         "tileseteditor.h",
         "tilesetmodel.cpp",

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -687,8 +687,6 @@ void TilesetDock::retranslateUi()
 
 void TilesetDock::onTilesetRowsInserted(const QModelIndex &parent, int first, int last)
 {
-    Q_UNUSED(parent)
-
     for (int row = first; row <= last; ++row) {
         const QModelIndex index = mTilesetDocumentsFilterModel->index(row, 0, parent);
         const QVariant var = mTilesetDocumentsFilterModel->data(index, TilesetDocumentsModel::TilesetDocumentRole);
@@ -731,7 +729,7 @@ void TilesetDock::onTilesetLayoutChanged(const QList<QPersistentModelIndex> &par
 
     // Make sure the tileset tabs and views are still in the right order
     for (int i = 0, rows = mTilesetDocumentsFilterModel->rowCount(); i < rows; ++i) {
-        const QModelIndex index = mTilesetDocumentsFilterModel->index(i, 0, QModelIndex());
+        const QModelIndex index = mTilesetDocumentsFilterModel->index(i, 0);
         const QVariant var = mTilesetDocumentsFilterModel->data(index, TilesetDocumentsModel::TilesetDocumentRole);
         TilesetDocument *tilesetDocument = var.value<TilesetDocument*>();
         int currentIndex = mTilesetDocuments.indexOf(tilesetDocument);

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -40,6 +40,7 @@
 #include "tile.h"
 #include "tilelayer.h"
 #include "tilesetdocument.h"
+#include "tilesetdocumentsmodel.h"
 #include "tilesetformat.h"
 #include "tilesetmodel.h"
 #include "tilesetview.h"
@@ -149,33 +150,34 @@ static void removeTileReferences(MapDocument *mapDocument,
 
 } // anonymous namespace
 
-TilesetDock::TilesetDock(QWidget *parent):
-    QDockWidget(parent),
-    mMapDocument(nullptr),
-    mTabBar(new WheelEnabledTabBar),
-    mViewStack(new QStackedWidget),
-    mToolBar(new QToolBar),
-    mCurrentTile(nullptr),
-    mCurrentTiles(nullptr),
-    mNewTileset(new QAction(this)),
-    mEmbedTileset(new QAction(this)),
-    mExportTileset(new QAction(this)),
-    mEditTileset(new QAction(this)),
-    mDeleteTileset(new QAction(this)),
-    mTilesetMenuButton(new TilesetMenuButton(this)),
-    mTilesetMenu(new QMenu(this)),
-    mTilesetActionGroup(new QActionGroup(this)),
-    mTilesetMenuMapper(nullptr),
-    mEmittingStampCaptured(false),
-    mSynchronizingSelection(false)
+TilesetDock::TilesetDock(QWidget *parent)
+    : QDockWidget(parent)
+    , mMapDocument(nullptr)
+    , mTilesetDocumentsFilterModel(new TilesetDocumentsFilterModel(this))
+    , mTabBar(new WheelEnabledTabBar)
+    , mViewStack(new QStackedWidget)
+    , mToolBar(new QToolBar)
+    , mCurrentTile(nullptr)
+    , mCurrentTiles(nullptr)
+    , mNewTileset(new QAction(this))
+    , mEmbedTileset(new QAction(this))
+    , mExportTileset(new QAction(this))
+    , mEditTileset(new QAction(this))
+    , mDeleteTileset(new QAction(this))
+    , mTilesetMenuButton(new TilesetMenuButton(this))
+    , mTilesetMenu(new QMenu(this))
+    , mTilesetActionGroup(new QActionGroup(this))
+    , mTilesetMenuMapper(nullptr)
+    , mEmittingStampCaptured(false)
+    , mSynchronizingSelection(false)
 {
     setObjectName(QLatin1String("TilesetDock"));
 
     mTabBar->setUsesScrollButtons(true);
     mTabBar->setExpanding(false);
 
-    connect(mTabBar, &QTabBar::currentChanged,
-            this, &TilesetDock::updateActions);
+    connect(mTabBar, &QTabBar::currentChanged, this, &TilesetDock::updateActions);
+    connect(mTabBar, &QTabBar::tabMoved, this, &TilesetDock::onTabMoved);
 
     QWidget *w = new QWidget(this);
 
@@ -231,12 +233,16 @@ TilesetDock::TilesetDock(QWidget *parent):
     connect(TilesetManager::instance(), &TilesetManager::tilesetImagesChanged,
             this, &TilesetDock::tilesetChanged);
 
-    auto *documentManager = DocumentManager::instance();
-
-    connect(documentManager, &DocumentManager::tilesetDocumentAdded,
-            this, &TilesetDock::updateTilesets);
-    connect(documentManager, &DocumentManager::tilesetDocumentRemoved,
-            this, &TilesetDock::updateTilesets);
+    connect(mTilesetDocumentsFilterModel, &TilesetDocumentsModel::rowsInserted,
+            this, &TilesetDock::onTilesetRowsInserted);
+    connect(mTilesetDocumentsFilterModel, &TilesetDocumentsModel::rowsAboutToBeRemoved,
+            this, &TilesetDock::onTilesetRowsAboutToBeRemoved);
+    connect(mTilesetDocumentsFilterModel, &TilesetDocumentsModel::rowsMoved,
+            this, &TilesetDock::onTilesetRowsMoved);
+    connect(mTilesetDocumentsFilterModel, &TilesetDocumentsModel::layoutChanged,
+            this, &TilesetDock::onTilesetLayoutChanged);
+    connect(mTilesetDocumentsFilterModel, &TilesetDocumentsModel::dataChanged,
+            this, &TilesetDock::onTilesetDataChanged);
 
     mTilesetMenuButton->setMenu(mTilesetMenu);
     connect(mTilesetMenu, SIGNAL(aboutToShow()), SLOT(refreshTilesetMenu()));
@@ -273,7 +279,7 @@ void TilesetDock::setMapDocument(MapDocument *mapDocument)
 
     mMapDocument = mapDocument;
 
-    updateTilesets();
+    mTilesetDocumentsFilterModel->setMapDocument(mapDocument);
 
     if (mMapDocument) {
         if (Object *object = mMapDocument->currentObject())
@@ -281,11 +287,11 @@ void TilesetDock::setMapDocument(MapDocument *mapDocument)
                 setCurrentTile(static_cast<Tile*>(object));
 
         connect(mMapDocument, &MapDocument::tilesetAdded,
-                this, &TilesetDock::updateTilesets);
+                this, &TilesetDock::updateActions);
         connect(mMapDocument, &MapDocument::tilesetRemoved,
-                this, &TilesetDock::updateTilesets);
+                this, &TilesetDock::updateActions);
         connect(mMapDocument, &MapDocument::tilesetReplaced,
-                this, &TilesetDock::updateTilesets);
+                this, &TilesetDock::updateActions);
     }
 
     updateActions();
@@ -506,8 +512,6 @@ void TilesetDock::createTilesetView(int index, TilesetDocument *tilesetDocument)
     qreal scale = Preferences::instance()->settings()->value(path, 1).toReal();
     view->zoomable()->setScale(scale);
 
-    connect(tilesetDocument, &TilesetDocument::tilesetNameChanged,
-            this, &TilesetDock::tilesetNameChanged);
     connect(tilesetDocument, &TilesetDocument::fileNameChanged,
             this, &TilesetDock::tilesetFileNameChanged);
     connect(tilesetDocument, &TilesetDocument::tilesetChanged,
@@ -557,27 +561,7 @@ void TilesetDock::deleteTilesetView(int index)
 
 void TilesetDock::moveTilesetView(int from, int to)
 {
-#if QT_VERSION >= 0x050600
-    mTilesets.move(from, to);
-#else
-    mTilesets.insert(to, mTilesets.takeAt(from));
-#endif
-
-    // Move the related tileset views
-    QWidget *widget = mViewStack->widget(from);
-    mViewStack->removeWidget(widget);
-    mViewStack->insertWidget(to, widget);
-    mViewStack->setCurrentIndex(mTabBar->currentIndex());
-
-    // Update the titles of the affected tabs
-    const int start = qMin(from, to);
-    const int end = qMax(from, to);
-    for (int i = start; i <= end; ++i) {
-        const SharedTileset &tileset = mTilesets.at(i);
-        if (mTabBar->tabText(i) != tileset->name())
-            mTabBar->setTabText(i, tileset->name());
-        mTabBar->setTabToolTip(i, tileset->fileName());
-    }
+    mTabBar->moveTab(from, to);
 }
 
 void TilesetDock::tilesetChanged(Tileset *tileset)
@@ -701,54 +685,88 @@ void TilesetDock::retranslateUi()
     mDeleteTileset->setText(tr("&Remove Tileset"));
 }
 
-static auto lessThan = [](const TilesetDocument *a, const TilesetDocument *b) {
-    if (a->tileset()->name() != b->tileset()->name())
-        return a->tileset()->name() < b->tileset()->name();
-    else
-        return a < b; // some deterministic order
-};
-
-/**
- * Updates the list of displayed tilesets.
- */
-void TilesetDock::updateTilesets()
+void TilesetDock::onTilesetRowsInserted(const QModelIndex &parent, int first, int last)
 {
-    auto *documentManager = DocumentManager::instance();
-    auto tilesetDocuments = documentManager->tilesetDocuments();
+    Q_UNUSED(parent)
 
-    auto embeddedElsewhere = [this](const TilesetDocument *c) {
-        return c->isEmbedded() && c->mapDocuments().first() != mMapDocument;
-    };
+    for (int row = first; row <= last; ++row) {
+        const QModelIndex index = mTilesetDocumentsFilterModel->index(row, 0, parent);
+        const QVariant var = mTilesetDocumentsFilterModel->data(index, TilesetDocumentsModel::TilesetDocumentRole);
+        createTilesetView(row, var.value<TilesetDocument*>());
+    }
+}
 
-    // Filter out embedded tilesets in other maps
-    tilesetDocuments.erase(std::remove_if(tilesetDocuments.begin(),
-                                          tilesetDocuments.end(),
-                                          embeddedElsewhere),
-                           tilesetDocuments.end());
+void TilesetDock::onTilesetRowsAboutToBeRemoved(const QModelIndex &parent, int first, int last)
+{
+    Q_UNUSED(parent)
 
-    std::sort(tilesetDocuments.begin(), tilesetDocuments.end(), lessThan);
+    for (int index = last; index >= first; --index)
+        deleteTilesetView(index);
+}
 
-    // Due to the above sorting we can iterate over the tilesets once, skipping
-    // tilesets that are still there, removing tilesets that are no longer
-    // there and adding new tilesets in the right position.
-    for (int index = 0;
-         index < tilesetDocuments.size() || index < mTilesetDocuments.size(); )
-    {
-        TilesetDocument *newDocument = tilesetDocuments.value(index);
-        TilesetDocument *oldDocument = mTilesetDocuments.value(index);
+void TilesetDock::onTilesetRowsMoved(const QModelIndex &parent, int start, int end, const QModelIndex &destination, int row)
+{
+    Q_UNUSED(parent)
+    Q_UNUSED(destination)
 
-        if (newDocument == oldDocument) {
-            // nothing to do
-            ++index;
-        } else if (!newDocument || (oldDocument && !tilesetDocuments.contains(oldDocument))) {
-            deleteTilesetView(index);
+    if (start == row)
+        return;
+
+    while (start <= end) {
+        moveTilesetView(start, row);
+
+        if (row < start) {
+            ++start;
+            ++row;
         } else {
-            createTilesetView(index, newDocument);
-            ++index;
+            --end;
         }
     }
+}
 
-    updateActions();
+void TilesetDock::onTilesetLayoutChanged(const QList<QPersistentModelIndex> &parents, QAbstractItemModel::LayoutChangeHint hint)
+{
+    Q_UNUSED(parents)
+    Q_UNUSED(hint)
+
+    // Make sure the tileset tabs and views are still in the right order
+    for (int i = 0, rows = mTilesetDocumentsFilterModel->rowCount(); i < rows; ++i) {
+        const QModelIndex index = mTilesetDocumentsFilterModel->index(i, 0, QModelIndex());
+        const QVariant var = mTilesetDocumentsFilterModel->data(index, TilesetDocumentsModel::TilesetDocumentRole);
+        TilesetDocument *tilesetDocument = var.value<TilesetDocument*>();
+        int currentIndex = mTilesetDocuments.indexOf(tilesetDocument);
+        if (currentIndex != i) {
+            Q_ASSERT(currentIndex > i);
+            moveTilesetView(currentIndex, i);
+        }
+    }
+}
+
+void TilesetDock::onTilesetDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
+{
+    // Update the titles of the affected tabs
+    for (int i = topLeft.row(); i <= bottomRight.row(); ++i) {
+        const SharedTileset &tileset = mTilesets.at(i);
+        if (mTabBar->tabText(i) != tileset->name())
+            mTabBar->setTabText(i, tileset->name());
+        mTabBar->setTabToolTip(i, tileset->fileName());
+    }
+}
+
+void TilesetDock::onTabMoved(int from, int to)
+{
+#if QT_VERSION >= 0x050600
+    mTilesets.move(from, to);
+#else
+    mTilesets.insert(to, mTilesets.takeAt(from));
+#endif
+    mTilesetDocuments.move(from, to);
+
+    // Move the related tileset view
+    const QSignalBlocker blocker(mViewStack);
+    QWidget *widget = mViewStack->widget(from);
+    mViewStack->removeWidget(widget);
+    mViewStack->insertWidget(to, widget);
 }
 
 Tileset *TilesetDock::currentTileset() const
@@ -886,21 +904,6 @@ void TilesetDock::embedTileset()
     int embeddedTilesetIndex = mTilesets.indexOf(embeddedTileset);
     if (embeddedTilesetIndex != -1)
         mTabBar->setCurrentIndex(embeddedTilesetIndex);
-}
-
-void TilesetDock::tilesetNameChanged(Tileset *tileset)
-{
-    const int index = indexOf(mTilesets, tileset);
-    Q_ASSERT(index != -1);
-
-    mTabBar->setTabText(index, tileset->name());
-
-    std::stable_sort(mTilesetDocuments.begin(), mTilesetDocuments.end(), lessThan);
-
-    auto tilesetDocument = static_cast<TilesetDocument*>(sender());
-    const int newIndex = indexOf(mTilesetDocuments, tilesetDocument);
-    if (index != newIndex)
-        moveTilesetView(index, newIndex);
 }
 
 void TilesetDock::tilesetFileNameChanged(const QString &fileName)

--- a/src/tiled/tilesetdock.h
+++ b/src/tiled/tilesetdock.h
@@ -24,6 +24,7 @@
 
 #include "tileset.h"
 
+#include <QAbstractItemModel>
 #include <QDockWidget>
 #include <QList>
 #include <QMap>
@@ -51,6 +52,7 @@ namespace Internal {
 class Document;
 class MapDocument;
 class TilesetDocument;
+class TilesetDocumentsFilterModel;
 class TilesetView;
 class TileStamp;
 class Zoomable;
@@ -114,7 +116,6 @@ private slots:
     void updateCurrentTiles();
 
     void tilesetChanged(Tileset *tileset);
-    void tilesetNameChanged(Tileset *tileset);
     void tilesetFileNameChanged(const QString &fileName);
 
     void tileImageSourceChanged(Tile *tile);
@@ -138,7 +139,13 @@ private:
     void setCurrentTiles(TileLayer *tiles);
     void retranslateUi();
 
-    void updateTilesets();
+    void onTilesetRowsInserted(const QModelIndex &parent, int first, int last);
+    void onTilesetRowsAboutToBeRemoved(const QModelIndex &parent, int first, int last);
+    void onTilesetRowsMoved(const QModelIndex &parent, int start, int end, const QModelIndex &destination, int row);
+    void onTilesetLayoutChanged(const QList<QPersistentModelIndex> &parents, QAbstractItemModel::LayoutChangeHint hint);
+    void onTilesetDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
+
+    void onTabMoved(int from, int to);
 
     Tileset *currentTileset() const;
     TilesetView *currentTilesetView() const;
@@ -154,6 +161,7 @@ private:
     // Shared tileset references because the dock wants to add new tiles
     QVector<SharedTileset> mTilesets;
     QList<TilesetDocument *> mTilesetDocuments;
+    TilesetDocumentsFilterModel *mTilesetDocumentsFilterModel;
 
     QTabBar *mTabBar;
     QStackedWidget *mViewStack;

--- a/src/tiled/tilesetdocument.cpp
+++ b/src/tiled/tilesetdocument.cpp
@@ -73,12 +73,6 @@ TilesetDocument::TilesetDocument(const SharedTileset &tileset, const QString &fi
     connect(this, &TilesetDocument::propertiesChanged,
             this, &TilesetDocument::onPropertiesChanged);
 
-    connect(mTerrainModel, &TilesetTerrainModel::terrainAboutToBeAdded,
-            this, &TilesetDocument::onTerrainAboutToBeAdded);
-    connect(mTerrainModel, &TilesetTerrainModel::terrainAdded,
-            this, &TilesetDocument::onTerrainAdded);
-    connect(mTerrainModel, &TilesetTerrainModel::terrainAboutToBeRemoved,
-            this, &TilesetDocument::onTerrainAboutToBeRemoved);
     connect(mTerrainModel, &TilesetTerrainModel::terrainRemoved,
             this, &TilesetDocument::onTerrainRemoved);
 
@@ -335,31 +329,10 @@ void TilesetDocument::onPropertiesChanged(Object *object)
         emit mapDocument->propertiesChanged(object);
 }
 
-void TilesetDocument::onTerrainAboutToBeAdded(Tileset *tileset, int terrainId)
-{
-    for (MapDocument *mapDocument : mapDocuments())
-        emit mapDocument->tilesetTerrainAboutToBeAdded(tileset, terrainId);
-}
-
-void TilesetDocument::onTerrainAdded(Tileset *tileset, int terrainId)
-{
-    for (MapDocument *mapDocument : mapDocuments())
-        emit mapDocument->tilesetTerrainAdded(tileset, terrainId);
-}
-
-void TilesetDocument::onTerrainAboutToBeRemoved(Terrain *terrain)
-{
-    for (MapDocument *mapDocument : mapDocuments())
-        emit mapDocument->tilesetTerrainAboutToBeRemoved(mTileset.data(), terrain);
-}
-
 void TilesetDocument::onTerrainRemoved(Terrain *terrain)
 {
     if (terrain == mCurrentObject)
         setCurrentObject(nullptr);
-
-    for (MapDocument *mapDocument : mapDocuments())
-        emit mapDocument->tilesetTerrainRemoved(mTileset.data(), terrain);
 }
 
 } // namespace Internal

--- a/src/tiled/tilesetdocument.h
+++ b/src/tiled/tilesetdocument.h
@@ -137,9 +137,6 @@ private slots:
     void onPropertyChanged(Object *object, const QString &name);
     void onPropertiesChanged(Object *object);
 
-    void onTerrainAboutToBeAdded(Tileset *tileset, int terrainId);
-    void onTerrainAdded(Tileset *tileset, int terrainId);
-    void onTerrainAboutToBeRemoved(Terrain *terrain);
     void onTerrainRemoved(Terrain *terrain);
 
 private:

--- a/src/tiled/tilesetdocumentsmodel.cpp
+++ b/src/tiled/tilesetdocumentsmodel.cpp
@@ -1,0 +1,139 @@
+/*
+ * tilesetdocumentsmodel.cpp
+ * Copyright 2017, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "tilesetdocumentsmodel.h"
+
+#include "documentmanager.h"
+#include "mapdocument.h"
+#include "tilesetdocument.h"
+#include "tileset.h"
+
+#include <algorithm>
+
+namespace Tiled {
+namespace Internal {
+
+TilesetDocumentsModel::TilesetDocumentsModel(QObject *parent)
+    : QAbstractListModel(parent)
+{
+}
+
+int TilesetDocumentsModel::rowCount(const QModelIndex &parent) const
+{
+    return parent.isValid() ? 0 : mTilesetDocuments.size();
+}
+
+QVariant TilesetDocumentsModel::data(const QModelIndex &index, int role) const
+{
+    TilesetDocument *document = mTilesetDocuments.at(index.row());
+
+    switch (role) {
+    case TilesetDocumentRole:
+        return QVariant::fromValue(document);
+    case TilesetRole:
+        return QVariant::fromValue(document->tileset());
+    case Qt::DisplayRole:
+        return document->tileset()->name();
+    case Qt::ToolTipRole:
+        return document->fileName();
+    }
+
+    return QVariant();
+}
+
+void TilesetDocumentsModel::insert(int index, TilesetDocument *tilesetDocument)
+{
+    beginInsertRows(QModelIndex(), index, index);
+    mTilesetDocuments.insert(index, tilesetDocument);
+    endInsertRows();
+
+    connect(tilesetDocument, &TilesetDocument::tilesetNameChanged,
+            this, &TilesetDocumentsModel::tilesetNameChanged);
+    connect(tilesetDocument, &TilesetDocument::fileNameChanged,
+            this, &TilesetDocumentsModel::tilesetFileNameChanged);
+}
+
+void TilesetDocumentsModel::remove(int index)
+{
+    beginRemoveRows(QModelIndex(), index, index);
+    TilesetDocument *tilesetDocument = mTilesetDocuments.takeAt(index);
+    endRemoveRows();
+
+    tilesetDocument->disconnect(this);
+}
+
+void TilesetDocumentsModel::tilesetNameChanged(Tileset *tileset)
+{
+    for (int i = 0; i < mTilesetDocuments.size(); ++i) {
+        TilesetDocument *doc = mTilesetDocuments.at(i);
+        if (doc->tileset() == tileset) {
+            const QModelIndex dataIndex = index(i, 0, QModelIndex());
+            emit dataChanged(dataIndex, dataIndex, { Qt::DisplayRole });
+            break;
+        }
+    }
+}
+
+void TilesetDocumentsModel::tilesetFileNameChanged()
+{
+    TilesetDocument *tilesetDocument = static_cast<TilesetDocument*>(sender());
+    for (int i = 0; i < mTilesetDocuments.size(); ++i) {
+        if (mTilesetDocuments.at(i) == tilesetDocument) {
+            const QModelIndex dataIndex = index(i, 0, QModelIndex());
+            emit dataChanged(dataIndex, dataIndex, { Qt::ToolTipRole });
+            break;
+        }
+    }
+}
+
+
+TilesetDocumentsFilterModel::TilesetDocumentsFilterModel(QObject *parent)
+    : QSortFilterProxyModel(parent)
+    , mMapDocument(nullptr)
+{
+    setSortLocaleAware(true);
+    setSourceModel(DocumentManager::instance()->tilesetDocumentsModel());
+    sort(0);
+}
+
+void TilesetDocumentsFilterModel::setMapDocument(MapDocument *mapDocument)
+{
+    if (mMapDocument == mapDocument)
+        return;
+
+    mMapDocument = mapDocument;
+    invalidateFilter();
+}
+
+bool TilesetDocumentsFilterModel::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
+{
+    const auto sm = sourceModel();
+    const auto index = sm->index(sourceRow, 0, sourceParent);
+    const QVariant variant = sm->data(index, TilesetDocumentsModel::TilesetDocumentRole);
+    const TilesetDocument *tilesetDocument = variant.value<TilesetDocument *>();
+    Q_ASSERT(tilesetDocument);
+
+    const bool accepted = !tilesetDocument->isEmbedded()
+            || tilesetDocument->mapDocuments().first() == mMapDocument;
+    return accepted;
+}
+
+} // namespace Internal
+} // namespace Tiled

--- a/src/tiled/tilesetdocumentsmodel.h
+++ b/src/tiled/tilesetdocumentsmodel.h
@@ -1,0 +1,113 @@
+/*
+ * tilesetdocumentsmodel.h
+ * Copyright 2017, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TILESETDOCUMENTSMODEL_H
+#define TILESETDOCUMENTSMODEL_H
+
+#include <QAbstractListModel>
+#include <QList>
+#include <QSortFilterProxyModel>
+
+namespace Tiled {
+
+class Tileset;
+
+namespace Internal {
+
+class MapDocument;
+class TilesetDocument;
+
+/**
+ * This model exposes the list of tileset documents. This includes opened
+ * tileset files, as well as both internal and external tilesets loaded as part
+ * of a map.
+ */
+class TilesetDocumentsModel : public QAbstractListModel
+{
+public:
+    enum {
+        TilesetDocumentRole = Qt::UserRole,
+        TilesetRole,
+    };
+
+    TilesetDocumentsModel(QObject *parent = nullptr);
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+
+    const QList<TilesetDocument *> &tilesetDocuments() const;
+
+    bool contains(TilesetDocument *tilesetDocument) const;
+    void append(TilesetDocument *tilesetDocument);
+    void insert(int index, TilesetDocument *tilesetDocument);
+    void remove(TilesetDocument *tilesetDocument);
+    void remove(int index);
+
+private:
+    void tilesetNameChanged(Tileset *tileset);
+    void tilesetFileNameChanged();
+
+    QList<TilesetDocument *> mTilesetDocuments;
+};
+
+
+inline const QList<TilesetDocument *> &TilesetDocumentsModel::tilesetDocuments() const
+{
+    return mTilesetDocuments;
+}
+
+inline bool TilesetDocumentsModel::contains(TilesetDocument *tilesetDocument) const
+{
+    return mTilesetDocuments.contains(tilesetDocument);
+}
+
+inline void TilesetDocumentsModel::append(TilesetDocument *tilesetDocument)
+{
+    insert(mTilesetDocuments.size(), tilesetDocument);
+}
+
+inline void TilesetDocumentsModel::remove(TilesetDocument *tilesetDocument)
+{
+    remove(mTilesetDocuments.indexOf(tilesetDocument));
+}
+
+
+/**
+ * Sorts the tilesets in alphabetical order and filters out embedded tilesets
+ * that are not part of the current map document.
+ */
+class TilesetDocumentsFilterModel : public QSortFilterProxyModel
+{
+public:
+    TilesetDocumentsFilterModel(QObject *parent = nullptr);
+
+    void setMapDocument(MapDocument *mapDocument);
+
+protected:
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
+
+private:
+    MapDocument *mMapDocument;
+};
+
+} // namespace Internal
+} // namespace Tiled
+
+#endif // TILESETDOCUMENTSMODEL_H


### PR DESCRIPTION
This model lists the tileset documents that are currently open, and the sort-filter version sorts them by name and filters out tilesets that are embedded in other maps than the current one.

This model extracts part of the logic from TilesetDock, so that it could be reused by an updated TerrainModel. The TerrainModel currently only lists terrains from tilesets that are already part of the map, but it should display all loaded external tilesets.

This is for addressing the following issue raised on the forum:
http://discourse.mapeditor.org/t/created-a-terrain-but-its-not-showing-up-in-the-terrain-tab/2478