### PR TITLE
Add JSON support for reusable object templates

### DIFF
--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -124,6 +124,38 @@ QVariant MapToVariantConverter::toVariant(const Tileset &tileset,
     return toVariant(tileset, 0);
 }
 
+QVariant MapToVariantConverter::toVariant(const TemplateGroup &templateGroup,
+                                          const QDir &directory)
+{
+    mMapDir = directory;
+    QVariantMap templateGroupVariant;
+
+    templateGroupVariant[QLatin1String("type")] = QLatin1String("templategroup");
+    templateGroupVariant[QLatin1String("name")] = templateGroup.name();
+    templateGroupVariant[QLatin1String("nexttemplateid")] = templateGroup.nextTemplateId();
+
+    QVariantList tilesetVariants;
+
+    mGidMapper.clear();
+    unsigned firstGid = 1;
+    for (const SharedTileset &tileset : templateGroup.tilesets()) {
+        tilesetVariants << toVariant(*tileset, firstGid);
+        mGidMapper.insert(firstGid, tileset.data());
+        firstGid += tileset->nextTileId();
+    }
+
+    templateGroupVariant[QLatin1String("tilesets")] = tilesetVariants;
+
+    QVariantList templateVariants;
+
+    for (const ObjectTemplate *objectTemplate: templateGroup.templates())
+        templateVariants << toVariant(*objectTemplate);
+
+    templateGroupVariant[QLatin1String("templates")] = templateVariants;
+
+    return templateGroupVariant;
+}
+
 QVariant MapToVariantConverter::toVariant(const Tileset &tileset,
                                           int firstGid) const
 {
@@ -383,95 +415,115 @@ QVariant MapToVariantConverter::toVariant(const ObjectGroup &objectGroup) const
 
     addLayerAttributes(objectGroupVariant, objectGroup);
     QVariantList objectVariants;
-    for (const MapObject *object : objectGroup.objects()) {
-        QVariantMap objectVariant;
-        const QString &name = object->name();
-        const QString &type = object->type();
-
-        addProperties(objectVariant, object->properties());
-
-        bool notTemplateInstance = !object->isTemplateInstance();
-
-        if (object->isTemplateInstance()) {
-            unsigned tid = mTidMapper.templateRefToTid(object->templateRef());
-            objectVariant[QLatin1String("tid")] = tid;
-        }
-
-        objectVariant[QLatin1String("id")] = object->id();
-
-        if (notTemplateInstance || object->propertyChanged(MapObject::NameProperty))
-            objectVariant[QLatin1String("name")] = name;
-
-        if (notTemplateInstance || object->propertyChanged(MapObject::TypeProperty))
-            objectVariant[QLatin1String("type")] = type;
-
-
-        if (notTemplateInstance || object->propertyChanged(MapObject::CellProperty))
-            if (!object->cell().isEmpty())
-                objectVariant[QLatin1String("gid")] = mGidMapper.cellToGid(object->cell());
-
-        objectVariant[QLatin1String("x")] = object->x();
-        objectVariant[QLatin1String("y")] = object->y();
-
-        if (notTemplateInstance || object->propertyChanged(MapObject::SizeProperty)) {
-            objectVariant[QLatin1String("width")] = object->width();
-            objectVariant[QLatin1String("height")] = object->height();
-        }
-
-        if (notTemplateInstance || object->propertyChanged(MapObject::RotationProperty))
-            objectVariant[QLatin1String("rotation")] = object->rotation();
-
-        if (notTemplateInstance || object->propertyChanged(MapObject::VisibleProperty))
-            objectVariant[QLatin1String("visible")] = object->isVisible();
-
-        /* Polygons are stored in this format:
-         *
-         *   "polygon/polyline": [
-         *       { "x": 0, "y": 0 },
-         *       { "x": 1, "y": 1 },
-         *       ...
-         *   ]
-         */
-        switch (object->shape()) {
-        case MapObject::Rectangle:
-            break;
-        case MapObject::Polygon:
-        case MapObject::Polyline: {
-            if (notTemplateInstance || object->propertyChanged(MapObject::ShapeProperty)) {
-                QVariantList pointVariants;
-                for (const QPointF &point : object->polygon()) {
-                    QVariantMap pointVariant;
-                    pointVariant[QLatin1String("x")] = point.x();
-                    pointVariant[QLatin1String("y")] = point.y();
-                    pointVariants.append(pointVariant);
-                }
-
-                if (object->shape() == MapObject::Polygon)
-                    objectVariant[QLatin1String("polygon")] = pointVariants;
-                else
-                    objectVariant[QLatin1String("polyline")] = pointVariants;
-            }
-            break;
-        }
-        case MapObject::Ellipse:
-            if (notTemplateInstance || object->propertyChanged(MapObject::ShapeProperty))
-                objectVariant[QLatin1String("ellipse")] = true;
-            break;
-        case MapObject::Text:
-            if (notTemplateInstance || (object->propertyChanged(MapObject::TextProperty) ||
-                                        object->propertyChanged(MapObject::TextFontProperty) ||
-                                        object->propertyChanged(MapObject::TextAlignmentProperty) ||
-                                        object->propertyChanged(MapObject::TextWordWrapProperty) ||
-                                        object->propertyChanged(MapObject::TextColorProperty)))
-                objectVariant[QLatin1String("text")] = toVariant(object->textData());
-            break;
-        }
-
-        objectVariants << objectVariant;
-    }
+    for (const MapObject *object : objectGroup.objects())
+        objectVariants << toVariant(*object);
 
     objectGroupVariant[QLatin1String("objects")] = objectVariants;
+
     return objectGroupVariant;
+}
+
+QVariant MapToVariantConverter::toVariant(const MapObject &object) const
+{
+    QVariantMap objectVariant;
+    const QString &name = object.name();
+    const QString &type = object.type();
+
+    addProperties(objectVariant, object.properties());
+
+    bool notTemplateInstance = !object.isTemplateInstance();
+
+    if (object.isTemplateInstance()) {
+        unsigned tid = mTidMapper.templateRefToTid(object.templateRef());
+        objectVariant[QLatin1String("tid")] = tid;
+    }
+
+    int id = object.id();
+    if (id != 0)
+        objectVariant[QLatin1String("id")] = id;
+
+    if (notTemplateInstance || object.propertyChanged(MapObject::NameProperty))
+        objectVariant[QLatin1String("name")] = name;
+
+    if (notTemplateInstance || object.propertyChanged(MapObject::TypeProperty))
+        objectVariant[QLatin1String("type")] = type;
+
+
+    if (notTemplateInstance || object.propertyChanged(MapObject::CellProperty))
+        if (!object.cell().isEmpty())
+            objectVariant[QLatin1String("gid")] = mGidMapper.cellToGid(object.cell());
+
+    if (id != 0) {
+        objectVariant[QLatin1String("x")] = object.x();
+        objectVariant[QLatin1String("y")] = object.y();
+    }
+
+    if (notTemplateInstance || object.propertyChanged(MapObject::SizeProperty)) {
+        objectVariant[QLatin1String("width")] = object.width();
+        objectVariant[QLatin1String("height")] = object.height();
+    }
+
+    if (notTemplateInstance || object.propertyChanged(MapObject::RotationProperty))
+        objectVariant[QLatin1String("rotation")] = object.rotation();
+
+    if (notTemplateInstance || object.propertyChanged(MapObject::VisibleProperty))
+        objectVariant[QLatin1String("visible")] = object.isVisible();
+
+    /* Polygons are stored in this format:
+     *
+     *   "polygon/polyline": [
+     *       { "x": 0, "y": 0 },
+     *       { "x": 1, "y": 1 },
+     *       ...
+     *   ]
+     */
+    switch (object.shape()) {
+    case MapObject::Rectangle:
+        break;
+    case MapObject::Polygon:
+    case MapObject::Polyline: {
+        if (notTemplateInstance || object.propertyChanged(MapObject::ShapeProperty)) {
+            QVariantList pointVariants;
+            for (const QPointF &point : object.polygon()) {
+                QVariantMap pointVariant;
+                pointVariant[QLatin1String("x")] = point.x();
+                pointVariant[QLatin1String("y")] = point.y();
+                pointVariants.append(pointVariant);
+            }
+
+            if (object.shape() == MapObject::Polygon)
+                objectVariant[QLatin1String("polygon")] = pointVariants;
+            else
+                objectVariant[QLatin1String("polyline")] = pointVariants;
+        }
+        break;
+    }
+    case MapObject::Ellipse:
+        if (notTemplateInstance || object.propertyChanged(MapObject::ShapeProperty))
+            objectVariant[QLatin1String("ellipse")] = true;
+        break;
+    case MapObject::Text:
+        if (notTemplateInstance || (object.propertyChanged(MapObject::TextProperty) ||
+                                    object.propertyChanged(MapObject::TextFontProperty) ||
+                                    object.propertyChanged(MapObject::TextAlignmentProperty) ||
+                                    object.propertyChanged(MapObject::TextWordWrapProperty) ||
+                                    object.propertyChanged(MapObject::TextColorProperty)))
+            objectVariant[QLatin1String("text")] = toVariant(object.textData());
+        break;
+    }
+
+    return objectVariant;
+}
+
+QVariant MapToVariantConverter::toVariant(const ObjectTemplate &objectTemplate) const
+{
+    QVariantMap templateVariant;
+
+    templateVariant[QLatin1String("name")] = objectTemplate.name();
+    templateVariant[QLatin1String("id")] = objectTemplate.id();
+    templateVariant[QLatin1String("object")] = toVariant(*objectTemplate.object());
+
+    return templateVariant;
 }
 
 QVariant MapToVariantConverter::toVariant(const TextData &textData) const

