### PR TITLE
Editing templates

### DIFF
--- a/src/libtiled/mapobject.h
+++ b/src/libtiled/mapobject.h
@@ -170,6 +170,7 @@ public:
     void setShape(Shape shape);
 
     bool isPolyShape() const;
+    bool isTileObject() const;
 
     QRectF bounds() const;
     QRectF boundsUseTile() const;
@@ -401,6 +402,9 @@ inline void MapObject::setShape(MapObject::Shape shape)
  */
 inline bool MapObject::isPolyShape() const
 { return mShape == Polygon || mShape == Polyline; }
+
+inline bool MapObject::isTileObject() const
+{ return !mCell.isEmpty(); }
 
 /**
  * Shortcut to getting a QRectF from position() and size().

--- a/src/libtiled/objecttemplate.h
+++ b/src/libtiled/objecttemplate.h
@@ -43,7 +43,7 @@ public:
     ObjectTemplate(unsigned id, QString name);
 
     const MapObject *object() const;
-    void setObject(MapObject *object);
+    void setObject(const MapObject *object);
 
     unsigned id() const;
     void setId(unsigned id);
@@ -64,8 +64,9 @@ private:
 inline const MapObject *ObjectTemplate::object() const
 { return mObject; }
 
-inline void ObjectTemplate::setObject(MapObject *object)
+inline void ObjectTemplate::setObject(const MapObject *object)
 {
+    delete mObject;
     mObject = object->clone();
     mObject->setId(0);
 }

--- a/src/tiled/abstractobjecttool.h
+++ b/src/tiled/abstractobjecttool.h
@@ -73,6 +73,7 @@ private slots:
     void removeObjects();
     void resetTileSize();
     void saveSelectedObject();
+    void changeTile();
 
     void flipHorizontally();
     void flipVertically();

--- a/src/tiled/abstracttool.cpp
+++ b/src/tiled/abstracttool.cpp
@@ -35,6 +35,7 @@ AbstractTool::AbstractTool(const QString &name, const QIcon &icon,
     , mIcon(icon)
     , mShortcut(shortcut)
     , mEnabled(false)
+    , mTile(nullptr)
     , mMapDocument(nullptr)
 {
 }

--- a/src/tiled/abstracttool.h
+++ b/src/tiled/abstracttool.h
@@ -36,6 +36,7 @@ class QToolBar;
 namespace Tiled {
 
 class Layer;
+class Tile;
 
 namespace Internal {
 
@@ -90,6 +91,8 @@ public:
 
     bool isEnabled() const;
     void setEnabled(bool enabled);
+
+    Tile *tile() const;
 
     /**
      * Activates this tool. If the tool plans to add any items to the scene, it
@@ -148,6 +151,7 @@ public:
 
 public slots:
     void setMapDocument(MapDocument *mapDocument);
+    void setTile(Tile *tile);
 
 protected:
     /**
@@ -186,6 +190,7 @@ private:
     QString mStatusInfo;
     QCursor mCursor;
     bool mEnabled;
+    Tile *mTile;
 
     MapDocument *mMapDocument;
 };
@@ -234,6 +239,16 @@ inline QCursor AbstractTool::cursor() const
 inline bool AbstractTool::isEnabled() const
 {
     return mEnabled;
+}
+
+inline Tile *AbstractTool::tile() const
+{
+    return mTile;
+}
+
+inline void AbstractTool::setTile(Tile *tile)
+{
+    mTile = tile;
 }
 
 } // namespace Internal

--- a/src/tiled/createobjecttool.cpp
+++ b/src/tiled/createobjecttool.cpp
@@ -50,7 +50,6 @@ CreateObjectTool::CreateObjectTool(QObject *parent)
     , mObjectGroupItem(new ObjectGroupItem(mNewMapObjectGroup))
     , mNewMapObjectItem(nullptr)
     , mOverlayPolygonItem(nullptr)
-    , mTile(nullptr)
 {
     mObjectGroupItem->setZValue(10000); // same as the BrushItem
 }

--- a/src/tiled/createobjecttool.h
+++ b/src/tiled/createobjecttool.h
@@ -49,13 +49,6 @@ public:
     void mousePressed(QGraphicsSceneMouseEvent *event) override;
     void mouseReleased(QGraphicsSceneMouseEvent *event) override;
 
-public slots:
-    /**
-     * Sets the tile that will be used when the creation mode is
-     * CreateTileObjects.
-     */
-    void setTile(Tile *tile) { mTile = tile; }
-
 protected:
     virtual void mouseMovedWhileCreatingObject(const QPointF &pos,
                                                Qt::KeyboardModifiers modifiers);
