### PR TITLE
Added keyboard shortcut for Save All, Ctrl+Shift+S

### DIFF
--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -163,7 +163,6 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     mUi->actionNewMap->setShortcuts(QKeySequence::New);
     mUi->actionOpen->setShortcuts(QKeySequence::Open);
     mUi->actionSave->setShortcuts(QKeySequence::Save);
-    mUi->actionSaveAs->setShortcuts(QKeySequence::SaveAs);
     mUi->actionClose->setShortcuts(QKeySequence::Close);
     mUi->actionQuit->setShortcuts(QKeySequence::Quit);
     mUi->actionCut->setShortcuts(QKeySequence::Cut);

--- a/src/tiled/mainwindow.ui
+++ b/src/tiled/mainwindow.ui
@@ -486,6 +486,9 @@
    <property name="text">
     <string>Save All</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+S</string>
+   </property>
   </action>
   <action name="actionDocumentation">
    <property name="text">


### PR DESCRIPTION
There doesn't seem to be a strong standard for which shortcut to use. I
chose Ctrl+Shift+S because it's used in Visual Studio and Qt Creator,
and consistent with Ctrl+Shift+W for Close All.

Some applications, like GEdit, use Ctrl+Shift+S for Save As instead, but
I think that's a much rarer operation which doesn't warrant the visual
clutter of a keyboard shortcut in the menu.