--- a/src/libtiled/maptovariantconverter.h
+++ b/src/libtiled/maptovariantconverter.h
@@ -25,6 +25,7 @@
 #include <QVariant>
 
 #include "gidmapper.h"
+#include "tidmapper.h"
 
 namespace Tiled {
 
@@ -54,6 +55,7 @@ public:
 
 private:
     QVariant toVariant(const Tileset &tileset, int firstGid) const;
+    QVariant toVariant(const TemplateGroup &templateGroup, int firstTid) const;
     QVariant toVariant(const Properties &properties) const;
     QVariant propertyTypesToVariant(const Properties &properties) const;
     QVariant toVariant(const QList<Layer*> &layers, Map::LayerDataFormat format) const;
@@ -71,6 +73,7 @@ private:
 
     QDir mMapDir;
     GidMapper mGidMapper;
+    TidMapper mTidMapper;
 };
 
 } // namespace Tiled

--- a/src/libtiled/maptovariantconverter.h
+++ b/src/libtiled/maptovariantconverter.h
@@ -52,6 +52,7 @@ public:
      * construct relative paths to external resources.
      */
     QVariant toVariant(const Tileset &tileset, const QDir &directory);
+    QVariant toVariant(const TemplateGroup &templateGroup, const QDir &directory);
 
 private:
     QVariant toVariant(const Tileset &tileset, int firstGid) const;
