### PR TITLE
Adds move selection feature

### DIFF
--- a/src/tiled/abstracttileselectiontool.h
+++ b/src/tiled/abstracttileselectiontool.h
@@ -23,6 +23,8 @@
 
 #include "abstracttiletool.h"
 
+#include "tilelayer.h"
+
 class QAction;
 class QActionGroup;
 
@@ -41,6 +43,7 @@ public:
                               const QKeySequence &shortcut,
                               QObject *parent = nullptr);
 
+    void mouseMoved(const QPointF &pos,Qt::KeyboardModifiers modifiers) override;
     void mousePressed(QGraphicsSceneMouseEvent *event) override;
     void mouseReleased(QGraphicsSceneMouseEvent *event) override;
 
@@ -51,6 +54,8 @@ public:
     void populateToolBar(QToolBar *toolBar) override;
 
 protected:
+    void tilePositionChanged(const QPoint &pos) override;
+
     enum SelectionMode {
         Replace,
         Add,
@@ -63,7 +68,28 @@ protected:
     QRegion selectedRegion() { return mSelectedRegion; }
     void setSelectedRegion(QRegion region) { mSelectedRegion = region; }
 
+    bool moving() { return mMoving; }
+
 private:
+    void activate();
+    void deactivate();
+
+    void refreshCursor();
+
+    void cut();
+    void paste();
+
+    bool mMoving;
+    bool mDragging;
+    bool mMousePressed;
+    bool mDuplicate;
+
+    QPoint mMouseStart;
+    QPoint mDragStart;
+    QPoint mLastUpdate;
+
+    SharedTileLayer mPreviewLayer;
+    TileLayer *mTargetLayer;
 
     SelectionMode mSelectionMode;
     SelectionMode mDefaultMode;

--- a/src/tiled/magicwandtool.cpp
+++ b/src/tiled/magicwandtool.cpp
@@ -40,6 +40,11 @@ MagicWandTool::MagicWandTool(QObject *parent)
 
 void MagicWandTool::tilePositionChanged(const QPoint &tilePos)
 {
+    AbstractTileSelectionTool::tilePositionChanged(tilePos);
+
+    if (moving())
+        return;
+
     // Make sure that a tile layer is selected
     TileLayer *tileLayer = currentTileLayer();
     if (!tileLayer)

--- a/src/tiled/selectsametiletool.cpp
+++ b/src/tiled/selectsametiletool.cpp
@@ -36,6 +36,11 @@ SelectSameTileTool::SelectSameTileTool(QObject *parent)
 
 void SelectSameTileTool::tilePositionChanged(const QPoint &tilePos)
 {
+    AbstractTileSelectionTool::tilePositionChanged(tilePos);
+
+    if (moving())
+        return;
+
     // Make sure that a tile layer is selected and contains current tile pos.
     TileLayer *tileLayer = currentTileLayer();
     if (!tileLayer)

--- a/src/tiled/tileselectiontool.h
+++ b/src/tiled/tileselectiontool.h
@@ -39,7 +39,7 @@ public:
     void languageChanged() override;
 
 protected:
-    void tilePositionChanged(const QPoint &tilePos) override;
+    void tilePositionChanged(const QPoint &pos) override;
 
     void updateStatusInfo() override;
 


### PR DESCRIPTION
#650 

The tool works when an area is selected and then Ctrl+Alt is used to move the selection. Ctrl+Alt+Shift is used to duplicate the selection but this modifer works weirdly (You need to hold Ctrl+Alt and after that the shift).