### PR TITLE
Show red highlight over brush item on locked layer

### DIFF
--- a/src/tiled/brushitem.cpp
+++ b/src/tiled/brushitem.cpp
@@ -148,6 +148,11 @@ void BrushItem::paint(QPainter *painter,
         painter->setOpacity(opacity);
     }
 
+    if (!mMapDocument->currentLayer()->isUnlocked()) {
+        insideMapRegion = QRegion();
+        outsideMapRegion = mRegion;
+    }
+
     renderer->drawTileSelection(painter, insideMapRegion,
                                 insideMapHighlight,
                                 option->exposedRect);

--- a/src/tiled/brushitem.cpp
+++ b/src/tiled/brushitem.cpp
@@ -137,6 +137,10 @@ void BrushItem::paint(QPainter *painter,
     int mapWidth = mMapDocument->map()->width();
     int mapHeight = mMapDocument->map()->height();
     QRegion mapRegion = QRegion(0, 0, mapWidth, mapHeight);
+
+    if (!mMapDocument->currentLayer()->isUnlocked())
+        mapRegion = QRegion();
+
     QRegion insideMapRegion = mRegion.intersected(mapRegion);
     QRegion outsideMapRegion = mRegion.subtracted(mapRegion);
 
@@ -146,11 +150,6 @@ void BrushItem::paint(QPainter *painter,
         painter->setOpacity(0.75);
         renderer->drawTileLayer(painter, mTileLayer.data(), option->exposedRect);
         painter->setOpacity(opacity);
-    }
-
-    if (!mMapDocument->currentLayer()->isUnlocked()) {
-        insideMapRegion = QRegion();
-        outsideMapRegion = mRegion;
     }
 
     renderer->drawTileSelection(painter, insideMapRegion,


### PR DESCRIPTION
This gives a clear sign to the user in case of locked layer. Also helps when the current layer is not locked but some parent layer is locked because it's not very intuitive that we won't be able to paint on the current layer.