@@ -61,6 +62,8 @@ private:
     QVariant toVariant(const QList<Layer*> &layers, Map::LayerDataFormat format) const;
     QVariant toVariant(const TileLayer &tileLayer, Map::LayerDataFormat format) const;
     QVariant toVariant(const ObjectGroup &objectGroup) const;
+    QVariant toVariant(const MapObject &object) const;
+    QVariant toVariant(const ObjectTemplate &objectTemplate) const;
     QVariant toVariant(const TextData &textData) const;
     QVariant toVariant(const ImageLayer &imageLayer) const;
     QVariant toVariant(const GroupLayer &groupLayer, Map::LayerDataFormat format) const;

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -757,7 +757,7 @@ void MapWriterPrivate::writeObject(QXmlStreamWriter &w,
                         mapObject.propertyChanged(MapObject::TextFontProperty) ||
                         mapObject.propertyChanged(MapObject::TextAlignmentProperty) ||
                         mapObject.propertyChanged(MapObject::TextWordWrapProperty) ||
-                        mapObject.propertyChanged(MapObject::TextColorProperty)  ))
+                        mapObject.propertyChanged(MapObject::TextColorProperty)))
             writeObjectText(w, mapObject.textData());
         break;
     }

--- a/src/libtiled/templategroupformat.cpp
+++ b/src/libtiled/templategroupformat.cpp
@@ -27,6 +27,22 @@ namespace Tiled {
 
 TemplateGroup *readTemplateGroup(const QString &fileName, QString *error)
 {
+    if (TemplateGroupFormat *format = findSupportingGroupFormat(fileName)) {
+        TemplateGroup *templateGroup = format->read(fileName);
+
+        if (error) {
+            if (!templateGroup)
+                *error = format->errorString();
+            else
+                *error = QString();
+        }
+
+        if (templateGroup)
+            templateGroup->setFormat(format);
+
+        return templateGroup;
+    }
+
     MapReader reader;
     TemplateGroup *templateGroup = reader.readTemplateGroup(fileName);
 
@@ -38,6 +54,14 @@ TemplateGroup *readTemplateGroup(const QString &fileName, QString *error)
     }
 
     return templateGroup;
+}
+
+TemplateGroupFormat *findSupportingGroupFormat(const QString &fileName)
+{
+    for (TemplateGroupFormat *format : PluginManager::objects<TemplateGroupFormat>())
+        if (format->supportsFile(fileName))
+            return format;
+    return nullptr;
 }
 
 } // namespace Tiled