@@ -73,7 +66,6 @@ protected:
     ObjectGroupItem *mObjectGroupItem;
     MapObjectItem *mNewMapObjectItem;
     MapObjectItem *mOverlayPolygonItem;
-    Tile *mTile;
 };
 
 } // namespace Internal

--- a/src/tiled/createtileobjecttool.cpp
+++ b/src/tiled/createtileobjecttool.cpp
@@ -86,12 +86,12 @@ void CreateTileObjectTool::languageChanged()
 
 MapObject *CreateTileObjectTool::createNewMapObject()
 {
-    if (!mTile)
+    if (!tile())
         return nullptr;
 
     MapObject *newMapObject = new MapObject;
     newMapObject->setShape(MapObject::Rectangle);
-    newMapObject->setCell(Cell(mTile));
-    newMapObject->setSize(mTile->size());
+    newMapObject->setCell(Cell(tile()));
+    newMapObject->setSize(tile()->size());
     return newMapObject;
 }

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -924,6 +924,20 @@ void MapDocument::onLayerRemoved(Layer *layer)
     emit layerRemoved(layer);
 }
 
+void MapDocument::updateTemplateInstances(const MapObject *mapObject)
+{
+    QList<MapObject*> objectList;
+    for (ObjectGroup *group : mMap->objectGroups()) {
+        for (auto object : group->objects()) {
+            if (object->isTemplateInstance() && object->templateObject() == mapObject) {
+                object->syncWithTemplate();
+                objectList.append(object);
+            }
+        }
+    }
+    emit objectsChanged(objectList);
+}
+
 void MapDocument::deselectObjects(const QList<MapObject *> &objects)
 {
     // Unset the current object when it was part of this list of objects

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -303,6 +303,9 @@ private slots:
     void onLayerAboutToBeRemoved(GroupLayer *groupLayer, int index);
     void onLayerRemoved(Layer *layer);
 
+public slots:
+    void updateTemplateInstances(const MapObject *mapObject);
+
 private:
     void deselectObjects(const QList<MapObject*> &objects);
     void moveObjectIndex(const MapObject *object, int count);

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -243,7 +243,8 @@ MapEditor::MapEditor(QObject *parent)
 
     connect(mWidgetStack, &QStackedWidget::currentChanged, this, &MapEditor::currentWidgetChanged);
     connect(mToolManager, &ToolManager::statusInfoChanged, this, &MapEditor::updateStatusInfoLabel);
-    connect(mTilesetDock, &TilesetDock::currentTileChanged, tileObjectsTool, &CreateObjectTool::setTile);
+    connect(mTilesetDock, &TilesetDock::currentTileChanged, mToolManager, &ToolManager::setTile);
+    connect(mTilesetDock, &TilesetDock::currentTileChanged, mTemplatesDock, &TemplatesDock::setTile);
     connect(mTilesetDock, &TilesetDock::stampCaptured, this, &MapEditor::setStamp);
     connect(mTilesetDock, &TilesetDock::localFilesDropped, this, &MapEditor::filesDroppedOnTilesetDock);
     connect(mTemplatesDock, &TemplatesDock::currentTemplateChanged, templatesTool, &CreateTemplateTool::setTemplate);

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -403,9 +403,6 @@ void MapEditor::setCurrentDocument(Document *document)
     mMiniMapDock->setMapDocument(mapDocument);
 
     if (mapDocument) {
-        connect(mapDocument, &MapDocument::currentObjectChanged,
-                this, [this, mapDocument](){ mPropertiesDock->setDocument(mapDocument); });
-
         connect(mapDocument, &MapDocument::currentLayerChanged,
                 this, &MapEditor::updateLayerComboIndex);
 //        connect(mapDocument, SIGNAL(selectedAreaChanged(QRegion,QRegion)),
@@ -417,6 +414,12 @@ void MapEditor::setCurrentDocument(Document *document)
             mZoomable = mapView->zoomable();
             mZoomable->setComboBox(mZoomComboBox);
         }
+
+        connect(mCurrentMapDocument, &MapDocument::currentObjectChanged,
+                this, [this, mapDocument](){ mPropertiesDock->setDocument(mapDocument); });
+
+        connect(mapView, &MapView::focused,
+                this, [this, mapDocument](){ mPropertiesDock->setDocument(mapDocument); });
 
         mReversingProxyModel->setSourceModel(mapDocument->layerModel());
     } else {

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -282,6 +282,9 @@ MapEditor::MapEditor(QObject *parent)
     connect(mToolManager, &ToolManager::selectedToolChanged,
             this, &MapEditor::setSelectedTool);
 
+    connect(mTemplatesDock, &TemplatesDock::templateEdited,
+            this, &MapEditor::updateTemplateInstances);
+
     setupQuickStamps();
     retranslateUi();
     connect(Preferences::instance(), &Preferences::languageChanged, this, &MapEditor::retranslateUi);
@@ -763,6 +766,15 @@ void MapEditor::addExternalTilesets(const QStringList &fileNames)
 void MapEditor::filesDroppedOnTilesetDock(const QStringList &fileNames)
 {
     handleExternalTilesetsAndImages(fileNames, true);
+}
+
+void MapEditor::updateTemplateInstances(const MapObject *mapObject)
+{
+    QHashIterator<MapDocument*, MapView*> mapDocumentIterator(mWidgetForMap);
+    while (mapDocumentIterator.hasNext()) {
+        mapDocumentIterator.next();
+        mapDocumentIterator.key()->updateTemplateInstances(mapObject);
+    }
 }
 
 void MapEditor::handleExternalTilesetsAndImages(const QStringList &fileNames,

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -203,6 +203,7 @@ MapEditor::MapEditor(QObject *parent)
     mMainWindow->addToolBar(mToolSpecificToolBar);
 
     mPropertiesDock = new PropertiesDock(mMainWindow);
+    mTemplatesDock->setPropertiesDock(mPropertiesDock);
     mTileStampsDock = new TileStampsDock(mTileStampManager, mMainWindow);
 
     mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mLayerDock);
@@ -399,6 +400,9 @@ void MapEditor::setCurrentDocument(Document *document)
     mMiniMapDock->setMapDocument(mapDocument);
 
     if (mapDocument) {
+        connect(mapDocument, &MapDocument::currentObjectChanged,
+                this, [this, mapDocument](){ mPropertiesDock->setDocument(mapDocument); });
+
         connect(mapDocument, &MapDocument::currentLayerChanged,
                 this, &MapEditor::updateLayerComboIndex);
 //        connect(mapDocument, SIGNAL(selectedAreaChanged(QRegion,QRegion)),

--- a/src/tiled/mapeditor.h
+++ b/src/tiled/mapeditor.h
@@ -38,6 +38,7 @@ class QToolButton;
 
 namespace Tiled {
 
+class MapObject;
 class Terrain;
 
 namespace Internal {
@@ -122,6 +123,8 @@ public slots:
 
     void addExternalTilesets(const QStringList &fileNames);
     void filesDroppedOnTilesetDock(const QStringList &fileNames);
+
+    void updateTemplateInstances(const MapObject *mapObject);
 
 private slots:
     void currentWidgetChanged();

--- a/src/tiled/mapview.cpp
+++ b/src/tiled/mapview.cpp
@@ -316,6 +316,12 @@ void MapView::mouseReleaseEvent(QMouseEvent *event)
     QGraphicsView::mouseReleaseEvent(event);
 }
 
+void MapView::focusInEvent(QFocusEvent *event)
+{
+    Q_UNUSED(event);
+    emit focused();
+}
+
 /**
  * Moves the view with the mouse while hand scrolling.
  */

--- a/src/tiled/mapview.h
+++ b/src/tiled/mapview.h
@@ -79,9 +79,14 @@ protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
 
+    void focusInEvent(QFocusEvent *event) override;
+
     void handlePinchGesture(QPinchGesture *pinch);
 
     void adjustCenterFromMousePosition(QPoint &mousePos);
+
+signals:
+    void focused();
 
 private slots:
     void adjustScale(qreal scale);

--- a/src/tiled/objecttemplatemodel.cpp
+++ b/src/tiled/objecttemplatemodel.cpp
@@ -227,6 +227,16 @@ ObjectTemplate *ObjectTemplateModel::toObjectTemplate(const QModelIndex &index) 
     return nullptr;
 }
 
+void ObjectTemplateModel::save(const TemplateGroup *templateGroup) const
+{
+    for (auto document : mTemplateDocuments) {
+        if (document->templateGroup() == templateGroup) {
+            document->save(document->fileName());
+            break;
+        }
+    }
+}
+
 TemplateGroup *ObjectTemplateModel::toTemplateGroup(const QModelIndex &index) const
 {
     if (!index.isValid())

--- a/src/tiled/objecttemplatemodel.h
+++ b/src/tiled/objecttemplatemodel.h
@@ -55,6 +55,7 @@ public:
     bool addTemplateGroup(TemplateGroup *templateGroup);
     bool saveObjectToDocument(MapObject *object, QString name, int documentIndex);
     ObjectTemplate *toObjectTemplate(const QModelIndex &index) const;
+    void save(const TemplateGroup *templateGroup) const;
 
     Qt::ItemFlags flags(const QModelIndex &index) const override;
     QStringList mimeTypes() const override;

--- a/src/tiled/propertiesdock.cpp
+++ b/src/tiled/propertiesdock.cpp
@@ -104,6 +104,9 @@ PropertiesDock::PropertiesDock(QWidget *parent)
 
 void PropertiesDock::setDocument(Document *document)
 {
+    if (mDocument == document)
+        return;
+
     if (mDocument)
         mDocument->disconnect(this);
 

--- a/src/tiled/templatesdock.cpp
+++ b/src/tiled/templatesdock.cpp
@@ -166,6 +166,10 @@ TemplatesDock::TemplatesDock(QWidget *parent):
 
     connect(mToolManager, &ToolManager::selectedToolChanged,
             this, &TemplatesDock::setSelectedTool);
+
+    setFocusPolicy(Qt::ClickFocus);
+    mTemplatesView->setFocusProxy(this);
+    mMapView->setFocusProxy(this);
 }
 
 TemplatesDock::~TemplatesDock()
@@ -352,6 +356,12 @@ void TemplatesDock::applyChanges()
     mUndoAction->setEnabled(mDummyMapDocument->undoStack()->canUndo());
     mRedoAction->setEnabled(mDummyMapDocument->undoStack()->canRedo());
     emit templateEdited(mObjectTemplate->object());
+}
+
+void TemplatesDock::focusInEvent(QFocusEvent *event)
+{
+    Q_UNUSED(event);
+    mPropertiesDock->setDocument(mDummyMapDocument);
 }
 
 void TemplatesDock::retranslateUi()

--- a/src/tiled/templatesdock.cpp
+++ b/src/tiled/templatesdock.cpp
@@ -80,6 +80,7 @@ TemplatesDock::TemplatesDock(QWidget *parent):
     mOpenTemplateGroup->setIcon(QIcon(QLatin1String(":/images/16x16/document-open.png")));
     Utils::setThemeIcon(mOpenTemplateGroup, "document-open");
     connect(mOpenTemplateGroup, &QAction::triggered, this, &TemplatesDock::openTemplateGroup);
+    connect(this, &TemplatesDock::setTile, mToolManager, &ToolManager::setTile);
 
     toolBar->addAction(mNewTemplateGroup);
     toolBar->addAction(mOpenTemplateGroup);
@@ -350,8 +351,15 @@ void TemplatesDock::redo()
 
 void TemplatesDock::applyChanges()
 {
+    TemplateGroup *templateGroup = mObjectTemplate->templateGroup();
+
+    // Add the tileset of the new tile in case the operation was change tile
+    // TODO: only save used tilesets
+    if (auto tileset = mObject->cell().tileset())
+        templateGroup->addTileset(tileset->sharedPointer());
+
     mObjectTemplate->setObject(mObject);
-    ObjectTemplateModel::instance()->save(mObjectTemplate->templateGroup());
+    ObjectTemplateModel::instance()->save(templateGroup);
 
     mUndoAction->setEnabled(mDummyMapDocument->undoStack()->canUndo());
     mRedoAction->setEnabled(mDummyMapDocument->undoStack()->canRedo());

--- a/src/tiled/templatesdock.h
+++ b/src/tiled/templatesdock.h
@@ -31,6 +31,7 @@ namespace Tiled {
 
 class ObjectTemplate;
 class MapObject;
+class Tile;
 
 namespace Internal {
 
@@ -56,6 +57,7 @@ public:
 signals:
     void currentTemplateChanged(ObjectTemplate *objectTemplate);
     void templateEdited(const MapObject *mapObject);
+    void setTile(Tile *tile);
 
 private slots:
     void setSelectedTool(AbstractTool*tool);

--- a/src/tiled/templatesdock.h
+++ b/src/tiled/templatesdock.h
@@ -55,6 +55,7 @@ public:
 
 signals:
     void currentTemplateChanged(ObjectTemplate *objectTemplate);
+    void templateEdited(const MapObject *mapObject);
 
 private slots:
     void setSelectedTool(AbstractTool*tool);

--- a/src/tiled/templatesdock.h
+++ b/src/tiled/templatesdock.h
@@ -62,6 +62,10 @@ private slots:
     void openTemplateGroup();
     void setTemplate(ObjectTemplate *objectTemplate);
 
+    void undo();
+    void redo();
+    void applyChanges();
+
 private:
     void retranslateUi();
 
@@ -69,6 +73,8 @@ private:
 
     QAction *mNewTemplateGroup;
     QAction *mOpenTemplateGroup;
+    QAction *mUndoAction;
+    QAction *mRedoAction;
 
     MapDocument *mDummyMapDocument;
     MapScene *mMapScene;

--- a/src/tiled/templatesdock.h
+++ b/src/tiled/templatesdock.h
@@ -30,12 +30,18 @@ class QAbstractProxyModel;
 namespace Tiled {
 
 class ObjectTemplate;
+class MapObject;
 
 namespace Internal {
 
+class AbstractTool;
+class MapDocument;
+class MapScene;
+class MapView;
 class ObjectTemplateModel;
-
+class PropertiesDock;
 class TemplatesView;
+class ToolManager;
 
 class TemplatesDock : public QDockWidget
 {
@@ -45,12 +51,16 @@ public:
     TemplatesDock(QWidget *parent = nullptr);
     ~TemplatesDock();
 
+    void setPropertiesDock(PropertiesDock *propertiesDock);
+
 signals:
     void currentTemplateChanged(ObjectTemplate *objectTemplate);
 
 private slots:
+    void setSelectedTool(AbstractTool*tool);
     void newTemplateGroup();
     void openTemplateGroup();
+    void setTemplate(ObjectTemplate *objectTemplate);
 
 private:
     void retranslateUi();
@@ -59,6 +69,14 @@ private:
 
     QAction *mNewTemplateGroup;
     QAction *mOpenTemplateGroup;
+
+    MapDocument *mDummyMapDocument;
+    MapScene *mMapScene;
+    MapView *mMapView;
+    ObjectTemplate *mObjectTemplate;
+    MapObject *mObject;
+    PropertiesDock *mPropertiesDock;
+    ToolManager *mToolManager;
 };
 
 class TemplatesView : public QTreeView
@@ -77,6 +95,9 @@ signals:
 private slots:
     void onPressed(const QModelIndex &index);
 };
+
+inline void TemplatesDock::setPropertiesDock(PropertiesDock *propertiesDock)
+{ mPropertiesDock = propertiesDock; }
 
 } // namespace Internal
 } // namespace Tiled

--- a/src/tiled/templatesdock.h
+++ b/src/tiled/templatesdock.h
@@ -71,6 +71,7 @@ private slots:
 
 protected:
     void focusInEvent(QFocusEvent *event) override;
+    void focusOutEvent(QFocusEvent *event) override;
 
 private:
     void retranslateUi();
@@ -103,9 +104,11 @@ public:
 
 signals:
     void currentTemplateChanged(ObjectTemplate *objectTemplate);
+    void focusInEvent(QFocusEvent *event) override;
+    void focusOutEvent(QFocusEvent *event) override;
 
-private slots:
-    void onPressed(const QModelIndex &index);
+public slots:
+    void updateSelection(const QItemSelection &selected, const QItemSelection &deselected);
 };
 
 inline void TemplatesDock::setPropertiesDock(PropertiesDock *propertiesDock)

--- a/src/tiled/templatesdock.h
+++ b/src/tiled/templatesdock.h
@@ -67,6 +67,9 @@ private slots:
     void redo();
     void applyChanges();
 
+protected:
+    void focusInEvent(QFocusEvent *event) override;
+
 private:
     void retranslateUi();
 

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -989,7 +989,7 @@ static QList<MapObject*> chooseTileObjects(QList<MapObject*> objects)
     QList<MapObject*> tileObjects;
 
     for (auto object : objects)
-        if (!object->cell().isEmpty())
+        if (object->isTileObject())
             tileObjects.append(object);
 
     return tileObjects;

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -35,7 +35,6 @@
 #include "preferences.h"
 #include "replacetileset.h"
 #include "swaptiles.h"
-#include "changemapobject.h"
 #include "terrain.h"
 #include "tile.h"
 #include "tilelayer.h"
@@ -532,8 +531,6 @@ void TilesetDock::createTilesetView(int index, TilesetDocument *tilesetDocument)
             this, &TilesetDock::updateCurrentTiles);
     connect(view, &TilesetView::swapTilesRequested,
             this, &TilesetDock::swapTiles);
-    connect(view, &TilesetView::changeSelectedMapObjectsTileRequested,
-            this, &TilesetDock::changeSelectedMapObjectsTile);
 }
 
 void TilesetDock::deleteTilesetView(int index)
@@ -982,36 +979,4 @@ void TilesetDock::swapTiles(Tile *tileA, Tile *tileB)
 
     QUndoStack *undoStack = mMapDocument->undoStack();
     undoStack->push(new SwapTiles(mMapDocument, tileA, tileB));
-}
-
-static QList<MapObject*> chooseTileObjects(QList<MapObject*> objects)
-{
-    QList<MapObject*> tileObjects;
-
-    for (auto object : objects)
-        if (object->isTileObject())
-            tileObjects.append(object);
-
-    return tileObjects;
-}
-
-void TilesetDock::changeSelectedMapObjectsTile(Tile *tile)
-{
-    if (!mMapDocument)
-        return;
-
-    // Only change tiles of tile objects
-    QList<MapObject*> tileObjects = chooseTileObjects(mMapDocument->selectedObjects());
-
-    if (tileObjects.isEmpty())
-        return;
-
-    auto changeMapObjectCommand = new ChangeMapObjectsTile(mMapDocument, tileObjects, tile);
-
-    // Make sure the tileset is part of the map
-    SharedTileset sharedTileset = tile->tileset()->sharedPointer();
-    if (!mMapDocument->map()->tilesets().contains(sharedTileset))
-        new AddTileset(mMapDocument, sharedTileset, changeMapObjectCommand);
-
-    mMapDocument->undoStack()->push(changeMapObjectCommand);
 }

