### PR TITLE
Fixed wrong exception being caught in TileSet.

### DIFF
--- a/util/java/libtiled-java/src/main/java/tiled/core/TileSet.java
+++ b/util/java/libtiled-java/src/main/java/tiled/core/TileSet.java
@@ -417,7 +417,7 @@ public class TileSet implements Iterable<Tile> {
     public Tile getTile(int i) {
         try {
             return tiles.get(i);
-        } catch (ArrayIndexOutOfBoundsException a) {
+        } catch (IndexOutOfBoundsException a) {
         }
         return null;
     }


### PR DESCRIPTION
Issue #1626 happens because an incorrect exception is caught in TileSet#getTile(). This makes it catch the correct exception.