### PR TITLE
Added keyboard shortcut for Save All, Ctrl+Shift+L

### DIFF
--- a/src/tiled/mainwindow.ui
+++ b/src/tiled/mainwindow.ui
@@ -486,6 +486,9 @@
    <property name="text">
     <string>Save All</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+L</string>
+   </property>
   </action>
   <action name="actionDocumentation">
    <property name="text">


### PR DESCRIPTION
There doesn't seem to be a strong standard for which shortcut to use. I
would prefer Ctrl+Shift+S because it's used in Visual Studio and Qt
Creator, and consistent with Ctrl+Shift+W for Close All.

However, Ctrl+Shift+S is already used as Save As on some platforms (e.g.
Gnome), which instead use Ctrl+Shift+L for Save All, so we follow suit.