--- a/src/tiled/tilesetdock.h
+++ b/src/tiled/tilesetdock.h
@@ -134,7 +134,6 @@ private slots:
     void refreshTilesetMenu();
 
     void swapTiles(Tile *tileA, Tile *tileB);
-    void changeSelectedMapObjectsTile(Tile *tile);
 
 private:
     void setCurrentTile(Tile *tile);

--- a/src/tiled/tilesetview.cpp
+++ b/src/tiled/tilesetview.cpp
@@ -1242,17 +1242,6 @@ void TilesetView::contextMenuEvent(QContextMenuEvent *event)
             swapTilesAction->setEnabled(exactlyTwoTilesSelected);
             connect(swapTilesAction, SIGNAL(triggered()),
                     SLOT(swapTiles()));
-
-            bool onlyOneTileSelected =
-                    (selectionModel()->selectedIndexes().size() == 1);
-
-            // TODO: check that at least one object is selected
-
-            QAction *changeSelectedMapObjectsTileAction =
-                    menu.addAction(tr("&Replace Tile of Selected Objects"));
-            changeSelectedMapObjectsTileAction->setEnabled(onlyOneTileSelected);
-            connect(changeSelectedMapObjectsTileAction, &QAction::triggered,
-                    this, &TilesetView::changeSelectedMapObjectsTile);
         }
 
         menu.addSeparator();