--- a/src/libtiled/templategroupformat.h
+++ b/src/libtiled/templategroupformat.h
@@ -50,6 +50,8 @@ public:
 TILEDSHARED_EXPORT TemplateGroup *readTemplateGroup(const QString &fileName,
                                                     QString *error = nullptr);
 
+TILEDSHARED_EXPORT TemplateGroupFormat *findSupportingGroupFormat(const QString &fileName);
+
 } // namespace Tiled
 
 Q_DECLARE_INTERFACE(Tiled::TemplateGroupFormat, "org.mapeditor.TemplateGroupFormat")

--- a/src/libtiled/varianttomapconverter.h
+++ b/src/libtiled/varianttomapconverter.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "gidmapper.h"
+#include "tidmapper.h"
 #include "mapobject.h"
 
 #include <QCoreApplication>
@@ -80,6 +81,7 @@ private:
     Properties toProperties(const QVariant &propertiesVariant,
                             const QVariant &propertyTypesVariant) const;
     SharedTileset toTileset(const QVariant &variant);
+    TemplateGroup *toTemplateGroup(const QVariant &variant);
     Layer *toLayer(const QVariant &variant);
     TileLayer *toTileLayer(const QVariantMap &variantMap);
     ObjectGroup *toObjectGroup(const QVariantMap &variantMap);
@@ -95,6 +97,7 @@ private:
     QDir mMapDir;
     bool mReadingExternalTileset;
     GidMapper mGidMapper;
+    TidMapper mTidMapper;
     QString mError;
 };
 

--- a/src/libtiled/varianttomapconverter.h
+++ b/src/libtiled/varianttomapconverter.h
@@ -71,6 +71,7 @@ public:
      * errorString().
      */
     SharedTileset toTileset(const QVariant &variant, const QDir &directory);
