### PR TITLE
Fix tile replacement

### DIFF
--- a/src/tiled/changemapobject.cpp
+++ b/src/tiled/changemapobject.cpp
@@ -118,6 +118,18 @@ static void setObjectCell(MapObject *object,
         object->setSize(cell.tile()->size());
 }
 
+void ChangeMapObjectsTile::undo()
+{
+    restoreTiles();
+    QUndoCommand::undo(); // undo child commands
+}
+
+void ChangeMapObjectsTile::redo()
+{
+    QUndoCommand::redo(); // redo child commands
+    changeTiles();
+}
+
 void ChangeMapObjectsTile::restoreTiles()
 {
     for (int i = 0; i < mMapObjects.size(); ++i)

--- a/src/tiled/changemapobject.h
+++ b/src/tiled/changemapobject.h
@@ -94,8 +94,8 @@ public:
                          const QList<MapObject *> &mapObjects,
                          Tile *tile);
 
-    void undo() override { restoreTiles(); }
-    void redo() override { changeTiles(); }
+    void undo() override;
+    void redo() override;
 
 private:
     void changeTiles();

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -1006,6 +1006,15 @@ void TilesetDock::changeSelectedMapObjectsTile(Tile *tile)
     if (tileObjects.isEmpty())
         return;
 
-    QUndoStack *undoStack = mMapDocument->undoStack();
-    undoStack->push(new ChangeMapObjectsTile(mMapDocument, tileObjects, tile));
+    auto changeMapObjectCommand = new ChangeMapObjectsTile(mMapDocument, tileObjects, tile);
+
+    if (Tileset *tileset = tile->tileset()) {
+        SharedTileset sharedTileset = tileset->sharedPointer();
+
+        // Make sure this tileset is part of the map
+        if (!mMapDocument->map()->tilesets().contains(sharedTileset))
+            new AddTileset(mMapDocument, sharedTileset, changeMapObjectCommand);
+    }
+
+    mMapDocument->undoStack()->push(changeMapObjectCommand);
 }

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -1008,13 +1008,10 @@ void TilesetDock::changeSelectedMapObjectsTile(Tile *tile)
 
     auto changeMapObjectCommand = new ChangeMapObjectsTile(mMapDocument, tileObjects, tile);
 
-    if (Tileset *tileset = tile->tileset()) {
-        SharedTileset sharedTileset = tileset->sharedPointer();
-
-        // Make sure this tileset is part of the map
-        if (!mMapDocument->map()->tilesets().contains(sharedTileset))
-            new AddTileset(mMapDocument, sharedTileset, changeMapObjectCommand);
-    }
+    // Make sure the tileset is part of the map
+    SharedTileset sharedTileset = tile->tileset()->sharedPointer();
+    if (!mMapDocument->map()->tilesets().contains(sharedTileset))
+        new AddTileset(mMapDocument, sharedTileset, changeMapObjectCommand);
 
     mMapDocument->undoStack()->push(changeMapObjectCommand);
 }


### PR DESCRIPTION
When the tile of an object is replaced with a tile from an unused tileset, the new tileset wasn't added to the map. This PR fixes that.