@@ -1319,14 +1308,6 @@ void TilesetView::swapTiles()
         return;
 
     emit swapTilesRequested(tile1, tile2);
-}
-
-void TilesetView::changeSelectedMapObjectsTile()
-{
-    const QModelIndexList selectedIndexes = selectionModel()->selectedIndexes();
-    const TilesetModel *model = tilesetModel();
-    Tile *tile = model->tileAt(selectedIndexes[0]);
-    emit changeSelectedMapObjectsTileRequested(tile);
 }
 
 void TilesetView::setDrawGrid(bool drawGrid)

--- a/src/tiled/tilesetview.h
+++ b/src/tiled/tilesetview.h
@@ -135,7 +135,6 @@ signals:
     void wangIdUsedChanged(WangId wangId);
     void currentWangIdChanged(WangId wangId);
     void swapTilesRequested(Tile *tileA, Tile *tileB);
-    void changeSelectedMapObjectsTileRequested(Tile *tile);
 
 protected:
     bool event(QEvent *event) override;
@@ -155,7 +154,6 @@ private slots:
     void selectWangColorImage();
     void editTileProperties();
     void swapTiles();
-    void changeSelectedMapObjectsTile();
     void setDrawGrid(bool drawGrid);
 
     void adjustScale();

--- a/src/tiled/toolmanager.cpp
+++ b/src/tiled/toolmanager.cpp
@@ -35,6 +35,7 @@ ToolManager::ToolManager(QObject *parent)
     , mDisabledTool(nullptr)
     , mPreviouslyDisabledTool(nullptr)
     , mMapDocument(nullptr)