+    TemplateGroup *toTemplateGroup(const QVariant &variant, const QDir &directory);
 
     /**
      * Returns the last error, if any.
@@ -85,6 +86,8 @@ private:
     Layer *toLayer(const QVariant &variant);
     TileLayer *toTileLayer(const QVariantMap &variantMap);
     ObjectGroup *toObjectGroup(const QVariantMap &variantMap);
+    MapObject *toMapObject(const QVariantMap &variantMap);
+    ObjectTemplate *toObjectTemplate(const QVariantMap &variantMap);
     ImageLayer *toImageLayer(const QVariantMap &variantMap);
     GroupLayer *toGroupLayer(const QVariantMap &variantMap);
 

--- a/src/plugins/json/jsonplugin.cpp
+++ b/src/plugins/json/jsonplugin.cpp
@@ -40,6 +40,7 @@ void JsonPlugin::initialize()
     addObject(new JsonMapFormat(JsonMapFormat::Json, this));
     addObject(new JsonMapFormat(JsonMapFormat::JavaScript, this));
     addObject(new JsonTilesetFormat(this));
+    addObject(new JsonTemplateGroupFormat(this));
 }
 
 
@@ -314,6 +315,86 @@ QString JsonTilesetFormat::shortName() const
 }
 
 QString JsonTilesetFormat::errorString() const
+{
+    return mError;
+}
+
+JsonTemplateGroupFormat::JsonTemplateGroupFormat(QObject *parent)
+    : Tiled::TemplateGroupFormat(parent)
+{
+}
+
+Tiled::TemplateGroup *JsonTemplateGroupFormat::read(const QString &fileName)
+{
+    Q_UNUSED(fileName);
+    return nullptr;
+}
+
+bool JsonTemplateGroupFormat::supportsFile(const QString &fileName) const
+{
+    if (fileName.endsWith(QLatin1String(".json"), Qt::CaseInsensitive)) {
+        QFile file(fileName);
+
+        if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            const QJsonObject object = QJsonDocument::fromJson(file.readAll()).object();
+
+            if (object.value(QLatin1String("type")).toString() == QLatin1String("templategroup"))
+                return true;
+        }
+    }
+
+    return false;
+}
+
+bool JsonTemplateGroupFormat::write(const Tiled::TemplateGroup *templateGroup, const QString &fileName)
+{
+    Tiled::SaveFile file(fileName);
+
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        mError = tr("Could not open file for writing.");
+        return false;
+    }
+
+    Tiled::MapToVariantConverter converter;
+    QVariant variant = converter.toVariant(*templateGroup, QFileInfo(fileName).dir());
+
+    JsonWriter writer;
+    writer.setAutoFormatting(true);
+
+    if (!writer.stringify(variant)) {
+        // This can only happen due to coding error
+        mError = writer.errorString();
+        return false;
+    }
+
+    QTextStream out(file.device());
+    out << writer.result();
+    out.flush();
+
+    if (file.error() != QFileDevice::NoError) {
+        mError = tr("Error while writing file:\n%1").arg(file.errorString());
+        return false;
+    }
+
+    if (!file.commit()) {
+        mError = file.errorString();
+        return false;
+    }
+
+    return true;
+}
+
+QString JsonTemplateGroupFormat::nameFilter() const
+{
+    return tr("Json template group files (*.json)");
+}
+
+QString JsonTemplateGroupFormat::shortName() const
+{
+    return QLatin1String("json");
+}
+
+QString JsonTemplateGroupFormat::errorString() const
 {
     return mError;
 }

--- a/src/plugins/json/jsonplugin.h
+++ b/src/plugins/json/jsonplugin.h
@@ -25,6 +25,7 @@
 
 #include "mapformat.h"
 #include "plugin.h"
+#include "templategroupformat.h"
 #include "tilesetformat.h"
 
 #include <QObject>
@@ -86,6 +87,27 @@ public:
     bool supportsFile(const QString &fileName) const override;
 
     bool write(const Tiled::Tileset &tileset, const QString &fileName) override;
+
+    QString nameFilter() const override;
+    QString shortName() const override;
+    QString errorString() const override;
+
+protected:
+    QString mError;
+};
+
+class JSONSHARED_EXPORT JsonTemplateGroupFormat : public Tiled::TemplateGroupFormat
+{
+    Q_OBJECT
+    Q_INTERFACES(Tiled::TemplateGroupFormat)
+
+public:
+    JsonTemplateGroupFormat(QObject *parent = nullptr);
+
+    Tiled::TemplateGroup *read(const QString &fileName) override;
+    bool supportsFile(const QString &fileName) const override;
+
+    bool write(const Tiled::TemplateGroup *templateGroup, const QString &fileName) override;
 
     QString nameFilter() const override;
     QString shortName() const override;

--- a/src/tiled/brokenlinks.cpp
+++ b/src/tiled/brokenlinks.cpp
@@ -603,14 +603,14 @@ void BrokenLinksWidget::tryFixLink(const BrokenLink &link)
         prefs->setLastPath(Preferences::ExternalTileset,
                            QFileInfo(fileName).path());
     } else if (link.type == TemplateGroupReference) {
-        QString filter = TtxTemplateGroupFormat::instance()->nameFilter();
+        const QString allFilesFilter = tr("All Files (*)");
 
         Preferences *prefs = Preferences::instance();
         QString start = prefs->lastPath(Preferences::TemplateDocumentsFile);
 
         QString fileName = QFileDialog::getOpenFileName(this, tr("Locate Template Group"),
                                                         start,
-                                                        filter);
+                                                        allFilesFilter);
 
         if (fileName.isEmpty())
             return;

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -112,12 +112,13 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     , mDocumentManager(DocumentManager::instance())
     , mTmxMapFormat(new TmxMapFormat(this))
     , mTsxTilesetFormat(new TsxTilesetFormat(this))
+    , mTtxTemplateGroupFormat(new TtxTemplateGroupFormat(this))
 {
     mUi->setupUi(this);
 
     PluginManager::addObject(mTmxMapFormat);
     PluginManager::addObject(mTsxTilesetFormat);
-    PluginManager::addObject(TtxTemplateGroupFormat::instance());
+    PluginManager::addObject(mTtxTemplateGroupFormat);
 
     ActionManager::registerAction(mUi->actionNewMap, "file.new_map");
     ActionManager::registerAction(mUi->actionNewTileset, "file.new_tileset");

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -117,6 +117,7 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
 
     PluginManager::addObject(mTmxMapFormat);
     PluginManager::addObject(mTsxTilesetFormat);
+    PluginManager::addObject(TtxTemplateGroupFormat::instance());
 
     ActionManager::registerAction(mUi->actionNewMap, "file.new_map");
     ActionManager::registerAction(mUi->actionNewTileset, "file.new_tileset");

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -58,6 +58,7 @@ class MapView;
 class ObjectTypesEditor;
 class TmxMapFormat;
 class TsxTilesetFormat;
+class TtxTemplateGroupFormat;
 class Zoomable;
 
 /**
@@ -219,6 +220,7 @@ private:
 
     TmxMapFormat *mTmxMapFormat;
     TsxTilesetFormat *mTsxTilesetFormat;
+    TtxTemplateGroupFormat *mTtxTemplateGroupFormat;
 
     QPointer<PreferencesDialog> mPreferencesDialog;
 

--- a/src/tiled/templategroupdocument.cpp
+++ b/src/tiled/templategroupdocument.cpp
@@ -55,7 +55,7 @@ TemplateGroupDocument::~TemplateGroupDocument()
 
 bool TemplateGroupDocument::save(const QString &fileName, QString *error)
 {
-    auto format = TtxTemplateGroupFormat::instance();
+    auto format = mTemplateGroup->format();
 
     if (!format->write(mTemplateGroup, fileName)) {
         if (error)

--- a/src/tiled/templategroupdocument.cpp
+++ b/src/tiled/templategroupdocument.cpp
@@ -67,18 +67,12 @@ bool TemplateGroupDocument::save(const QString &fileName, QString *error)
 }
 
 TemplateGroupDocument *TemplateGroupDocument::load(const QString &fileName,
-                                                   TemplateGroupFormat *format,
                                                    QString *error)
 {
-    TemplateGroup *templateGroup = format->read(fileName);
+    TemplateGroup *templateGroup = readTemplateGroup(fileName, error);
 
-    if (!templateGroup) {
-        if (error)
-            *error = format->errorString();
+    if (!templateGroup)
         return nullptr;
-    }
-
-    templateGroup->setFormat(format);
 
     return new TemplateGroupDocument(templateGroup);
 }
@@ -151,8 +145,6 @@ static void readTemplateDocumentsXml(QFileDevice *device,
     // Saves the paths of loaded template groups to prevent loading duplicates
     QSet<QString> loadedPaths;
 
-    auto templateGroupFormat = TtxTemplateGroupFormat::instance();
-
     while (reader.readNextStartElement()) {
         if (reader.name() == QLatin1String("templategroup")) {
             const QXmlStreamAttributes atts = reader.attributes();
@@ -165,7 +157,7 @@ static void readTemplateDocumentsXml(QFileDevice *device,
 
                 // TODO: handle errors that might happen while loading
                 QScopedPointer<TemplateGroupDocument>
-                    templateGroupDocument(TemplateGroupDocument::load(path, templateGroupFormat));
+                    templateGroupDocument(TemplateGroupDocument::load(path));
 
                 if (templateGroupDocument)
                     templateDocuments.append(templateGroupDocument.take());

--- a/src/tiled/templategroupdocument.h
+++ b/src/tiled/templategroupdocument.h
@@ -51,7 +51,6 @@ public:
     bool save(const QString &fileName, QString *error = nullptr) override;
 
     static TemplateGroupDocument *load(const QString &fileName,
-                                       TemplateGroupFormat *format,
                                        QString *error = nullptr);
 
     FileFormat *writerFormat() const override;

--- a/src/tiled/templatesdock.cpp
+++ b/src/tiled/templatesdock.cpp
@@ -102,7 +102,7 @@ void TemplatesDock::newTemplateGroup()
 {
     FormatHelper<TemplateGroupFormat> helper(FileFormat::ReadWrite);
     QString filter = helper.filter();
-    QString selectedFilter = TtxTemplateGroupFormat::instance()->nameFilter();
+    QString selectedFilter = TtxTemplateGroupFormat().nameFilter();
 
     Preferences *prefs = Preferences::instance();
     QString suggestedFileName = prefs->lastPath(Preferences::TemplateDocumentsFile);
@@ -145,7 +145,7 @@ void TemplatesDock::openTemplateGroup()
 
     Preferences *prefs = Preferences::instance();
     QString suggestedFileName = prefs->lastPath(Preferences::TemplateDocumentsFile);
-    QString selectedFilter = TtxTemplateGroupFormat::instance()->nameFilter();
+    QString selectedFilter = TtxTemplateGroupFormat().nameFilter();
 
     QString fileName = QFileDialog::getOpenFileName(this, tr("Open Template Group"),
                                                     suggestedFileName,

--- a/src/tiled/templatesdock.cpp
+++ b/src/tiled/templatesdock.cpp
@@ -140,14 +140,17 @@ void TemplatesDock::newTemplateGroup()
 
 void TemplatesDock::openTemplateGroup()
 {
-    QString filter = TtxTemplateGroupFormat::instance()->nameFilter();
+    FormatHelper<TemplateGroupFormat> helper(FileFormat::ReadWrite);
+    QString filter = helper.filter();
 
     Preferences *prefs = Preferences::instance();
     QString suggestedFileName = prefs->lastPath(Preferences::TemplateDocumentsFile);
+    QString selectedFilter = TtxTemplateGroupFormat::instance()->nameFilter();
 
     QString fileName = QFileDialog::getOpenFileName(this, tr("Open Template Group"),
                                                     suggestedFileName,
-                                                    filter);
+                                                    filter,
+                                                    &selectedFilter);
 
     if (fileName.isEmpty())
         return;
@@ -158,8 +161,7 @@ void TemplatesDock::openTemplateGroup()
         return;
     }
 
-    auto templateGroupFormat = TtxTemplateGroupFormat::instance();
-    auto document = TemplateGroupDocument::load(fileName, templateGroupFormat);
+    auto document = TemplateGroupDocument::load(fileName);
 
     if (!document) {
         QMessageBox::warning(this, tr("Open Template Group"),

--- a/src/tiled/templatesdock.cpp
+++ b/src/tiled/templatesdock.cpp
@@ -100,7 +100,9 @@ TemplatesDock::~TemplatesDock()
 
 void TemplatesDock::newTemplateGroup()
 {
-    QString filter = TtxTemplateGroupFormat::instance()->nameFilter();
+    FormatHelper<TemplateGroupFormat> helper(FileFormat::ReadWrite);
+    QString filter = helper.filter();
+    QString selectedFilter = TtxTemplateGroupFormat::instance()->nameFilter();
 
     Preferences *prefs = Preferences::instance();
     QString suggestedFileName = prefs->lastPath(Preferences::TemplateDocumentsFile);
@@ -108,7 +110,8 @@ void TemplatesDock::newTemplateGroup()
 
     QString fileName = QFileDialog::getSaveFileName(this, tr("Save File"),
                                                     suggestedFileName,
-                                                    filter);
+                                                    filter,
+                                                    &selectedFilter);
 
     if (fileName.isEmpty())
         return;
@@ -118,6 +121,9 @@ void TemplatesDock::newTemplateGroup()
     templateGroup->setFileName(fileName);
     QScopedPointer<TemplateGroupDocument>
         templateGroupDocument(new TemplateGroupDocument(templateGroup));
+
+    TemplateGroupFormat *format = helper.formatByNameFilter(selectedFilter);
+    templateGroup->setFormat(format);
 
     QString error;
     if (!templateGroupDocument->save(fileName, &error)) {

--- a/src/tiled/tmxmapformat.cpp
+++ b/src/tiled/tmxmapformat.cpp
@@ -172,12 +172,6 @@ TtxTemplateGroupFormat::TtxTemplateGroupFormat(QObject *parent)
 {
 }
 
-TtxTemplateGroupFormat *TtxTemplateGroupFormat::instance()
-{
-    static TtxTemplateGroupFormat format;
-    return &format;
-}
-
 TemplateGroup *TtxTemplateGroupFormat::read(const QString &fileName)
 {
     mError.clear();

--- a/src/tiled/tmxmapformat.h
+++ b/src/tiled/tmxmapformat.h
@@ -112,7 +112,7 @@ class TtxTemplateGroupFormat : public TemplateGroupFormat
     Q_INTERFACES(Tiled::TemplateGroupFormat)
 
 public:
-    static TtxTemplateGroupFormat *instance();
+    TtxTemplateGroupFormat(QObject *parent = nullptr);
 
     TemplateGroup *read(const QString &fileName) override;
 
@@ -127,8 +127,6 @@ public:
     QString errorString() const override { return mError; }
 
 private:
-    TtxTemplateGroupFormat(QObject *parent = nullptr);
-
     QString mError;
 };
 


### PR DESCRIPTION
This PR adds JSON support for the reusable object templates, Tiled should be able to:
- [x] Write template instances.
- [x] Read template instances.
- [x] Write template groups.
- [x] Read template groups.

The groups file is used internally by Tiled, so I'm not sure if it's necessary to save it in JSON.