+    , mTile(nullptr)
     , mSelectEnabledToolPending(false)
 {
     mActionGroup->setExclusive(true);
@@ -146,6 +147,13 @@ void ToolManager::retranslateTools()
     }
 }
 
+void ToolManager::setTile(Tile *tile)
+{
+    mTile = tile;
+    if (mSelectedTool)
+        mSelectedTool->setTile(mTile);
+}
+
 void ToolManager::toolEnabledChanged(bool enabled)
 {
     AbstractTool *tool = qobject_cast<AbstractTool*>(sender());
@@ -220,5 +228,6 @@ void ToolManager::setSelectedTool(AbstractTool *tool)
         emit statusInfoChanged(mSelectedTool->statusInfo());
         connect(mSelectedTool, SIGNAL(statusInfoChanged(QString)),
                 this, SIGNAL(statusInfoChanged(QString)));
+        tool->setTile(mTile);
     }
 }

--- a/src/tiled/toolmanager.cpp
+++ b/src/tiled/toolmanager.cpp
@@ -77,9 +77,14 @@ QAction *ToolManager::registerTool(AbstractTool *tool)
     toolAction->setShortcut(tool->shortcut());
     toolAction->setData(QVariant::fromValue<AbstractTool*>(tool));
     toolAction->setCheckable(true);
-    toolAction->setToolTip(
-            QString(QLatin1String("%1 (%2)")).arg(tool->name(),
-                                                  tool->shortcut().toString()));
+    if (!tool->shortcut().isEmpty()) {
+        toolAction->setToolTip(
+                QString(QLatin1String("%1 (%2)")).arg(tool->name(),
+                                                      tool->shortcut().toString()));
+    } else {
+        toolAction->setToolTip(tool->name());
+    }
+
     toolAction->setEnabled(tool->isEnabled());
     mActionGroup->addAction(toolAction);
 

--- a/src/tiled/toolmanager.h
+++ b/src/tiled/toolmanager.h
@@ -26,6 +26,9 @@ class QAction;
 class QActionGroup;
 
 namespace Tiled {
+
+class Tile;
+
 namespace Internal {
 
 class AbstractTool;
@@ -55,6 +58,13 @@ public:
 
     void retranslateTools();
 
+public slots:
+    /**
+     * Sets the tile that will be used when the creation mode is
+     * CreateTileObjects or when replacing a tile of a tile object.
+     */
+    void setTile(Tile *tile);
+
 signals:
     void selectedToolChanged(AbstractTool *tool);
 
@@ -80,6 +90,7 @@ private:
     AbstractTool *mDisabledTool;
     AbstractTool *mPreviouslyDisabledTool;
     MapDocument *mMapDocument;
+    Tile *mTile;
 
     bool mSelectEnabledToolPending;
 };


### PR DESCRIPTION
This PR is part of the object templates project.

The goal is to be able to edit the templates and reflect those edits in the map.

A new view is embedded into the dock to show the template and allow graphical editing, also the properties can be edited through the properties dock.