### PR TITLE
[WIP] Tile Size per Tile Layer

### DIFF
--- a/.qmake.stash
+++ b/.qmake.stash
@@ -1,0 +1,42 @@
+QMAKE_MAC_SDK.macosx.Path = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
+QMAKE_MAC_SDK.macosx.PlatformPath = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform
+QMAKE_MAC_SDK.macosx.SDKVersion = 10.12
+QMAKE_MAC_SDK.macx-clang.macosx.QMAKE_CC = /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
+QMAKE_MAC_SDK.macx-clang.macosx.QMAKE_CXX = /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++
+QMAKE_MAC_SDK.macx-clang.macosx.QMAKE_FIX_RPATH = \
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool \
+    -id
+QMAKE_MAC_SDK.macx-clang.macosx.QMAKE_AR = \
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ar \
+    cq
+QMAKE_MAC_SDK.macx-clang.macosx.QMAKE_RANLIB = \
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib \
+    -s
+QMAKE_MAC_SDK.macx-clang.macosx.QMAKE_LINK = /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++
+QMAKE_MAC_SDK.macx-clang.macosx.QMAKE_LINK_SHLIB = /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++
+QMAKE_MAC_SDK.macx-clang.macosx.QMAKE_ACTOOL = /Applications/Xcode.app/Contents/Developer/usr/bin/actool
+QMAKE_CXX.INCDIRS = \
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 \
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/8.1.0/include \
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include \
+    /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/usr/include
+QMAKE_CXX.LIBDIRS = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/usr/lib
+QMAKE_CXX.QT_COMPILER_STDCXX = 199711L
+QMAKE_CXX.QMAKE_APPLE_CC = 6000
+QMAKE_CXX.QMAKE_APPLE_CLANG_MAJOR_VERSION = 8
+QMAKE_CXX.QMAKE_APPLE_CLANG_MINOR_VERSION = 1
+QMAKE_CXX.QMAKE_APPLE_CLANG_PATCH_VERSION = 0
+QMAKE_CXX.QMAKE_GCC_MAJOR_VERSION = 4
+QMAKE_CXX.QMAKE_GCC_MINOR_VERSION = 2
+QMAKE_CXX.QMAKE_GCC_PATCH_VERSION = 1
+QMAKE_CXX.COMPILER_MACROS = \
+    QT_COMPILER_STDCXX \
+    QMAKE_APPLE_CC \
+    QMAKE_APPLE_CLANG_MAJOR_VERSION \
+    QMAKE_APPLE_CLANG_MINOR_VERSION \
+    QMAKE_APPLE_CLANG_PATCH_VERSION \
+    QMAKE_GCC_MAJOR_VERSION \
+    QMAKE_GCC_MINOR_VERSION \
+    QMAKE_GCC_PATCH_VERSION
+QMAKE_XCODE_DEVELOPER_PATH = /Applications/Xcode.app/Contents/Developer
+QMAKE_XCODE_VERSION = 8.3.3

--- a/run
+++ b/run
@@ -1,0 +1,1 @@
+./bin/Tiled.app/Contents/MacOS/Tiled

--- a/src/automappingconverter/moc_predefs.h
+++ b/src/automappingconverter/moc_predefs.h
@@ -1,0 +1,357 @@
+#define OBJC_NEW_PROPERTIES 1
+#define _LP64 1
+#define __APPLE_CC__ 6000
+#define __APPLE__ 1
+#define __ATOMIC_ACQUIRE 2
+#define __ATOMIC_ACQ_REL 4
+#define __ATOMIC_CONSUME 1
+#define __ATOMIC_RELAXED 0
+#define __ATOMIC_RELEASE 3
+#define __ATOMIC_SEQ_CST 5
+#define __BIGGEST_ALIGNMENT__ 16
+#define __BLOCKS__ 1
+#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __CHAR16_TYPE__ unsigned short
+#define __CHAR32_TYPE__ unsigned int
+#define __CHAR_BIT__ 8
+#define __CONSTANT_CFSTRINGS__ 1
+#define __DBL_DECIMAL_DIG__ 17
+#define __DBL_DENORM_MIN__ 4.9406564584124654e-324
+#define __DBL_DIG__ 15
+#define __DBL_EPSILON__ 2.2204460492503131e-16
+#define __DBL_HAS_DENORM__ 1
+#define __DBL_HAS_INFINITY__ 1
+#define __DBL_HAS_QUIET_NAN__ 1
+#define __DBL_MANT_DIG__ 53
+#define __DBL_MAX_10_EXP__ 308
+#define __DBL_MAX_EXP__ 1024
+#define __DBL_MAX__ 1.7976931348623157e+308
+#define __DBL_MIN_10_EXP__ (-307)
+#define __DBL_MIN_EXP__ (-1021)
+#define __DBL_MIN__ 2.2250738585072014e-308
+#define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
+#define __DEPRECATED 1
+#define __DYNAMIC__ 1
+#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101000
+#define __EXCEPTIONS 1
+#define __FINITE_MATH_ONLY__ 0
+#define __FLT_DECIMAL_DIG__ 9
+#define __FLT_DENORM_MIN__ 1.40129846e-45F
+#define __FLT_DIG__ 6
+#define __FLT_EPSILON__ 1.19209290e-7F
+#define __FLT_EVAL_METHOD__ 0
+#define __FLT_HAS_DENORM__ 1
+#define __FLT_HAS_INFINITY__ 1
+#define __FLT_HAS_QUIET_NAN__ 1
+#define __FLT_MANT_DIG__ 24
+#define __FLT_MAX_10_EXP__ 38
+#define __FLT_MAX_EXP__ 128
+#define __FLT_MAX__ 3.40282347e+38F
+#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT_MIN_EXP__ (-125)
+#define __FLT_MIN__ 1.17549435e-38F
+#define __FLT_RADIX__ 2
+#define __FXSR__ 1
+#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+#define __GCC_ATOMIC_INT_LOCK_FREE 2
+#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
+#define __GLIBCXX_BITSIZE_INT_N_0 128
+#define __GLIBCXX_TYPE_INT_N_0 __int128
+#define __GNUC_GNU_INLINE__ 1
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 1
+#define __GNUC__ 4
+#define __GNUG__ 4
+#define __GXX_ABI_VERSION 1002
+#define __GXX_EXPERIMENTAL_CXX0X__ 1
+#define __GXX_RTTI 1
+#define __GXX_WEAK__ 1
+#define __INT16_C_SUFFIX__ 
+#define __INT16_FMTd__ "hd"
+#define __INT16_FMTi__ "hi"
+#define __INT16_MAX__ 32767
+#define __INT16_TYPE__ short
+#define __INT32_C_SUFFIX__ 
+#define __INT32_FMTd__ "d"
+#define __INT32_FMTi__ "i"
+#define __INT32_MAX__ 2147483647
+#define __INT32_TYPE__ int
+#define __INT64_C_SUFFIX__ LL
+#define __INT64_FMTd__ "lld"
+#define __INT64_FMTi__ "lli"
+#define __INT64_MAX__ 9223372036854775807LL
+#define __INT64_TYPE__ long long int
+#define __INT8_C_SUFFIX__ 
+#define __INT8_FMTd__ "hhd"
+#define __INT8_FMTi__ "hhi"
+#define __INT8_MAX__ 127
+#define __INT8_TYPE__ signed char
+#define __INTMAX_C_SUFFIX__ L
+#define __INTMAX_FMTd__ "ld"
+#define __INTMAX_FMTi__ "li"
+#define __INTMAX_MAX__ 9223372036854775807L
+#define __INTMAX_TYPE__ long int
+#define __INTMAX_WIDTH__ 64
+#define __INTPTR_FMTd__ "ld"
+#define __INTPTR_FMTi__ "li"
+#define __INTPTR_MAX__ 9223372036854775807L
+#define __INTPTR_TYPE__ long int
+#define __INTPTR_WIDTH__ 64
+#define __INT_FAST16_FMTd__ "hd"
+#define __INT_FAST16_FMTi__ "hi"
+#define __INT_FAST16_MAX__ 32767
+#define __INT_FAST16_TYPE__ short
+#define __INT_FAST32_FMTd__ "d"
+#define __INT_FAST32_FMTi__ "i"
+#define __INT_FAST32_MAX__ 2147483647
+#define __INT_FAST32_TYPE__ int
+#define __INT_FAST64_FMTd__ "ld"
+#define __INT_FAST64_FMTi__ "li"
+#define __INT_FAST64_MAX__ 9223372036854775807L
+#define __INT_FAST64_TYPE__ long int
+#define __INT_FAST8_FMTd__ "hhd"
+#define __INT_FAST8_FMTi__ "hhi"
+#define __INT_FAST8_MAX__ 127
+#define __INT_FAST8_TYPE__ signed char
+#define __INT_LEAST16_FMTd__ "hd"
+#define __INT_LEAST16_FMTi__ "hi"
+#define __INT_LEAST16_MAX__ 32767
+#define __INT_LEAST16_TYPE__ short
+#define __INT_LEAST32_FMTd__ "d"
+#define __INT_LEAST32_FMTi__ "i"
+#define __INT_LEAST32_MAX__ 2147483647
+#define __INT_LEAST32_TYPE__ int
+#define __INT_LEAST64_FMTd__ "ld"
+#define __INT_LEAST64_FMTi__ "li"
+#define __INT_LEAST64_MAX__ 9223372036854775807L
+#define __INT_LEAST64_TYPE__ long int
+#define __INT_LEAST8_FMTd__ "hhd"
+#define __INT_LEAST8_FMTi__ "hhi"
+#define __INT_LEAST8_MAX__ 127
+#define __INT_LEAST8_TYPE__ signed char
+#define __INT_MAX__ 2147483647
+#define __LDBL_DECIMAL_DIG__ 21
+#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+#define __LDBL_DIG__ 18
+#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
+#define __LDBL_HAS_DENORM__ 1
+#define __LDBL_HAS_INFINITY__ 1
+#define __LDBL_HAS_QUIET_NAN__ 1
+#define __LDBL_MANT_DIG__ 64
+#define __LDBL_MAX_10_EXP__ 4932
+#define __LDBL_MAX_EXP__ 16384
+#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+#define __LDBL_MIN_10_EXP__ (-4931)
+#define __LDBL_MIN_EXP__ (-16381)
+#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+#define __LITTLE_ENDIAN__ 1
+#define __LONG_LONG_MAX__ 9223372036854775807LL
+#define __LONG_MAX__ 9223372036854775807L
+#define __LP64__ 1
+#define __MACH__ 1
+#define __MMX__ 1
+#define __NO_MATH_INLINES 1
+#define __OBJC_BOOL_IS_BOOL 0
+#define __OPTIMIZE__ 1
+#define __ORDER_BIG_ENDIAN__ 4321
+#define __ORDER_LITTLE_ENDIAN__ 1234
+#define __ORDER_PDP_ENDIAN__ 3412
+#define __PIC__ 2
+#define __POINTER_WIDTH__ 64
+#define __PRAGMA_REDEFINE_EXTNAME 1
+#define __PTRDIFF_FMTd__ "ld"
+#define __PTRDIFF_FMTi__ "li"
+#define __PTRDIFF_MAX__ 9223372036854775807L
+#define __PTRDIFF_TYPE__ long int
+#define __PTRDIFF_WIDTH__ 64
+#define __REGISTER_PREFIX__ 
+#define __SCHAR_MAX__ 127
+#define __SHRT_MAX__ 32767
+#define __SIG_ATOMIC_MAX__ 2147483647
+#define __SIG_ATOMIC_WIDTH__ 32
+#define __SIZEOF_DOUBLE__ 8
+#define __SIZEOF_FLOAT__ 4
+#define __SIZEOF_INT128__ 16
+#define __SIZEOF_INT__ 4
+#define __SIZEOF_LONG_DOUBLE__ 16
+#define __SIZEOF_LONG_LONG__ 8
+#define __SIZEOF_LONG__ 8
+#define __SIZEOF_POINTER__ 8
+#define __SIZEOF_PTRDIFF_T__ 8
+#define __SIZEOF_SHORT__ 2
+#define __SIZEOF_SIZE_T__ 8
+#define __SIZEOF_WCHAR_T__ 4
+#define __SIZEOF_WINT_T__ 4
+#define __SIZE_FMTX__ "lX"
+#define __SIZE_FMTo__ "lo"
+#define __SIZE_FMTu__ "lu"
+#define __SIZE_FMTx__ "lx"
+#define __SIZE_MAX__ 18446744073709551615UL
+#define __SIZE_TYPE__ long unsigned int
+#define __SIZE_WIDTH__ 64
+#define __SSE2_MATH__ 1
+#define __SSE2__ 1
+#define __SSE3__ 1
+#define __SSE_MATH__ 1
+#define __SSE__ 1
+#define __SSP__ 1
+#define __SSSE3__ 1
+#define __STDC_HOSTED__ 1
+#define __STDC_UTF_16__ 1
+#define __STDC_UTF_32__ 1
+#define __STDC__ 1
+#define __UINT16_C_SUFFIX__ 
+#define __UINT16_FMTX__ "hX"
+#define __UINT16_FMTo__ "ho"
+#define __UINT16_FMTu__ "hu"
+#define __UINT16_FMTx__ "hx"
+#define __UINT16_MAX__ 65535
+#define __UINT16_TYPE__ unsigned short
+#define __UINT32_C_SUFFIX__ U
+#define __UINT32_FMTX__ "X"
+#define __UINT32_FMTo__ "o"
+#define __UINT32_FMTu__ "u"
+#define __UINT32_FMTx__ "x"
+#define __UINT32_MAX__ 4294967295U
+#define __UINT32_TYPE__ unsigned int
+#define __UINT64_C_SUFFIX__ ULL
+#define __UINT64_FMTX__ "llX"
+#define __UINT64_FMTo__ "llo"
+#define __UINT64_FMTu__ "llu"
+#define __UINT64_FMTx__ "llx"
+#define __UINT64_MAX__ 18446744073709551615ULL
+#define __UINT64_TYPE__ long long unsigned int
+#define __UINT8_C_SUFFIX__ 
+#define __UINT8_FMTX__ "hhX"
+#define __UINT8_FMTo__ "hho"
+#define __UINT8_FMTu__ "hhu"
+#define __UINT8_FMTx__ "hhx"
+#define __UINT8_MAX__ 255
+#define __UINT8_TYPE__ unsigned char
+#define __UINTMAX_C_SUFFIX__ UL
+#define __UINTMAX_FMTX__ "lX"
+#define __UINTMAX_FMTo__ "lo"
+#define __UINTMAX_FMTu__ "lu"
+#define __UINTMAX_FMTx__ "lx"
+#define __UINTMAX_MAX__ 18446744073709551615UL
+#define __UINTMAX_TYPE__ long unsigned int
+#define __UINTMAX_WIDTH__ 64
+#define __UINTPTR_FMTX__ "lX"
+#define __UINTPTR_FMTo__ "lo"
+#define __UINTPTR_FMTu__ "lu"
+#define __UINTPTR_FMTx__ "lx"
+#define __UINTPTR_MAX__ 18446744073709551615UL
+#define __UINTPTR_TYPE__ long unsigned int
+#define __UINTPTR_WIDTH__ 64
+#define __UINT_FAST16_FMTX__ "hX"
+#define __UINT_FAST16_FMTo__ "ho"
+#define __UINT_FAST16_FMTu__ "hu"
+#define __UINT_FAST16_FMTx__ "hx"
+#define __UINT_FAST16_MAX__ 65535
+#define __UINT_FAST16_TYPE__ unsigned short
+#define __UINT_FAST32_FMTX__ "X"
+#define __UINT_FAST32_FMTo__ "o"
+#define __UINT_FAST32_FMTu__ "u"
+#define __UINT_FAST32_FMTx__ "x"
+#define __UINT_FAST32_MAX__ 4294967295U
+#define __UINT_FAST32_TYPE__ unsigned int
+#define __UINT_FAST64_FMTX__ "lX"
+#define __UINT_FAST64_FMTo__ "lo"
+#define __UINT_FAST64_FMTu__ "lu"
+#define __UINT_FAST64_FMTx__ "lx"
+#define __UINT_FAST64_MAX__ 18446744073709551615UL
+#define __UINT_FAST64_TYPE__ long unsigned int
+#define __UINT_FAST8_FMTX__ "hhX"
+#define __UINT_FAST8_FMTo__ "hho"
+#define __UINT_FAST8_FMTu__ "hhu"
+#define __UINT_FAST8_FMTx__ "hhx"
+#define __UINT_FAST8_MAX__ 255
+#define __UINT_FAST8_TYPE__ unsigned char
+#define __UINT_LEAST16_FMTX__ "hX"
+#define __UINT_LEAST16_FMTo__ "ho"
+#define __UINT_LEAST16_FMTu__ "hu"
+#define __UINT_LEAST16_FMTx__ "hx"
+#define __UINT_LEAST16_MAX__ 65535
+#define __UINT_LEAST16_TYPE__ unsigned short
+#define __UINT_LEAST32_FMTX__ "X"
+#define __UINT_LEAST32_FMTo__ "o"
+#define __UINT_LEAST32_FMTu__ "u"
+#define __UINT_LEAST32_FMTx__ "x"
+#define __UINT_LEAST32_MAX__ 4294967295U
+#define __UINT_LEAST32_TYPE__ unsigned int
+#define __UINT_LEAST64_FMTX__ "lX"
+#define __UINT_LEAST64_FMTo__ "lo"
+#define __UINT_LEAST64_FMTu__ "lu"
+#define __UINT_LEAST64_FMTx__ "lx"
+#define __UINT_LEAST64_MAX__ 18446744073709551615UL
+#define __UINT_LEAST64_TYPE__ long unsigned int
+#define __UINT_LEAST8_FMTX__ "hhX"
+#define __UINT_LEAST8_FMTo__ "hho"
+#define __UINT_LEAST8_FMTu__ "hhu"
+#define __UINT_LEAST8_FMTx__ "hhx"
+#define __UINT_LEAST8_MAX__ 255
+#define __UINT_LEAST8_TYPE__ unsigned char
+#define __USER_LABEL_PREFIX__ _
+#define __VERSION__ "4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)"
+#define __WCHAR_MAX__ 2147483647
+#define __WCHAR_TYPE__ int
+#define __WCHAR_WIDTH__ 32
+#define __WINT_TYPE__ int
+#define __WINT_WIDTH__ 32
+#define __amd64 1
+#define __amd64__ 1
+#define __apple_build_version__ 8020042
+#define __block __attribute__((__blocks__(byref)))
+#define __clang__ 1
+#define __clang_major__ 8
+#define __clang_minor__ 1
+#define __clang_patchlevel__ 0
+#define __clang_version__ "8.1.0 (clang-802.0.42)"
+#define __core2 1
+#define __core2__ 1
+#define __cplusplus 201103L
+#define __cpp_alias_templates 200704
+#define __cpp_attributes 200809
+#define __cpp_constexpr 200704
+#define __cpp_decltype 200707
+#define __cpp_delegating_constructors 200604
+#define __cpp_exceptions 199711
+#define __cpp_inheriting_constructors 200802
+#define __cpp_initializer_lists 200806
+#define __cpp_lambdas 200907
+#define __cpp_nsdmi 200809
+#define __cpp_range_based_for 200907
+#define __cpp_raw_strings 200710
+#define __cpp_ref_qualifiers 200710
+#define __cpp_rtti 199711
+#define __cpp_rvalue_references 200610
+#define __cpp_static_assert 200410
+#define __cpp_unicode_characters 200704
+#define __cpp_unicode_literals 200710
+#define __cpp_user_defined_literals 200809
+#define __cpp_variadic_templates 200704
+#define __llvm__ 1
+#define __nonnull _Nonnull
+#define __null_unspecified _Null_unspecified
+#define __nullable _Nullable
+#define __pic__ 2
+#define __private_extern__ extern
+#define __strong 
+#define __tune_core2__ 1
+#define __unsafe_unretained 
+#define __weak __attribute__((objc_gc(weak)))
+#define __x86_64 1
+#define __x86_64__ 1

--- a/src/libtiled/hexagonalrenderer.cpp
+++ b/src/libtiled/hexagonalrenderer.cpp
@@ -42,8 +42,8 @@
 using namespace Tiled;
 
 HexagonalRenderer::RenderParams::RenderParams(const Map *map, const WorkSpace &workSpace)
-    : tileWidth(map->tileWidth() & ~1)
-    , tileHeight(map->tileHeight() & ~1)
+    : tileWidth(workSpace.tileWidth() & ~1)
+    , tileHeight(workSpace.tileHeight() & ~1)
     , sideLengthX(0)
     , sideLengthY(0)
     , staggerX(map->staggerAxis() == Map::StaggerX)
@@ -70,18 +70,18 @@ QSize HexagonalRenderer::workSize(const WorkSpace &workSpace) const
 
     // The map size is the same regardless of which indexes are shifted.
     if (p.staggerX) {
-        QSize size(map()->width() * p.columnWidth + p.sideOffsetX,
-                   map()->height() * (p.tileHeight + p.sideLengthY));
+        QSize size(workSpace.width() * p.columnWidth + p.sideOffsetX,
+                   workSpace.height() * (p.tileHeight + p.sideLengthY));
 
-        if (map()->width() > 1)
+        if (workSpace.width() > 1)
             size.rheight() += p.rowHeight;
 
         return size;
     } else {
-        QSize size(map()->width() * (p.tileWidth + p.sideLengthX),
-                   map()->height() * p.rowHeight + p.sideOffsetY);
+        QSize size(workSpace.width() * (p.tileWidth + p.sideLengthX),
+                   workSpace.height() * p.rowHeight + p.sideOffsetY);
 
-        if (map()->height() > 1)
+        if (workSpace.height() > 1)
             size.rwidth() += p.columnWidth;
 
         return size;
@@ -171,21 +171,21 @@ void HexagonalRenderer::drawGrid(QPainter *painter, const QRectF &exposed, const
         if (p.doStaggerX(startTile.x()))
             startPos.ry() -= p.rowHeight;
 
-        for (; startPos.x() <= rect.right() && startTile.x() < map()->width(); startTile.rx()++) {
+        for (; startPos.x() <= rect.right() && startTile.x() < workSpace.width(); startTile.rx()++) {
             QPoint rowTile = startTile;
             QPoint rowPos = startPos;
 
             if (p.doStaggerX(startTile.x()))
                 rowPos.ry() += p.rowHeight;
 
-            for (; rowPos.y() <= rect.bottom() && rowTile.y() < map()->height(); rowTile.ry()++) {
+            for (; rowPos.y() <= rect.bottom() && rowTile.y() < workSpace.height(); rowTile.ry()++) {
                 lines.append(QLine(rowPos + oct[1], rowPos + oct[2]));
                 lines.append(QLine(rowPos + oct[2], rowPos + oct[3]));
                 lines.append(QLine(rowPos + oct[3], rowPos + oct[4]));
 
                 const bool isStaggered = p.doStaggerX(startTile.x());
-                const bool lastRow = rowTile.y() == map()->height() - 1;
-                const bool lastColumn = rowTile.x() == map()->width() - 1;
+                const bool lastRow = rowTile.y() == workSpace.height() - 1;
+                const bool lastColumn = rowTile.x() == workSpace.width() - 1;
                 const bool bottomLeft = rowTile.x() == 0 || (lastRow && isStaggered);
                 const bool bottomRight = lastColumn || (lastRow && isStaggered);
 
@@ -209,21 +209,21 @@ void HexagonalRenderer::drawGrid(QPainter *painter, const QRectF &exposed, const
         if (p.doStaggerY(startTile.y()))
             startPos.rx() -= p.columnWidth;
 
-        for (; startPos.y() <= rect.bottom() && startTile.y() < map()->height(); startTile.ry()++) {
+        for (; startPos.y() <= rect.bottom() && startTile.y() < workSpace.height(); startTile.ry()++) {
             QPoint rowTile = startTile;
             QPoint rowPos = startPos;
 
             if (p.doStaggerY(startTile.y()))
                 rowPos.rx() += p.columnWidth;
 
-            for (; rowPos.x() <= rect.right() && rowTile.x() < map()->width(); rowTile.rx()++) {
+            for (; rowPos.x() <= rect.right() && rowTile.x() < workSpace.width(); rowTile.rx()++) {
                 lines.append(QLine(rowPos + oct[0], rowPos + oct[1]));
                 lines.append(QLine(rowPos + oct[1], rowPos + oct[2]));
                 lines.append(QLine(rowPos + oct[3], rowPos + oct[4]));
 
                 const bool isStaggered = p.doStaggerY(startTile.y());
-                const bool lastRow = rowTile.y() == map()->height() - 1;
-                const bool lastColumn = rowTile.x() == map()->width() - 1;
+                const bool lastRow = rowTile.y() == workSpace.height() - 1;
+                const bool lastColumn = rowTile.x() == workSpace.width() - 1;
                 const bool bottomLeft = lastRow || (rowTile.x() == 0 && !isStaggered);
                 const bool bottomRight = lastRow || (lastColumn && isStaggered);
 
@@ -308,7 +308,7 @@ void HexagonalRenderer::drawTileLayer(QPainter *painter,
 
                     if (!cell.isEmpty()) {
                         Tile *tile = cell.tile();
-                        QSize size = tile ? tile->size() : map()->tileSize();
+                        QSize size = tile ? tile->size() : workSpace.tileSize();
                         renderer.render(cell, rowPos, size, CellRenderer::BottomLeft);
                     }
                 }
@@ -352,7 +352,7 @@ void HexagonalRenderer::drawTileLayer(QPainter *painter,
 
                 if (!cell.isEmpty()) {
                     Tile *tile = cell.tile();
-                    QSize size = tile ? tile->size() : map()->tileSize();
+                    QSize size = tile ? tile->size() : workSpace.tileSize();
                     renderer.render(cell, rowPos, size, CellRenderer::BottomLeft);
                 }
 

--- a/src/libtiled/hexagonalrenderer.cpp
+++ b/src/libtiled/hexagonalrenderer.cpp
@@ -41,7 +41,7 @@
 
 using namespace Tiled;
 
-HexagonalRenderer::RenderParams::RenderParams(const Map *map, const QRect &workSpace)
+HexagonalRenderer::RenderParams::RenderParams(const Map *map, const WorkSpace &workSpace)
     : tileWidth(map->tileWidth() & ~1)
     , tileHeight(map->tileHeight() & ~1)
     , sideLengthX(0)
@@ -64,7 +64,7 @@ HexagonalRenderer::RenderParams::RenderParams(const Map *map, const QRect &workS
 }
 
 
-QSize HexagonalRenderer::workSize(const QRect &workSpace) const
+QSize HexagonalRenderer::workSize(const WorkSpace &workSpace) const
 {
     const RenderParams p(map(), workSpace);
 
@@ -88,7 +88,7 @@ QSize HexagonalRenderer::workSize(const QRect &workSpace) const
     }
 }
 
-QRect HexagonalRenderer::boundingRect(const QRect &rect, const QRect &workSpace) const
+QRect HexagonalRenderer::boundingRect(const QRect &rect, const WorkSpace &workSpace) const
 {
     const RenderParams p(map(), workSpace);
 
@@ -118,7 +118,7 @@ QRect HexagonalRenderer::boundingRect(const QRect &rect, const QRect &workSpace)
     return QRect(topLeft.x(), topLeft.y(), width, height);
 }
 
-void HexagonalRenderer::drawGrid(QPainter *painter, const QRectF &exposed, const QRect &workSpace,
+void HexagonalRenderer::drawGrid(QPainter *painter, const QRectF &exposed, const WorkSpace &workSpace,
                                  QColor gridColor) const
 {
     QRect rect = exposed.toAlignedRect();
@@ -247,7 +247,7 @@ void HexagonalRenderer::drawGrid(QPainter *painter, const QRectF &exposed, const
 
 void HexagonalRenderer::drawTileLayer(QPainter *painter,
                                       const TileLayer *layer,
-									  const QRect &workSpace,
+									  const WorkSpace &workSpace,
                                       const QRectF &exposed) const
 {
     const RenderParams p(map(), workSpace);
@@ -366,7 +366,7 @@ void HexagonalRenderer::drawTileLayer(QPainter *painter,
 
 void HexagonalRenderer::drawTileSelection(QPainter *painter,
                                           const QRegion &region,
-										  const QRect &workSpace,
+										  const WorkSpace &workSpace,
                                           const QColor &color,
                                           const QRectF &exposed) const
 {
@@ -384,12 +384,12 @@ void HexagonalRenderer::drawTileSelection(QPainter *painter,
     }
 }
 
-QPointF HexagonalRenderer::tileToPixelCoords(qreal x, qreal y, const QRect &workSpace) const
+QPointF HexagonalRenderer::tileToPixelCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
     return HexagonalRenderer::tileToScreenCoords(x, y, workSpace);
 }
 
-QPointF HexagonalRenderer::pixelToTileCoords(qreal x, qreal y, const QRect &workSpace) const
+QPointF HexagonalRenderer::pixelToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
     return HexagonalRenderer::screenToTileCoords(x, y, workSpace);
 }
@@ -398,7 +398,7 @@ QPointF HexagonalRenderer::pixelToTileCoords(qreal x, qreal y, const QRect &work
  * Converts screen to tile coordinates. Sub-tile return values are not
  * supported by this renderer.
  */
-QPointF HexagonalRenderer::screenToTileCoords(qreal x, qreal y, const QRect &workSpace) const
+QPointF HexagonalRenderer::screenToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
     const RenderParams p(map(), workSpace);
 
@@ -477,7 +477,7 @@ QPointF HexagonalRenderer::screenToTileCoords(qreal x, qreal y, const QRect &wor
  * Converts tile to screen coordinates. Sub-tile return values are not
  * supported by this renderer.
  */
-QPointF HexagonalRenderer::tileToScreenCoords(qreal x, qreal y, const QRect &workSpace) const
+QPointF HexagonalRenderer::tileToScreenCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
     const RenderParams p(map(), workSpace);
     const int tileX = qFloor(x);
@@ -564,7 +564,7 @@ QPoint HexagonalRenderer::bottomRight(int x, int y) const
 QPolygonF HexagonalRenderer::tileToScreenPolygon(int x, int y) const
 {
 	// LUCA TODO: Do this properly, workSpace is not set to anything
-	const QRect workSpace;
+	const WorkSpace workSpace;
     const RenderParams p(map(), workSpace);
     const QPointF topRight = tileToScreenCoords(x, y, workSpace);
 

--- a/src/libtiled/hexagonalrenderer.cpp
+++ b/src/libtiled/hexagonalrenderer.cpp
@@ -64,10 +64,8 @@ HexagonalRenderer::RenderParams::RenderParams(const Map *map, const QRect &workS
 }
 
 
-QSize HexagonalRenderer::mapSize() const
+QSize HexagonalRenderer::workSize(const QRect &workSpace) const
 {
-	// LUCA TODO: Fix this up
-	const QRect workSpace;
     const RenderParams p(map(), workSpace);
 
     // The map size is the same regardless of which indexes are shifted.

--- a/src/libtiled/hexagonalrenderer.h
+++ b/src/libtiled/hexagonalrenderer.h
@@ -46,7 +46,7 @@ class TILEDSHARED_EXPORT HexagonalRenderer : public OrthogonalRenderer
 protected:
     struct RenderParams
     {
-        RenderParams(const Map *map, const QRect &workSize);
+        RenderParams(const Map *map, const QRect &workSpace);
 
         bool doStaggerX(int x) const
         { return staggerX && (x & 1) ^ staggerEven; }
@@ -71,31 +71,31 @@ public:
 
     QSize mapSize() const override;
 
-    QRect boundingRect(const QRect &rect, const QRect &workSize) const override;
+    QRect boundingRect(const QRect &rect, const QRect &workSpace) const override;
 
-    void drawGrid(QPainter *painter, const QRectF &exposed, const QRect &workSize,
+    void drawGrid(QPainter *painter, const QRectF &exposed, const QRect &workSpace,
                   QColor gridColor) const override;
 
-    void drawTileLayer(QPainter *painter, const TileLayer *layer, const QRect &workSize,
+    void drawTileLayer(QPainter *painter, const TileLayer *layer, const QRect &workSpace,
                        const QRectF &exposed = QRectF()) const override;
 
     void drawTileSelection(QPainter *painter,
                            const QRegion &region,
-						   const QRect &workSize,
+						   const QRect &workSpace,
                            const QColor &color,
                            const QRectF &exposed) const override;
 
     using OrthogonalRenderer::pixelToTileCoords;
-    QPointF pixelToTileCoords(qreal x, qreal y, const QRect &workSize) const override;
+    QPointF pixelToTileCoords(qreal x, qreal y, const QRect &workSpace) const override;
 
     using OrthogonalRenderer::tileToPixelCoords;
-    QPointF tileToPixelCoords(qreal x, qreal y, const QRect &workSize) const override;
+    QPointF tileToPixelCoords(qreal x, qreal y, const QRect &workSpace) const override;
 
     using OrthogonalRenderer::screenToTileCoords;
-    QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSize) const override;
+    QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSpace) const override;
 
     using OrthogonalRenderer::tileToScreenCoords;
-    QPointF tileToScreenCoords(qreal x, qreal y, const QRect &workSize) const override;
+    QPointF tileToScreenCoords(qreal x, qreal y, const QRect &workSpace) const override;
 
     // Functions specific to this type of renderer
     QPoint topLeft(int x, int y) const;

--- a/src/libtiled/hexagonalrenderer.h
+++ b/src/libtiled/hexagonalrenderer.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "orthogonalrenderer.h"
+#include "workspace.h"
 
 namespace Tiled {
 
@@ -46,7 +47,7 @@ class TILEDSHARED_EXPORT HexagonalRenderer : public OrthogonalRenderer
 protected:
     struct RenderParams
     {
-        RenderParams(const Map *map, const QRect &workSpace);
+        RenderParams(const Map *map, const WorkSpace &workSpace);
 
         bool doStaggerX(int x) const
         { return staggerX && (x & 1) ^ staggerEven; }
@@ -69,33 +70,33 @@ protected:
 public:
     HexagonalRenderer(const Map *map) : OrthogonalRenderer(map) {}
 
-    QSize workSize(const QRect &workSpace) const override;
+    QSize workSize(const WorkSpace &workSpace) const override;
 
-    QRect boundingRect(const QRect &rect, const QRect &workSpace) const override;
+    QRect boundingRect(const QRect &rect, const WorkSpace &workSpace) const override;
 
-    void drawGrid(QPainter *painter, const QRectF &exposed, const QRect &workSpace,
+    void drawGrid(QPainter *painter, const QRectF &exposed, const WorkSpace &workSpace,
                   QColor gridColor) const override;
 
-    void drawTileLayer(QPainter *painter, const TileLayer *layer, const QRect &workSpace,
+    void drawTileLayer(QPainter *painter, const TileLayer *layer, const WorkSpace &workSpace,
                        const QRectF &exposed = QRectF()) const override;
 
     void drawTileSelection(QPainter *painter,
                            const QRegion &region,
-						   const QRect &workSpace,
+						   const WorkSpace &workSpace,
                            const QColor &color,
                            const QRectF &exposed) const override;
 
     using OrthogonalRenderer::pixelToTileCoords;
-    QPointF pixelToTileCoords(qreal x, qreal y, const QRect &workSpace) const override;
+    QPointF pixelToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const override;
 
     using OrthogonalRenderer::tileToPixelCoords;
-    QPointF tileToPixelCoords(qreal x, qreal y, const QRect &workSpace) const override;
+    QPointF tileToPixelCoords(qreal x, qreal y, const WorkSpace &workSpace) const override;
 
     using OrthogonalRenderer::screenToTileCoords;
-    QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSpace) const override;
+    QPointF screenToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const override;
 
     using OrthogonalRenderer::tileToScreenCoords;
-    QPointF tileToScreenCoords(qreal x, qreal y, const QRect &workSpace) const override;
+    QPointF tileToScreenCoords(qreal x, qreal y, const WorkSpace &workSpace) const override;
 
     // Functions specific to this type of renderer
     QPoint topLeft(int x, int y) const;

--- a/src/libtiled/hexagonalrenderer.h
+++ b/src/libtiled/hexagonalrenderer.h
@@ -46,7 +46,7 @@ class TILEDSHARED_EXPORT HexagonalRenderer : public OrthogonalRenderer
 protected:
     struct RenderParams
     {
-        RenderParams(const Map *map);
+        RenderParams(const Map *map, const QRect &workSize);
 
         bool doStaggerX(int x) const
         { return staggerX && (x & 1) ^ staggerEven; }
@@ -71,30 +71,31 @@ public:
 
     QSize mapSize() const override;
 
-    QRect boundingRect(const QRect &rect) const override;
+    QRect boundingRect(const QRect &rect, const QRect &workSize) const override;
 
-    void drawGrid(QPainter *painter, const QRectF &exposed,
+    void drawGrid(QPainter *painter, const QRectF &exposed, const QRect &workSize,
                   QColor gridColor) const override;
 
-    void drawTileLayer(QPainter *painter, const TileLayer *layer,
+    void drawTileLayer(QPainter *painter, const TileLayer *layer, const QRect &workSize,
                        const QRectF &exposed = QRectF()) const override;
 
     void drawTileSelection(QPainter *painter,
                            const QRegion &region,
+						   const QRect &workSize,
                            const QColor &color,
                            const QRectF &exposed) const override;
 
     using OrthogonalRenderer::pixelToTileCoords;
-    QPointF pixelToTileCoords(qreal x, qreal y) const override;
+    QPointF pixelToTileCoords(qreal x, qreal y, const QRect &workSize) const override;
 
     using OrthogonalRenderer::tileToPixelCoords;
-    QPointF tileToPixelCoords(qreal x, qreal y) const override;
+    QPointF tileToPixelCoords(qreal x, qreal y, const QRect &workSize) const override;
 
     using OrthogonalRenderer::screenToTileCoords;
-    QPointF screenToTileCoords(qreal x, qreal y) const override;
+    QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSize) const override;
 
     using OrthogonalRenderer::tileToScreenCoords;
-    QPointF tileToScreenCoords(qreal x, qreal y) const override;
+    QPointF tileToScreenCoords(qreal x, qreal y, const QRect &workSize) const override;
 
     // Functions specific to this type of renderer
     QPoint topLeft(int x, int y) const;

--- a/src/libtiled/hexagonalrenderer.h
+++ b/src/libtiled/hexagonalrenderer.h
@@ -69,7 +69,7 @@ protected:
 public:
     HexagonalRenderer(const Map *map) : OrthogonalRenderer(map) {}
 
-    QSize mapSize() const override;
+    QSize workSize(const QRect &workSpace) const override;
 
     QRect boundingRect(const QRect &rect, const QRect &workSpace) const override;
 

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -38,7 +38,7 @@
 
 using namespace Tiled;
 
-QSize IsometricRenderer::mapSize() const
+QSize IsometricRenderer::workSize(const QRect &workSpace) const
 {
     // Map width and height contribute equally in both directions
     const int side = map()->height() + map()->width();

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -41,17 +41,17 @@ using namespace Tiled;
 QSize IsometricRenderer::workSize(const WorkSpace &workSpace) const
 {
     // Map width and height contribute equally in both directions
-    const int side = map()->height() + map()->width();
-    return QSize(side * map()->tileWidth() / 2,
-                 side * map()->tileHeight() / 2);
+    const int side = workSpace.height() + workSpace.width();
+    return QSize(side * workSpace.tileWidth() / 2,
+                 side * workSpace.tileHeight() / 2);
 }
 
 QRect IsometricRenderer::boundingRect(const QRect &rect, const WorkSpace &workSpace) const
 {
-    const int tileWidth = map()->tileWidth();
-    const int tileHeight = map()->tileHeight();
+    const int tileWidth = workSpace.tileWidth();
+    const int tileHeight = workSpace.tileHeight();
 
-    const int originX = map()->height() * tileWidth / 2;
+    const int originX = workSpace.height() * tileWidth / 2;
     const QPoint pos((rect.x() - (rect.y() + rect.height()))
                      * tileWidth / 2 + originX,
                      (rect.x() + rect.y()) * tileHeight / 2);
@@ -150,8 +150,8 @@ QPainterPath IsometricRenderer::shape(const MapObject *object, const WorkSpace &
 void IsometricRenderer::drawGrid(QPainter *painter, const QRectF &rect, const WorkSpace &workSpace,
                                  QColor gridColor) const
 {
-    const int tileWidth = map()->tileWidth();
-    const int tileHeight = map()->tileHeight();
+    const int tileWidth = workSpace.tileWidth();
+    const int tileHeight = workSpace.tileHeight();
 
     QRect r = rect.toAlignedRect();
     r.adjust(-tileWidth / 2, -tileHeight / 2,
@@ -159,9 +159,9 @@ void IsometricRenderer::drawGrid(QPainter *painter, const QRectF &rect, const Wo
 
     const int startX = qMax(qreal(0), screenToTileCoords(r.topLeft(), workSpace).x());
     const int startY = qMax(qreal(0), screenToTileCoords(r.topRight(), workSpace).y());
-    const int endX = qMin(qreal(map()->width()),
+    const int endX = qMin(qreal(workSpace.width()),
                           screenToTileCoords(r.bottomRight(), workSpace).x());
-    const int endY = qMin(qreal(map()->height()),
+    const int endY = qMin(qreal(workSpace.height()),
                           screenToTileCoords(r.bottomLeft(), workSpace).y());
 
     QPen gridPen = makeGridPen(painter->device(), gridColor);
@@ -184,8 +184,8 @@ void IsometricRenderer::drawTileLayer(QPainter *painter,
 									  const WorkSpace &workSpace,
                                       const QRectF &exposed) const
 {
-    const int tileWidth = map()->tileWidth();
-    const int tileHeight = map()->tileHeight();
+    const int tileWidth = workSpace.tileWidth();
+    const int tileHeight = workSpace.tileHeight();
 
     if (tileWidth <= 0 || tileHeight <= 1)
         return;
@@ -248,7 +248,7 @@ void IsometricRenderer::drawTileLayer(QPainter *painter,
                 const Cell &cell = layer->cellAt(columnItr);
                 if (!cell.isEmpty()) {
                     Tile *tile = cell.tile();
-                    QSize size = tile ? tile->size() : map()->tileSize();
+                    QSize size = tile ? tile->size() : workSpace.tileSize();
                     renderer.render(cell, QPointF(x, (float)y / 2), size,
                                     CellRenderer::BottomLeft);
                 }
@@ -358,8 +358,8 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
         case MapObject::Ellipse: {
             QPolygonF polygon = pixelRectToScreenPolygon(object->bounds(), workSpace);
 
-            float tw = map()->tileWidth();
-            float th = map()->tileHeight();
+            float tw = workSpace.tileWidth();
+            float th = workSpace.tileHeight();
             QPointF transformScale(1, 1);
             if (tw > th)
                 transformScale = QPointF(1, th/tw);
@@ -472,24 +472,24 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
 
 QPointF IsometricRenderer::pixelToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
-    const int tileHeight = map()->tileHeight();
+    const int tileHeight = workSpace.tileHeight();
 
     return QPointF(x / tileHeight, y / tileHeight);
 }
 
 QPointF IsometricRenderer::tileToPixelCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
-    const int tileHeight = map()->tileHeight();
+    const int tileHeight = workSpace.tileHeight();
 
     return QPointF(x * tileHeight, y * tileHeight);
 }
 
 QPointF IsometricRenderer::screenToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
-    const int tileWidth = map()->tileWidth();
-    const int tileHeight = map()->tileHeight();
+    const int tileWidth = workSpace.tileWidth();
+    const int tileHeight = workSpace.tileHeight();
 
-    x -= map()->height() * tileWidth / 2;
+    x -= workSpace.height() * tileWidth / 2;
     const qreal tileY = y / tileHeight;
     const qreal tileX = x / tileWidth;
 
@@ -499,9 +499,9 @@ QPointF IsometricRenderer::screenToTileCoords(qreal x, qreal y, const WorkSpace 
 
 QPointF IsometricRenderer::tileToScreenCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
-    const int tileWidth = map()->tileWidth();
-    const int tileHeight = map()->tileHeight();
-    const int originX = map()->height() * tileWidth / 2;
+    const int tileWidth = workSpace.tileWidth();
+    const int tileHeight = workSpace.tileHeight();
+    const int originX = workSpace.height() * tileWidth / 2;
 
     return QPointF((x - y) * tileWidth / 2 + originX,
                    (x + y) * tileHeight / 2);
@@ -509,10 +509,10 @@ QPointF IsometricRenderer::tileToScreenCoords(qreal x, qreal y, const WorkSpace 
 
 QPointF IsometricRenderer::screenToPixelCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
-    const int tileWidth = map()->tileWidth();
-    const int tileHeight = map()->tileHeight();
+    const int tileWidth = workSpace.tileWidth();
+    const int tileHeight = workSpace.tileHeight();
 
-    x -= map()->height() * tileWidth / 2;
+    x -= workSpace.height() * tileWidth / 2;
     const qreal tileY = y / tileHeight;
     const qreal tileX = x / tileWidth;
 
@@ -522,9 +522,9 @@ QPointF IsometricRenderer::screenToPixelCoords(qreal x, qreal y, const WorkSpace
 
 QPointF IsometricRenderer::pixelToScreenCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
-    const int tileWidth = map()->tileWidth();
-    const int tileHeight = map()->tileHeight();
-    const int originX = map()->height() * tileWidth / 2;
+    const int tileWidth = workSpace.tileWidth();
+    const int tileHeight = workSpace.tileHeight();
+    const int originX = workSpace.height() * tileWidth / 2;
     const qreal tileY = y / tileHeight;
     const qreal tileX = x / tileHeight;
 
@@ -544,8 +544,8 @@ QPolygonF IsometricRenderer::pixelRectToScreenPolygon(const QRectF &rect, const 
 
 QPolygonF IsometricRenderer::tileRectToScreenPolygon(const QRect &rect, const WorkSpace &workSpace) const
 {
-    const int tileWidth = map()->tileWidth();
-    const int tileHeight = map()->tileHeight();
+    const int tileWidth = workSpace.tileWidth();
+    const int tileHeight = workSpace.tileHeight();
 
     const QPointF topRight = tileToScreenCoords(rect.topRight(), workSpace);
     const QPointF bottomRight = tileToScreenCoords(rect.bottomRight(), workSpace);

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -38,7 +38,7 @@
 
 using namespace Tiled;
 
-QSize IsometricRenderer::workSize(const QRect &workSpace) const
+QSize IsometricRenderer::workSize(const WorkSpace &workSpace) const
 {
     // Map width and height contribute equally in both directions
     const int side = map()->height() + map()->width();
@@ -46,7 +46,7 @@ QSize IsometricRenderer::workSize(const QRect &workSpace) const
                  side * map()->tileHeight() / 2);
 }
 
-QRect IsometricRenderer::boundingRect(const QRect &rect, const QRect &workSpace) const
+QRect IsometricRenderer::boundingRect(const QRect &rect, const WorkSpace &workSpace) const
 {
     const int tileWidth = map()->tileWidth();
     const int tileHeight = map()->tileHeight();
@@ -63,7 +63,7 @@ QRect IsometricRenderer::boundingRect(const QRect &rect, const QRect &workSpace)
     return QRect(pos, size);
 }
 
-QRectF IsometricRenderer::boundingRect(const MapObject *object, const QRect &workSpace) const
+QRectF IsometricRenderer::boundingRect(const MapObject *object, const WorkSpace &workSpace) const
 {
     if (object->shape() == MapObject::Text) {
         const QPointF topLeft = pixelToScreenCoords(object->position(), workSpace);
@@ -113,7 +113,7 @@ QRectF IsometricRenderer::boundingRect(const MapObject *object, const QRect &wor
     }
 }
 
-QPainterPath IsometricRenderer::shape(const MapObject *object, const QRect &workSpace) const
+QPainterPath IsometricRenderer::shape(const MapObject *object, const WorkSpace &workSpace) const
 {
     QPainterPath path;
     if (!object->cell().isEmpty() || object->shape() == MapObject::Text) {
@@ -147,7 +147,7 @@ QPainterPath IsometricRenderer::shape(const MapObject *object, const QRect &work
     return path;
 }
 
-void IsometricRenderer::drawGrid(QPainter *painter, const QRectF &rect, const QRect &workSpace,
+void IsometricRenderer::drawGrid(QPainter *painter, const QRectF &rect, const WorkSpace &workSpace,
                                  QColor gridColor) const
 {
     const int tileWidth = map()->tileWidth();
@@ -181,7 +181,7 @@ void IsometricRenderer::drawGrid(QPainter *painter, const QRectF &rect, const QR
 
 void IsometricRenderer::drawTileLayer(QPainter *painter,
                                       const TileLayer *layer,
-									  const QRect &workSpace,
+									  const WorkSpace &workSpace,
                                       const QRectF &exposed) const
 {
     const int tileWidth = map()->tileWidth();
@@ -274,7 +274,7 @@ void IsometricRenderer::drawTileLayer(QPainter *painter,
 
 void IsometricRenderer::drawTileSelection(QPainter *painter,
                                           const QRegion &region,
-										  const QRect &workSpace,
+										  const WorkSpace &workSpace,
                                           const QColor &color,
                                           const QRectF &exposed) const
 {
@@ -288,7 +288,7 @@ void IsometricRenderer::drawTileSelection(QPainter *painter,
 }
 
 void IsometricRenderer::drawMapObject(QPainter *painter,
-		                              const QRect &workSpace,
+		                              const WorkSpace &workSpace,
                                       const MapObject *object,
                                       const QColor &color) const
 {
@@ -470,21 +470,21 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
     painter->restore();
 }
 
-QPointF IsometricRenderer::pixelToTileCoords(qreal x, qreal y, const QRect &workSpace) const
+QPointF IsometricRenderer::pixelToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
     const int tileHeight = map()->tileHeight();
 
     return QPointF(x / tileHeight, y / tileHeight);
 }
 
-QPointF IsometricRenderer::tileToPixelCoords(qreal x, qreal y, const QRect &workSpace) const
+QPointF IsometricRenderer::tileToPixelCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
     const int tileHeight = map()->tileHeight();
 
     return QPointF(x * tileHeight, y * tileHeight);
 }
 
-QPointF IsometricRenderer::screenToTileCoords(qreal x, qreal y, const QRect &workSpace) const
+QPointF IsometricRenderer::screenToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
     const int tileWidth = map()->tileWidth();
     const int tileHeight = map()->tileHeight();
@@ -497,7 +497,7 @@ QPointF IsometricRenderer::screenToTileCoords(qreal x, qreal y, const QRect &wor
                    tileY - tileX);
 }
 
-QPointF IsometricRenderer::tileToScreenCoords(qreal x, qreal y, const QRect &workSpace) const
+QPointF IsometricRenderer::tileToScreenCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
     const int tileWidth = map()->tileWidth();
     const int tileHeight = map()->tileHeight();
@@ -507,7 +507,7 @@ QPointF IsometricRenderer::tileToScreenCoords(qreal x, qreal y, const QRect &wor
                    (x + y) * tileHeight / 2);
 }
 
-QPointF IsometricRenderer::screenToPixelCoords(qreal x, qreal y, const QRect &workSpace) const
+QPointF IsometricRenderer::screenToPixelCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
     const int tileWidth = map()->tileWidth();
     const int tileHeight = map()->tileHeight();
@@ -520,7 +520,7 @@ QPointF IsometricRenderer::screenToPixelCoords(qreal x, qreal y, const QRect &wo
                    (tileY - tileX) * tileHeight);
 }
 
-QPointF IsometricRenderer::pixelToScreenCoords(qreal x, qreal y, const QRect &workSpace) const
+QPointF IsometricRenderer::pixelToScreenCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
     const int tileWidth = map()->tileWidth();
     const int tileHeight = map()->tileHeight();
@@ -532,7 +532,7 @@ QPointF IsometricRenderer::pixelToScreenCoords(qreal x, qreal y, const QRect &wo
                    (tileX + tileY) * tileHeight / 2);
 }
 
-QPolygonF IsometricRenderer::pixelRectToScreenPolygon(const QRectF &rect, const QRect &workSpace) const
+QPolygonF IsometricRenderer::pixelRectToScreenPolygon(const QRectF &rect, const WorkSpace &workSpace) const
 {
     QPolygonF polygon;
     polygon << QPointF(pixelToScreenCoords(rect.topLeft(), workSpace));
@@ -542,7 +542,7 @@ QPolygonF IsometricRenderer::pixelRectToScreenPolygon(const QRectF &rect, const 
     return polygon;
 }
 
-QPolygonF IsometricRenderer::tileRectToScreenPolygon(const QRect &rect, const QRect &workSpace) const
+QPolygonF IsometricRenderer::tileRectToScreenPolygon(const QRect &rect, const WorkSpace &workSpace) const
 {
     const int tileWidth = map()->tileWidth();
     const int tileHeight = map()->tileHeight();

--- a/src/libtiled/isometricrenderer.h
+++ b/src/libtiled/isometricrenderer.h
@@ -46,46 +46,48 @@ public:
 
     QSize mapSize() const override;
 
-    QRect boundingRect(const QRect &rect) const override;
+    QRect boundingRect(const QRect &rect, const QRect &workSize) const override;
 
-    QRectF boundingRect(const MapObject *object) const override;
-    QPainterPath shape(const MapObject *object) const override;
+    QRectF boundingRect(const MapObject *object, const QRect &workSize) const override;
+    QPainterPath shape(const MapObject *object, const QRect &workSize) const override;
 
-    void drawGrid(QPainter *painter, const QRectF &rect, QColor grid) const override;
+    void drawGrid(QPainter *painter, const QRectF &rect, const QRect &workSize, QColor grid) const override;
 
-    void drawTileLayer(QPainter *painter, const TileLayer *layer,
+    void drawTileLayer(QPainter *painter, const TileLayer *layer, const QRect &workSize,
                        const QRectF &exposed = QRectF()) const override;
 
     void drawTileSelection(QPainter *painter,
                            const QRegion &region,
+						   const QRect &workSize,
                            const QColor &color,
                            const QRectF &exposed) const override;
 
     void drawMapObject(QPainter *painter,
+			           const QRect &workSize,
                        const MapObject *object,
                        const QColor &color) const override;
 
     using MapRenderer::pixelToTileCoords;
-    QPointF pixelToTileCoords(qreal x, qreal y) const override;
+    QPointF pixelToTileCoords(qreal x, qreal y, const QRect &workSize) const override;
 
     using MapRenderer::tileToPixelCoords;
-    QPointF tileToPixelCoords(qreal x, qreal y) const override;
+    QPointF tileToPixelCoords(qreal x, qreal y, const QRect &workSize) const override;
 
     using MapRenderer::screenToTileCoords;
-    QPointF screenToTileCoords(qreal x, qreal y) const override;
+    QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSize) const override;
 
     using MapRenderer::tileToScreenCoords;
-    QPointF tileToScreenCoords(qreal x, qreal y) const override;
+    QPointF tileToScreenCoords(qreal x, qreal y, const QRect &workSize) const override;
 
     using MapRenderer::screenToPixelCoords;
-    QPointF screenToPixelCoords(qreal x, qreal y) const override;
+    QPointF screenToPixelCoords(qreal x, qreal y, const QRect &workSize) const override;
 
     using MapRenderer::pixelToScreenCoords;
-    QPointF pixelToScreenCoords(qreal x, qreal y) const override;
+    QPointF pixelToScreenCoords(qreal x, qreal y, const QRect &workSize) const override;
 
 private:
-    QPolygonF pixelRectToScreenPolygon(const QRectF &rect) const;
-    QPolygonF tileRectToScreenPolygon(const QRect &rect) const;
+    QPolygonF pixelRectToScreenPolygon(const QRectF &rect, const QRect &workSize) const;
+    QPolygonF tileRectToScreenPolygon(const QRect &rect, const QRect &workSize) const;
 };
 
 } // namespace Tiled

--- a/src/libtiled/isometricrenderer.h
+++ b/src/libtiled/isometricrenderer.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "maprenderer.h"
+#include "workspace.h"
 
 namespace Tiled {
 
@@ -44,50 +45,50 @@ class TILEDSHARED_EXPORT IsometricRenderer : public MapRenderer
 public:
     IsometricRenderer(const Map *map) : MapRenderer(map) {}
 
-    QSize workSize(const QRect &workSpace) const override;
+    QSize workSize(const WorkSpace &workSpace) const override;
 
-    QRect boundingRect(const QRect &rect, const QRect &workSpace) const override;
+    QRect boundingRect(const QRect &rect, const WorkSpace &workSpace) const override;
 
-    QRectF boundingRect(const MapObject *object, const QRect &workSpace) const override;
-    QPainterPath shape(const MapObject *object, const QRect &workSpace) const override;
+    QRectF boundingRect(const MapObject *object, const WorkSpace &workSpace) const override;
+    QPainterPath shape(const MapObject *object, const WorkSpace &workSpace) const override;
 
-    void drawGrid(QPainter *painter, const QRectF &rect, const QRect &workSpace, QColor grid) const override;
+    void drawGrid(QPainter *painter, const QRectF &rect, const WorkSpace &workSpace, QColor grid) const override;
 
-    void drawTileLayer(QPainter *painter, const TileLayer *layer, const QRect &workSpace,
+    void drawTileLayer(QPainter *painter, const TileLayer *layer, const WorkSpace &workSpace,
                        const QRectF &exposed = QRectF()) const override;
 
     void drawTileSelection(QPainter *painter,
                            const QRegion &region,
-						   const QRect &workSpace,
+						   const WorkSpace &workSpace,
                            const QColor &color,
                            const QRectF &exposed) const override;
 
     void drawMapObject(QPainter *painter,
-			           const QRect &workSpace,
+			           const WorkSpace &workSpace,
                        const MapObject *object,
                        const QColor &color) const override;
 
     using MapRenderer::pixelToTileCoords;
-    QPointF pixelToTileCoords(qreal x, qreal y, const QRect &workSpace) const override;
+    QPointF pixelToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const override;
 
     using MapRenderer::tileToPixelCoords;
-    QPointF tileToPixelCoords(qreal x, qreal y, const QRect &workSpace) const override;
+    QPointF tileToPixelCoords(qreal x, qreal y, const WorkSpace &workSpace) const override;
 
     using MapRenderer::screenToTileCoords;
-    QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSpace) const override;
+    QPointF screenToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const override;
 
     using MapRenderer::tileToScreenCoords;
-    QPointF tileToScreenCoords(qreal x, qreal y, const QRect &workSpace) const override;
+    QPointF tileToScreenCoords(qreal x, qreal y, const WorkSpace &workSpace) const override;
 
     using MapRenderer::screenToPixelCoords;
-    QPointF screenToPixelCoords(qreal x, qreal y, const QRect &workSpace) const override;
+    QPointF screenToPixelCoords(qreal x, qreal y, const WorkSpace &workSpace) const override;
 
     using MapRenderer::pixelToScreenCoords;
-    QPointF pixelToScreenCoords(qreal x, qreal y, const QRect &workSpace) const override;
+    QPointF pixelToScreenCoords(qreal x, qreal y, const WorkSpace &workSpace) const override;
 
 private:
-    QPolygonF pixelRectToScreenPolygon(const QRectF &rect, const QRect &workSpace) const;
-    QPolygonF tileRectToScreenPolygon(const QRect &rect, const QRect &workSpace) const;
+    QPolygonF pixelRectToScreenPolygon(const QRectF &rect, const WorkSpace &workSpace) const;
+    QPolygonF tileRectToScreenPolygon(const QRect &rect, const WorkSpace &workSpace) const;
 };
 
 } // namespace Tiled

--- a/src/libtiled/isometricrenderer.h
+++ b/src/libtiled/isometricrenderer.h
@@ -44,7 +44,7 @@ class TILEDSHARED_EXPORT IsometricRenderer : public MapRenderer
 public:
     IsometricRenderer(const Map *map) : MapRenderer(map) {}
 
-    QSize mapSize() const override;
+    QSize workSize(const QRect &workSpace) const override;
 
     QRect boundingRect(const QRect &rect, const QRect &workSpace) const override;
 

--- a/src/libtiled/isometricrenderer.h
+++ b/src/libtiled/isometricrenderer.h
@@ -46,48 +46,48 @@ public:
 
     QSize mapSize() const override;
 
-    QRect boundingRect(const QRect &rect, const QRect &workSize) const override;
+    QRect boundingRect(const QRect &rect, const QRect &workSpace) const override;
 
-    QRectF boundingRect(const MapObject *object, const QRect &workSize) const override;
-    QPainterPath shape(const MapObject *object, const QRect &workSize) const override;
+    QRectF boundingRect(const MapObject *object, const QRect &workSpace) const override;
+    QPainterPath shape(const MapObject *object, const QRect &workSpace) const override;
 
-    void drawGrid(QPainter *painter, const QRectF &rect, const QRect &workSize, QColor grid) const override;
+    void drawGrid(QPainter *painter, const QRectF &rect, const QRect &workSpace, QColor grid) const override;
 
-    void drawTileLayer(QPainter *painter, const TileLayer *layer, const QRect &workSize,
+    void drawTileLayer(QPainter *painter, const TileLayer *layer, const QRect &workSpace,
                        const QRectF &exposed = QRectF()) const override;
 
     void drawTileSelection(QPainter *painter,
                            const QRegion &region,
-						   const QRect &workSize,
+						   const QRect &workSpace,
                            const QColor &color,
                            const QRectF &exposed) const override;
 
     void drawMapObject(QPainter *painter,
-			           const QRect &workSize,
+			           const QRect &workSpace,
                        const MapObject *object,
                        const QColor &color) const override;
 
     using MapRenderer::pixelToTileCoords;
-    QPointF pixelToTileCoords(qreal x, qreal y, const QRect &workSize) const override;
+    QPointF pixelToTileCoords(qreal x, qreal y, const QRect &workSpace) const override;
 
     using MapRenderer::tileToPixelCoords;
-    QPointF tileToPixelCoords(qreal x, qreal y, const QRect &workSize) const override;
+    QPointF tileToPixelCoords(qreal x, qreal y, const QRect &workSpace) const override;
 
     using MapRenderer::screenToTileCoords;
-    QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSize) const override;
+    QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSpace) const override;
 
     using MapRenderer::tileToScreenCoords;
-    QPointF tileToScreenCoords(qreal x, qreal y, const QRect &workSize) const override;
+    QPointF tileToScreenCoords(qreal x, qreal y, const QRect &workSpace) const override;
 
     using MapRenderer::screenToPixelCoords;
-    QPointF screenToPixelCoords(qreal x, qreal y, const QRect &workSize) const override;
+    QPointF screenToPixelCoords(qreal x, qreal y, const QRect &workSpace) const override;
 
     using MapRenderer::pixelToScreenCoords;
-    QPointF pixelToScreenCoords(qreal x, qreal y, const QRect &workSize) const override;
+    QPointF pixelToScreenCoords(qreal x, qreal y, const QRect &workSpace) const override;
 
 private:
-    QPolygonF pixelRectToScreenPolygon(const QRectF &rect, const QRect &workSize) const;
-    QPolygonF tileRectToScreenPolygon(const QRect &rect, const QRect &workSize) const;
+    QPolygonF pixelRectToScreenPolygon(const QRectF &rect, const QRect &workSpace) const;
+    QPolygonF tileRectToScreenPolygon(const QRect &rect, const QRect &workSpace) const;
 };
 
 } // namespace Tiled

--- a/src/libtiled/libtiled.qbs
+++ b/src/libtiled/libtiled.qbs
@@ -96,6 +96,7 @@ DynamicLibrary {
         "tilesetmanager.h",
         "varianttomapconverter.cpp",
         "varianttomapconverter.h",
+		"workspace.h"
     ]
 
     Group {

--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -603,7 +603,9 @@ TileLayer *MapReaderPrivate::readTileLayer()
 	const int tileWidth = atts.value(QLatin1String("tilewidth")).toInt();
 	const int tileHeight = atts.value(QLatin1String("tileheight")).toInt();
 
-    TileLayer *tileLayer = new TileLayer(name, x, y, width, height, tileWidth, tileHeight);
+    TileLayer *tileLayer = new TileLayer(name, x, y,
+										 width, height,
+										 (tileWidth ? tileWidth : mMap->tileWidth()) , (tileHeight ? tileHeight : mMap->tileHeight()));
     readLayerAttributes(*tileLayer, atts);
 
     while (xml.readNextStartElement()) {

--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -600,8 +600,10 @@ TileLayer *MapReaderPrivate::readTileLayer()
     const int y = atts.value(QLatin1String("y")).toInt();
     const int width = atts.value(QLatin1String("width")).toInt();
     const int height = atts.value(QLatin1String("height")).toInt();
+	const int tileWidth = atts.value(QLatin1String("tilewidth")).toInt();
+	const int tileHeight = atts.value(QLatin1String("tileheight")).toInt();
 
-    TileLayer *tileLayer = new TileLayer(name, x, y, width, height);
+    TileLayer *tileLayer = new TileLayer(name, x, y, width, height, tileWidth, tileHeight);
     readLayerAttributes(*tileLayer, atts);
 
     while (xml.readNextStartElement()) {

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -40,15 +40,18 @@
 
 using namespace Tiled;
 
-QRectF MapRenderer::boundingRect(const ImageLayer *imageLayer) const
+QRectF MapRenderer::boundingRect(const ImageLayer *imageLayer, const QRect &workSize) const
 {
+	Q_UNUSED(workSize)
     return QRectF(QPointF(), imageLayer->image().size());
 }
 
 void MapRenderer::drawImageLayer(QPainter *painter,
+		                         const QRect &workSize,
                                  const ImageLayer *imageLayer,
                                  const QRectF &exposed)
 {
+	Q_UNUSED(workSize)
     Q_UNUSED(exposed)
 
     painter->drawPixmap(QPointF(), imageLayer->image());

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -40,14 +40,14 @@
 
 using namespace Tiled;
 
-QRectF MapRenderer::boundingRect(const ImageLayer *imageLayer, const QRect &workSpace) const
+QRectF MapRenderer::boundingRect(const ImageLayer *imageLayer, const WorkSpace &workSpace) const
 {
 	Q_UNUSED(workSpace)
     return QRectF(QPointF(), imageLayer->image().size());
 }
 
 void MapRenderer::drawImageLayer(QPainter *painter,
-		                         const QRect &workSpace,
+		                         const WorkSpace &workSpace,
                                  const ImageLayer *imageLayer,
                                  const QRectF &exposed)
 {

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -40,18 +40,18 @@
 
 using namespace Tiled;
 
-QRectF MapRenderer::boundingRect(const ImageLayer *imageLayer, const QRect &workSize) const
+QRectF MapRenderer::boundingRect(const ImageLayer *imageLayer, const QRect &workSpace) const
 {
-	Q_UNUSED(workSize)
+	Q_UNUSED(workSpace)
     return QRectF(QPointF(), imageLayer->image().size());
 }
 
 void MapRenderer::drawImageLayer(QPainter *painter,
-		                         const QRect &workSize,
+		                         const QRect &workSpace,
                                  const ImageLayer *imageLayer,
                                  const QRectF &exposed)
 {
-	Q_UNUSED(workSize)
+	Q_UNUSED(workSpace)
     Q_UNUSED(exposed)
 
     painter->drawPixmap(QPointF(), imageLayer->image());

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -82,32 +82,32 @@ public:
      * This is useful for calculating the bounding rect of a tile layer or of
      * a region of tiles that was changed.
      */
-    virtual QRect boundingRect(const QRect &rect) const = 0;
+    virtual QRect boundingRect(const QRect &rect, const QRect &workSize) const = 0;
 
     /**
      * Returns the bounding rectangle in pixels of the given \a object, as it
      * would be drawn by drawMapObject().
      */
-    virtual QRectF boundingRect(const MapObject *object) const = 0;
+    virtual QRectF boundingRect(const MapObject *object, const QRect &workSize) const = 0;
 
     /**
      * Returns the bounding rectangle in pixels of the given \a imageLayer, as
      * it would be drawn by drawImageLayer().
      */
-    QRectF boundingRect(const ImageLayer *imageLayer) const;
+    QRectF boundingRect(const ImageLayer *imageLayer, const QRect &workSize) const;
 
     /**
      * Returns the shape in pixels of the given \a object. This is used for
      * mouse interaction and should match the rendered object as closely as
      * possible.
      */
-    virtual QPainterPath shape(const MapObject *object) const = 0;
+    virtual QPainterPath shape(const MapObject *object, const QRect &workSize) const = 0;
 
     /**
      * Draws the tile grid in the specified \a rect using the given
      * \a painter.
      */
-    virtual void drawGrid(QPainter *painter, const QRectF &rect,
+    virtual void drawGrid(QPainter *painter, const QRectF &rect, const QRect &workSize,
                           QColor gridColor = Qt::black) const = 0;
 
     /**
@@ -116,7 +116,7 @@ public:
      * Optionally, you can pass in the \a exposed rect (of pixels), so that
      * only tiles that can be visible in this area will be drawn.
      */
-    virtual void drawTileLayer(QPainter *painter, const TileLayer *layer,
+    virtual void drawTileLayer(QPainter *painter, const TileLayer *layer, const QRect &workSize,
                                const QRectF &exposed = QRectF()) const = 0;
 
     /**
@@ -127,6 +127,7 @@ public:
      */
     virtual void drawTileSelection(QPainter *painter,
                                    const QRegion &region,
+								   const QRect &workSize,
                                    const QColor &color,
                                    const QRectF &exposed) const = 0;
 
@@ -134,6 +135,7 @@ public:
      * Draws the \a object in the given \a color using the \a painter.
      */
     virtual void drawMapObject(QPainter *painter,
+			                   const QRect &workSize,
                                const MapObject *object,
                                const QColor &color) const = 0;
 
@@ -141,62 +143,63 @@ public:
      * Draws the given image \a layer using the given \a painter.
      */
     void drawImageLayer(QPainter *painter,
+			            const QRect &workSize,
                         const ImageLayer *imageLayer,
                         const QRectF &exposed = QRectF());
 
     /**
      * Returns the tile coordinates matching the given pixel position.
      */
-    virtual QPointF pixelToTileCoords(qreal x, qreal y) const = 0;
+    virtual QPointF pixelToTileCoords(qreal x, qreal y, const QRect &workSize) const = 0;
 
-    inline QPointF pixelToTileCoords(const QPointF &point) const
-    { return pixelToTileCoords(point.x(), point.y()); }
+    inline QPointF pixelToTileCoords(const QPointF &point, const QRect &workSize) const
+    { return pixelToTileCoords(point.x(), point.y(), workSize); }
 
-    QPolygonF pixelToScreenCoords(const QPolygonF &polygon) const
+    QPolygonF pixelToScreenCoords(const QPolygonF &polygon, const QRect &workSize) const
     {
         QPolygonF screenPolygon(polygon.size());
         for (int i = polygon.size() - 1; i >= 0; --i)
-            screenPolygon[i] = pixelToScreenCoords(polygon[i]);
+            screenPolygon[i] = pixelToScreenCoords(polygon[i], workSize);
         return screenPolygon;
     }
 
     /**
      * Returns the pixel coordinates matching the given tile coordinates.
      */
-    virtual QPointF tileToPixelCoords(qreal x, qreal y) const = 0;
+    virtual QPointF tileToPixelCoords(qreal x, qreal y, const QRect &workSize) const = 0;
 
-    inline QPointF tileToPixelCoords(const QPointF &point) const
-    { return tileToPixelCoords(point.x(), point.y()); }
+    inline QPointF tileToPixelCoords(const QPointF &point, const QRect &workSize) const
+    { return tileToPixelCoords(point.x(), point.y(), workSize); }
 
-    inline QRectF tileToPixelCoords(const QRectF &area) const
+    inline QRectF tileToPixelCoords(const QRectF &area, const QRect &workSize) const
     {
-        return QRectF(tileToPixelCoords(area.topLeft()),
-                      tileToPixelCoords(area.bottomRight()));
+        return QRectF(tileToPixelCoords(area.topLeft(), workSize),
+                      tileToPixelCoords(area.bottomRight(), workSize));
     }
 
     /**
      * Returns the tile coordinates matching the given screen position.
      */
-    virtual QPointF screenToTileCoords(qreal x, qreal y) const = 0;
-    inline QPointF screenToTileCoords(const QPointF &point) const;
+    virtual QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSize) const = 0;
+    inline QPointF screenToTileCoords(const QPointF &point, const QRect &workSize) const;
 
     /**
      * Returns the screen position matching the given tile coordinates.
      */
-    virtual QPointF tileToScreenCoords(qreal x, qreal y) const = 0;
-    inline QPointF tileToScreenCoords(const QPointF &point) const;
+    virtual QPointF tileToScreenCoords(qreal x, qreal y, const QRect &workSize) const = 0;
+    inline QPointF tileToScreenCoords(const QPointF &point, const QRect &workSize) const;
 
     /**
      * Returns the pixel position matching the given screen position.
      */
-    virtual QPointF screenToPixelCoords(qreal x, qreal y) const = 0;
-    inline QPointF screenToPixelCoords(const QPointF &point) const;
+    virtual QPointF screenToPixelCoords(qreal x, qreal y, const QRect &workSize) const = 0;
+    inline QPointF screenToPixelCoords(const QPointF &point, const QRect &workSize) const;
 
     /**
      * Returns the screen position matching the given pixel position.
      */
-    virtual QPointF pixelToScreenCoords(qreal x, qreal y) const = 0;
-    inline QPointF pixelToScreenCoords(const QPointF &point) const;
+    virtual QPointF pixelToScreenCoords(qreal x, qreal y, const QRect &workSize) const = 0;
+    inline QPointF pixelToScreenCoords(const QPointF &point, const QRect &workSize) const;
 
     qreal objectLineWidth() const { return mObjectLineWidth; }
     void setObjectLineWidth(qreal lineWidth) { mObjectLineWidth = lineWidth; }
@@ -204,7 +207,6 @@ public:
     void setFlag(RenderFlag flag, bool enabled = true);
     bool testFlag(RenderFlag flag) const
     { return mFlags.testFlag(flag); }
-
     qreal painterScale() const { return mPainterScale; }
     void setPainterScale(qreal painterScale) { mPainterScale = painterScale; }
 
@@ -213,40 +215,40 @@ public:
 
     static QPolygonF lineToPolygon(const QPointF &start, const QPointF &end);
 
+    const Map *mMap;
+
 protected:
     QPen makeGridPen(const QPaintDevice *device, QColor color) const;
 
 private:
-    const Map *mMap;
-
     RenderFlags mFlags;
     qreal mObjectLineWidth;
     qreal mPainterScale;
 };
 
+inline QPointF MapRenderer::screenToTileCoords(const QPointF &point, const QRect &workSize) const
+{
+    return screenToTileCoords(point.x(), point.y(), workSize);
+}
+
+inline QPointF MapRenderer::tileToScreenCoords(const QPointF &point, const QRect &workSize) const
+{
+    return tileToScreenCoords(point.x(), point.y(), workSize);
+}
+
+inline QPointF MapRenderer::screenToPixelCoords(const QPointF &point, const QRect &workSize) const
+{
+    return screenToPixelCoords(point.x(), point.y(), workSize);
+}
+
+inline QPointF MapRenderer::pixelToScreenCoords(const QPointF &point, const QRect &workSize) const
+{
+    return pixelToScreenCoords(point.x(), point.y(), workSize);
+}
+
 inline const Map *MapRenderer::map() const
 {
-    return mMap;
-}
-
-inline QPointF MapRenderer::screenToTileCoords(const QPointF &point) const
-{
-    return screenToTileCoords(point.x(), point.y());
-}
-
-inline QPointF MapRenderer::tileToScreenCoords(const QPointF &point) const
-{
-    return tileToScreenCoords(point.x(), point.y());
-}
-
-inline QPointF MapRenderer::screenToPixelCoords(const QPointF &point) const
-{
-    return screenToPixelCoords(point.x(), point.y());
-}
-
-inline QPointF MapRenderer::pixelToScreenCoords(const QPointF &point) const
-{
-    return pixelToScreenCoords(point.x(), point.y());
+	return mMap;
 }
 
 

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -71,9 +71,9 @@ public:
     const Map *map() const;
 
     /**
-     * Returns the size in pixels of the map associated with this renderer.
+     * Returns the size in pixels of the current work space associated with this renderer.
      */
-    virtual QSize mapSize() const = 0;
+    virtual QSize workSize(const QRect &workSpace) const = 0;
 
     /**
      * Returns the bounding rectangle in pixels of the given \a rect given in

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -82,32 +82,32 @@ public:
      * This is useful for calculating the bounding rect of a tile layer or of
      * a region of tiles that was changed.
      */
-    virtual QRect boundingRect(const QRect &rect, const QRect &workSize) const = 0;
+    virtual QRect boundingRect(const QRect &rect, const QRect &workSpace) const = 0;
 
     /**
      * Returns the bounding rectangle in pixels of the given \a object, as it
      * would be drawn by drawMapObject().
      */
-    virtual QRectF boundingRect(const MapObject *object, const QRect &workSize) const = 0;
+    virtual QRectF boundingRect(const MapObject *object, const QRect &workSpace) const = 0;
 
     /**
      * Returns the bounding rectangle in pixels of the given \a imageLayer, as
      * it would be drawn by drawImageLayer().
      */
-    QRectF boundingRect(const ImageLayer *imageLayer, const QRect &workSize) const;
+    QRectF boundingRect(const ImageLayer *imageLayer, const QRect &workSpace) const;
 
     /**
      * Returns the shape in pixels of the given \a object. This is used for
      * mouse interaction and should match the rendered object as closely as
      * possible.
      */
-    virtual QPainterPath shape(const MapObject *object, const QRect &workSize) const = 0;
+    virtual QPainterPath shape(const MapObject *object, const QRect &workSpace) const = 0;
 
     /**
      * Draws the tile grid in the specified \a rect using the given
      * \a painter.
      */
-    virtual void drawGrid(QPainter *painter, const QRectF &rect, const QRect &workSize,
+    virtual void drawGrid(QPainter *painter, const QRectF &rect, const QRect &workSpace,
                           QColor gridColor = Qt::black) const = 0;
 
     /**
@@ -116,7 +116,7 @@ public:
      * Optionally, you can pass in the \a exposed rect (of pixels), so that
      * only tiles that can be visible in this area will be drawn.
      */
-    virtual void drawTileLayer(QPainter *painter, const TileLayer *layer, const QRect &workSize,
+    virtual void drawTileLayer(QPainter *painter, const TileLayer *layer, const QRect &workSpace,
                                const QRectF &exposed = QRectF()) const = 0;
 
     /**
@@ -127,7 +127,7 @@ public:
      */
     virtual void drawTileSelection(QPainter *painter,
                                    const QRegion &region,
-								   const QRect &workSize,
+								   const QRect &workSpace,
                                    const QColor &color,
                                    const QRectF &exposed) const = 0;
 
@@ -135,7 +135,7 @@ public:
      * Draws the \a object in the given \a color using the \a painter.
      */
     virtual void drawMapObject(QPainter *painter,
-			                   const QRect &workSize,
+			                   const QRect &workSpace,
                                const MapObject *object,
                                const QColor &color) const = 0;
 
@@ -143,63 +143,63 @@ public:
      * Draws the given image \a layer using the given \a painter.
      */
     void drawImageLayer(QPainter *painter,
-			            const QRect &workSize,
+			            const QRect &workSpace,
                         const ImageLayer *imageLayer,
                         const QRectF &exposed = QRectF());
 
     /**
      * Returns the tile coordinates matching the given pixel position.
      */
-    virtual QPointF pixelToTileCoords(qreal x, qreal y, const QRect &workSize) const = 0;
+    virtual QPointF pixelToTileCoords(qreal x, qreal y, const QRect &workSpace) const = 0;
 
-    inline QPointF pixelToTileCoords(const QPointF &point, const QRect &workSize) const
-    { return pixelToTileCoords(point.x(), point.y(), workSize); }
+    inline QPointF pixelToTileCoords(const QPointF &point, const QRect &workSpace) const
+    { return pixelToTileCoords(point.x(), point.y(), workSpace); }
 
-    QPolygonF pixelToScreenCoords(const QPolygonF &polygon, const QRect &workSize) const
+    QPolygonF pixelToScreenCoords(const QPolygonF &polygon, const QRect &workSpace) const
     {
         QPolygonF screenPolygon(polygon.size());
         for (int i = polygon.size() - 1; i >= 0; --i)
-            screenPolygon[i] = pixelToScreenCoords(polygon[i], workSize);
+            screenPolygon[i] = pixelToScreenCoords(polygon[i], workSpace);
         return screenPolygon;
     }
 
     /**
      * Returns the pixel coordinates matching the given tile coordinates.
      */
-    virtual QPointF tileToPixelCoords(qreal x, qreal y, const QRect &workSize) const = 0;
+    virtual QPointF tileToPixelCoords(qreal x, qreal y, const QRect &workSpace) const = 0;
 
-    inline QPointF tileToPixelCoords(const QPointF &point, const QRect &workSize) const
-    { return tileToPixelCoords(point.x(), point.y(), workSize); }
+    inline QPointF tileToPixelCoords(const QPointF &point, const QRect &workSpace) const
+    { return tileToPixelCoords(point.x(), point.y(), workSpace); }
 
-    inline QRectF tileToPixelCoords(const QRectF &area, const QRect &workSize) const
+    inline QRectF tileToPixelCoords(const QRectF &area, const QRect &workSpace) const
     {
-        return QRectF(tileToPixelCoords(area.topLeft(), workSize),
-                      tileToPixelCoords(area.bottomRight(), workSize));
+        return QRectF(tileToPixelCoords(area.topLeft(), workSpace),
+                      tileToPixelCoords(area.bottomRight(), workSpace));
     }
 
     /**
      * Returns the tile coordinates matching the given screen position.
      */
-    virtual QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSize) const = 0;
-    inline QPointF screenToTileCoords(const QPointF &point, const QRect &workSize) const;
+    virtual QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSpace) const = 0;
+    inline QPointF screenToTileCoords(const QPointF &point, const QRect &workSpace) const;
 
     /**
      * Returns the screen position matching the given tile coordinates.
      */
-    virtual QPointF tileToScreenCoords(qreal x, qreal y, const QRect &workSize) const = 0;
-    inline QPointF tileToScreenCoords(const QPointF &point, const QRect &workSize) const;
+    virtual QPointF tileToScreenCoords(qreal x, qreal y, const QRect &workSpace) const = 0;
+    inline QPointF tileToScreenCoords(const QPointF &point, const QRect &workSpace) const;
 
     /**
      * Returns the pixel position matching the given screen position.
      */
-    virtual QPointF screenToPixelCoords(qreal x, qreal y, const QRect &workSize) const = 0;
-    inline QPointF screenToPixelCoords(const QPointF &point, const QRect &workSize) const;
+    virtual QPointF screenToPixelCoords(qreal x, qreal y, const QRect &workSpace) const = 0;
+    inline QPointF screenToPixelCoords(const QPointF &point, const QRect &workSpace) const;
 
     /**
      * Returns the screen position matching the given pixel position.
      */
-    virtual QPointF pixelToScreenCoords(qreal x, qreal y, const QRect &workSize) const = 0;
-    inline QPointF pixelToScreenCoords(const QPointF &point, const QRect &workSize) const;
+    virtual QPointF pixelToScreenCoords(qreal x, qreal y, const QRect &workSpace) const = 0;
+    inline QPointF pixelToScreenCoords(const QPointF &point, const QRect &workSpace) const;
 
     qreal objectLineWidth() const { return mObjectLineWidth; }
     void setObjectLineWidth(qreal lineWidth) { mObjectLineWidth = lineWidth; }
@@ -226,24 +226,24 @@ private:
     qreal mPainterScale;
 };
 
-inline QPointF MapRenderer::screenToTileCoords(const QPointF &point, const QRect &workSize) const
+inline QPointF MapRenderer::screenToTileCoords(const QPointF &point, const QRect &workSpace) const
 {
-    return screenToTileCoords(point.x(), point.y(), workSize);
+    return screenToTileCoords(point.x(), point.y(), workSpace);
 }
 
-inline QPointF MapRenderer::tileToScreenCoords(const QPointF &point, const QRect &workSize) const
+inline QPointF MapRenderer::tileToScreenCoords(const QPointF &point, const QRect &workSpace) const
 {
-    return tileToScreenCoords(point.x(), point.y(), workSize);
+    return tileToScreenCoords(point.x(), point.y(), workSpace);
 }
 
-inline QPointF MapRenderer::screenToPixelCoords(const QPointF &point, const QRect &workSize) const
+inline QPointF MapRenderer::screenToPixelCoords(const QPointF &point, const QRect &workSpace) const
 {
-    return screenToPixelCoords(point.x(), point.y(), workSize);
+    return screenToPixelCoords(point.x(), point.y(), workSpace);
 }
 
-inline QPointF MapRenderer::pixelToScreenCoords(const QPointF &point, const QRect &workSize) const
+inline QPointF MapRenderer::pixelToScreenCoords(const QPointF &point, const QRect &workSpace) const
 {
-    return pixelToScreenCoords(point.x(), point.y(), workSize);
+    return pixelToScreenCoords(point.x(), point.y(), workSpace);
 }
 
 inline const Map *MapRenderer::map() const

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "tiled_global.h"
+#include "workspace.h"
 
 #include <QPainter>
 
@@ -73,7 +74,7 @@ public:
     /**
      * Returns the size in pixels of the current work space associated with this renderer.
      */
-    virtual QSize workSize(const QRect &workSpace) const = 0;
+    virtual QSize workSize(const WorkSpace &workSpace) const = 0;
 
     /**
      * Returns the bounding rectangle in pixels of the given \a rect given in
@@ -82,32 +83,32 @@ public:
      * This is useful for calculating the bounding rect of a tile layer or of
      * a region of tiles that was changed.
      */
-    virtual QRect boundingRect(const QRect &rect, const QRect &workSpace) const = 0;
+    virtual QRect boundingRect(const QRect &rect, const WorkSpace &workSpace) const = 0;
 
     /**
      * Returns the bounding rectangle in pixels of the given \a object, as it
      * would be drawn by drawMapObject().
      */
-    virtual QRectF boundingRect(const MapObject *object, const QRect &workSpace) const = 0;
+    virtual QRectF boundingRect(const MapObject *object, const WorkSpace &workSpace) const = 0;
 
     /**
      * Returns the bounding rectangle in pixels of the given \a imageLayer, as
      * it would be drawn by drawImageLayer().
      */
-    QRectF boundingRect(const ImageLayer *imageLayer, const QRect &workSpace) const;
+    QRectF boundingRect(const ImageLayer *imageLayer, const WorkSpace &workSpace) const;
 
     /**
      * Returns the shape in pixels of the given \a object. This is used for
      * mouse interaction and should match the rendered object as closely as
      * possible.
      */
-    virtual QPainterPath shape(const MapObject *object, const QRect &workSpace) const = 0;
+    virtual QPainterPath shape(const MapObject *object, const WorkSpace &workSpace) const = 0;
 
     /**
      * Draws the tile grid in the specified \a rect using the given
      * \a painter.
      */
-    virtual void drawGrid(QPainter *painter, const QRectF &rect, const QRect &workSpace,
+    virtual void drawGrid(QPainter *painter, const QRectF &rect, const WorkSpace &workSpace,
                           QColor gridColor = Qt::black) const = 0;
 
     /**
@@ -116,7 +117,7 @@ public:
      * Optionally, you can pass in the \a exposed rect (of pixels), so that
      * only tiles that can be visible in this area will be drawn.
      */
-    virtual void drawTileLayer(QPainter *painter, const TileLayer *layer, const QRect &workSpace,
+    virtual void drawTileLayer(QPainter *painter, const TileLayer *layer, const WorkSpace &workSpace,
                                const QRectF &exposed = QRectF()) const = 0;
 
     /**
@@ -127,7 +128,7 @@ public:
      */
     virtual void drawTileSelection(QPainter *painter,
                                    const QRegion &region,
-								   const QRect &workSpace,
+								   const WorkSpace &workSpace,
                                    const QColor &color,
                                    const QRectF &exposed) const = 0;
 
@@ -135,7 +136,7 @@ public:
      * Draws the \a object in the given \a color using the \a painter.
      */
     virtual void drawMapObject(QPainter *painter,
-			                   const QRect &workSpace,
+			                   const WorkSpace &workSpace,
                                const MapObject *object,
                                const QColor &color) const = 0;
 
@@ -143,19 +144,19 @@ public:
      * Draws the given image \a layer using the given \a painter.
      */
     void drawImageLayer(QPainter *painter,
-			            const QRect &workSpace,
+			            const WorkSpace &workSpace,
                         const ImageLayer *imageLayer,
                         const QRectF &exposed = QRectF());
 
     /**
      * Returns the tile coordinates matching the given pixel position.
      */
-    virtual QPointF pixelToTileCoords(qreal x, qreal y, const QRect &workSpace) const = 0;
+    virtual QPointF pixelToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const = 0;
 
-    inline QPointF pixelToTileCoords(const QPointF &point, const QRect &workSpace) const
+    inline QPointF pixelToTileCoords(const QPointF &point, const WorkSpace &workSpace) const
     { return pixelToTileCoords(point.x(), point.y(), workSpace); }
 
-    QPolygonF pixelToScreenCoords(const QPolygonF &polygon, const QRect &workSpace) const
+    QPolygonF pixelToScreenCoords(const QPolygonF &polygon, const WorkSpace &workSpace) const
     {
         QPolygonF screenPolygon(polygon.size());
         for (int i = polygon.size() - 1; i >= 0; --i)
@@ -166,12 +167,12 @@ public:
     /**
      * Returns the pixel coordinates matching the given tile coordinates.
      */
-    virtual QPointF tileToPixelCoords(qreal x, qreal y, const QRect &workSpace) const = 0;
+    virtual QPointF tileToPixelCoords(qreal x, qreal y, const WorkSpace &workSpace) const = 0;
 
-    inline QPointF tileToPixelCoords(const QPointF &point, const QRect &workSpace) const
+    inline QPointF tileToPixelCoords(const QPointF &point, const WorkSpace &workSpace) const
     { return tileToPixelCoords(point.x(), point.y(), workSpace); }
 
-    inline QRectF tileToPixelCoords(const QRectF &area, const QRect &workSpace) const
+    inline QRectF tileToPixelCoords(const QRectF &area, const WorkSpace &workSpace) const
     {
         return QRectF(tileToPixelCoords(area.topLeft(), workSpace),
                       tileToPixelCoords(area.bottomRight(), workSpace));
@@ -180,26 +181,26 @@ public:
     /**
      * Returns the tile coordinates matching the given screen position.
      */
-    virtual QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSpace) const = 0;
-    inline QPointF screenToTileCoords(const QPointF &point, const QRect &workSpace) const;
+    virtual QPointF screenToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const = 0;
+    inline QPointF screenToTileCoords(const QPointF &point, const WorkSpace &workSpace) const;
 
     /**
      * Returns the screen position matching the given tile coordinates.
      */
-    virtual QPointF tileToScreenCoords(qreal x, qreal y, const QRect &workSpace) const = 0;
-    inline QPointF tileToScreenCoords(const QPointF &point, const QRect &workSpace) const;
+    virtual QPointF tileToScreenCoords(qreal x, qreal y, const WorkSpace &workSpace) const = 0;
+    inline QPointF tileToScreenCoords(const QPointF &point, const WorkSpace &workSpace) const;
 
     /**
      * Returns the pixel position matching the given screen position.
      */
-    virtual QPointF screenToPixelCoords(qreal x, qreal y, const QRect &workSpace) const = 0;
-    inline QPointF screenToPixelCoords(const QPointF &point, const QRect &workSpace) const;
+    virtual QPointF screenToPixelCoords(qreal x, qreal y, const WorkSpace &workSpace) const = 0;
+    inline QPointF screenToPixelCoords(const QPointF &point, const WorkSpace &workSpace) const;
 
     /**
      * Returns the screen position matching the given pixel position.
      */
-    virtual QPointF pixelToScreenCoords(qreal x, qreal y, const QRect &workSpace) const = 0;
-    inline QPointF pixelToScreenCoords(const QPointF &point, const QRect &workSpace) const;
+    virtual QPointF pixelToScreenCoords(qreal x, qreal y, const WorkSpace &workSpace) const = 0;
+    inline QPointF pixelToScreenCoords(const QPointF &point, const WorkSpace &workSpace) const;
 
     qreal objectLineWidth() const { return mObjectLineWidth; }
     void setObjectLineWidth(qreal lineWidth) { mObjectLineWidth = lineWidth; }
@@ -226,22 +227,22 @@ private:
     qreal mPainterScale;
 };
 
-inline QPointF MapRenderer::screenToTileCoords(const QPointF &point, const QRect &workSpace) const
+inline QPointF MapRenderer::screenToTileCoords(const QPointF &point, const WorkSpace &workSpace) const
 {
     return screenToTileCoords(point.x(), point.y(), workSpace);
 }
 
-inline QPointF MapRenderer::tileToScreenCoords(const QPointF &point, const QRect &workSpace) const
+inline QPointF MapRenderer::tileToScreenCoords(const QPointF &point, const WorkSpace &workSpace) const
 {
     return tileToScreenCoords(point.x(), point.y(), workSpace);
 }
 
-inline QPointF MapRenderer::screenToPixelCoords(const QPointF &point, const QRect &workSpace) const
+inline QPointF MapRenderer::screenToPixelCoords(const QPointF &point, const WorkSpace &workSpace) const
 {
     return screenToPixelCoords(point.x(), point.y(), workSpace);
 }
 
-inline QPointF MapRenderer::pixelToScreenCoords(const QPointF &point, const QRect &workSpace) const
+inline QPointF MapRenderer::pixelToScreenCoords(const QPointF &point, const WorkSpace &workSpace) const
 {
     return pixelToScreenCoords(point.x(), point.y(), workSpace);
 }

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -541,6 +541,11 @@ void MapWriterPrivate::writeLayerAttributes(QXmlStreamWriter &w,
                          QString::number(tileLayer.width()));
         w.writeAttribute(QLatin1String("height"),
                          QString::number(tileLayer.height()));
+
+		w.writeAttribute(QLatin1String("tilewidth"),
+						 QString::number(tileLayer.tileWidth()));
+		w.writeAttribute(QLatin1String("tileheight"),
+						 QString::number(tileLayer.tileHeight()));
     }
 
     if (!layer.isVisible())

--- a/src/libtiled/moc_predefs.h
+++ b/src/libtiled/moc_predefs.h
@@ -1,0 +1,357 @@
+#define OBJC_NEW_PROPERTIES 1
+#define _LP64 1
+#define __APPLE_CC__ 6000
+#define __APPLE__ 1
+#define __ATOMIC_ACQUIRE 2
+#define __ATOMIC_ACQ_REL 4
+#define __ATOMIC_CONSUME 1
+#define __ATOMIC_RELAXED 0
+#define __ATOMIC_RELEASE 3
+#define __ATOMIC_SEQ_CST 5
+#define __BIGGEST_ALIGNMENT__ 16
+#define __BLOCKS__ 1
+#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __CHAR16_TYPE__ unsigned short
+#define __CHAR32_TYPE__ unsigned int
+#define __CHAR_BIT__ 8
+#define __CONSTANT_CFSTRINGS__ 1
+#define __DBL_DECIMAL_DIG__ 17
+#define __DBL_DENORM_MIN__ 4.9406564584124654e-324
+#define __DBL_DIG__ 15
+#define __DBL_EPSILON__ 2.2204460492503131e-16
+#define __DBL_HAS_DENORM__ 1
+#define __DBL_HAS_INFINITY__ 1
+#define __DBL_HAS_QUIET_NAN__ 1
+#define __DBL_MANT_DIG__ 53
+#define __DBL_MAX_10_EXP__ 308
+#define __DBL_MAX_EXP__ 1024
+#define __DBL_MAX__ 1.7976931348623157e+308
+#define __DBL_MIN_10_EXP__ (-307)
+#define __DBL_MIN_EXP__ (-1021)
+#define __DBL_MIN__ 2.2250738585072014e-308
+#define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
+#define __DEPRECATED 1
+#define __DYNAMIC__ 1
+#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101000
+#define __EXCEPTIONS 1
+#define __FINITE_MATH_ONLY__ 0
+#define __FLT_DECIMAL_DIG__ 9
+#define __FLT_DENORM_MIN__ 1.40129846e-45F
+#define __FLT_DIG__ 6
+#define __FLT_EPSILON__ 1.19209290e-7F
+#define __FLT_EVAL_METHOD__ 0
+#define __FLT_HAS_DENORM__ 1
+#define __FLT_HAS_INFINITY__ 1
+#define __FLT_HAS_QUIET_NAN__ 1
+#define __FLT_MANT_DIG__ 24
+#define __FLT_MAX_10_EXP__ 38
+#define __FLT_MAX_EXP__ 128
+#define __FLT_MAX__ 3.40282347e+38F
+#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT_MIN_EXP__ (-125)
+#define __FLT_MIN__ 1.17549435e-38F
+#define __FLT_RADIX__ 2
+#define __FXSR__ 1
+#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+#define __GCC_ATOMIC_INT_LOCK_FREE 2
+#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
+#define __GLIBCXX_BITSIZE_INT_N_0 128
+#define __GLIBCXX_TYPE_INT_N_0 __int128
+#define __GNUC_GNU_INLINE__ 1
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 1
+#define __GNUC__ 4
+#define __GNUG__ 4
+#define __GXX_ABI_VERSION 1002
+#define __GXX_EXPERIMENTAL_CXX0X__ 1
+#define __GXX_RTTI 1
+#define __GXX_WEAK__ 1
+#define __INT16_C_SUFFIX__ 
+#define __INT16_FMTd__ "hd"
+#define __INT16_FMTi__ "hi"
+#define __INT16_MAX__ 32767
+#define __INT16_TYPE__ short
+#define __INT32_C_SUFFIX__ 
+#define __INT32_FMTd__ "d"
+#define __INT32_FMTi__ "i"
+#define __INT32_MAX__ 2147483647
+#define __INT32_TYPE__ int
+#define __INT64_C_SUFFIX__ LL
+#define __INT64_FMTd__ "lld"
+#define __INT64_FMTi__ "lli"
+#define __INT64_MAX__ 9223372036854775807LL
+#define __INT64_TYPE__ long long int
+#define __INT8_C_SUFFIX__ 
+#define __INT8_FMTd__ "hhd"
+#define __INT8_FMTi__ "hhi"
+#define __INT8_MAX__ 127
+#define __INT8_TYPE__ signed char
+#define __INTMAX_C_SUFFIX__ L
+#define __INTMAX_FMTd__ "ld"
+#define __INTMAX_FMTi__ "li"
+#define __INTMAX_MAX__ 9223372036854775807L
+#define __INTMAX_TYPE__ long int
+#define __INTMAX_WIDTH__ 64
+#define __INTPTR_FMTd__ "ld"
+#define __INTPTR_FMTi__ "li"
+#define __INTPTR_MAX__ 9223372036854775807L
+#define __INTPTR_TYPE__ long int
+#define __INTPTR_WIDTH__ 64
+#define __INT_FAST16_FMTd__ "hd"
+#define __INT_FAST16_FMTi__ "hi"
+#define __INT_FAST16_MAX__ 32767
+#define __INT_FAST16_TYPE__ short
+#define __INT_FAST32_FMTd__ "d"
+#define __INT_FAST32_FMTi__ "i"
+#define __INT_FAST32_MAX__ 2147483647
+#define __INT_FAST32_TYPE__ int
+#define __INT_FAST64_FMTd__ "ld"
+#define __INT_FAST64_FMTi__ "li"
+#define __INT_FAST64_MAX__ 9223372036854775807L
+#define __INT_FAST64_TYPE__ long int
+#define __INT_FAST8_FMTd__ "hhd"
+#define __INT_FAST8_FMTi__ "hhi"
+#define __INT_FAST8_MAX__ 127
+#define __INT_FAST8_TYPE__ signed char
+#define __INT_LEAST16_FMTd__ "hd"
+#define __INT_LEAST16_FMTi__ "hi"
+#define __INT_LEAST16_MAX__ 32767
+#define __INT_LEAST16_TYPE__ short
+#define __INT_LEAST32_FMTd__ "d"
+#define __INT_LEAST32_FMTi__ "i"
+#define __INT_LEAST32_MAX__ 2147483647
+#define __INT_LEAST32_TYPE__ int
+#define __INT_LEAST64_FMTd__ "ld"
+#define __INT_LEAST64_FMTi__ "li"
+#define __INT_LEAST64_MAX__ 9223372036854775807L
+#define __INT_LEAST64_TYPE__ long int
+#define __INT_LEAST8_FMTd__ "hhd"
+#define __INT_LEAST8_FMTi__ "hhi"
+#define __INT_LEAST8_MAX__ 127
+#define __INT_LEAST8_TYPE__ signed char
+#define __INT_MAX__ 2147483647
+#define __LDBL_DECIMAL_DIG__ 21
+#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+#define __LDBL_DIG__ 18
+#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
+#define __LDBL_HAS_DENORM__ 1
+#define __LDBL_HAS_INFINITY__ 1
+#define __LDBL_HAS_QUIET_NAN__ 1
+#define __LDBL_MANT_DIG__ 64
+#define __LDBL_MAX_10_EXP__ 4932
+#define __LDBL_MAX_EXP__ 16384
+#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+#define __LDBL_MIN_10_EXP__ (-4931)
+#define __LDBL_MIN_EXP__ (-16381)
+#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+#define __LITTLE_ENDIAN__ 1
+#define __LONG_LONG_MAX__ 9223372036854775807LL
+#define __LONG_MAX__ 9223372036854775807L
+#define __LP64__ 1
+#define __MACH__ 1
+#define __MMX__ 1
+#define __NO_MATH_INLINES 1
+#define __OBJC_BOOL_IS_BOOL 0
+#define __OPTIMIZE__ 1
+#define __ORDER_BIG_ENDIAN__ 4321
+#define __ORDER_LITTLE_ENDIAN__ 1234
+#define __ORDER_PDP_ENDIAN__ 3412
+#define __PIC__ 2
+#define __POINTER_WIDTH__ 64
+#define __PRAGMA_REDEFINE_EXTNAME 1
+#define __PTRDIFF_FMTd__ "ld"
+#define __PTRDIFF_FMTi__ "li"
+#define __PTRDIFF_MAX__ 9223372036854775807L
+#define __PTRDIFF_TYPE__ long int
+#define __PTRDIFF_WIDTH__ 64
+#define __REGISTER_PREFIX__ 
+#define __SCHAR_MAX__ 127
+#define __SHRT_MAX__ 32767
+#define __SIG_ATOMIC_MAX__ 2147483647
+#define __SIG_ATOMIC_WIDTH__ 32
+#define __SIZEOF_DOUBLE__ 8
+#define __SIZEOF_FLOAT__ 4
+#define __SIZEOF_INT128__ 16
+#define __SIZEOF_INT__ 4
+#define __SIZEOF_LONG_DOUBLE__ 16
+#define __SIZEOF_LONG_LONG__ 8
+#define __SIZEOF_LONG__ 8
+#define __SIZEOF_POINTER__ 8
+#define __SIZEOF_PTRDIFF_T__ 8
+#define __SIZEOF_SHORT__ 2
+#define __SIZEOF_SIZE_T__ 8
+#define __SIZEOF_WCHAR_T__ 4
+#define __SIZEOF_WINT_T__ 4
+#define __SIZE_FMTX__ "lX"
+#define __SIZE_FMTo__ "lo"
+#define __SIZE_FMTu__ "lu"
+#define __SIZE_FMTx__ "lx"
+#define __SIZE_MAX__ 18446744073709551615UL
+#define __SIZE_TYPE__ long unsigned int
+#define __SIZE_WIDTH__ 64
+#define __SSE2_MATH__ 1
+#define __SSE2__ 1
+#define __SSE3__ 1
+#define __SSE_MATH__ 1
+#define __SSE__ 1
+#define __SSP__ 1
+#define __SSSE3__ 1
+#define __STDC_HOSTED__ 1
+#define __STDC_UTF_16__ 1
+#define __STDC_UTF_32__ 1
+#define __STDC__ 1
+#define __UINT16_C_SUFFIX__ 
+#define __UINT16_FMTX__ "hX"
+#define __UINT16_FMTo__ "ho"
+#define __UINT16_FMTu__ "hu"
+#define __UINT16_FMTx__ "hx"
+#define __UINT16_MAX__ 65535
+#define __UINT16_TYPE__ unsigned short
+#define __UINT32_C_SUFFIX__ U
+#define __UINT32_FMTX__ "X"
+#define __UINT32_FMTo__ "o"
+#define __UINT32_FMTu__ "u"
+#define __UINT32_FMTx__ "x"
+#define __UINT32_MAX__ 4294967295U
+#define __UINT32_TYPE__ unsigned int
+#define __UINT64_C_SUFFIX__ ULL
+#define __UINT64_FMTX__ "llX"
+#define __UINT64_FMTo__ "llo"
+#define __UINT64_FMTu__ "llu"
+#define __UINT64_FMTx__ "llx"
+#define __UINT64_MAX__ 18446744073709551615ULL
+#define __UINT64_TYPE__ long long unsigned int
+#define __UINT8_C_SUFFIX__ 
+#define __UINT8_FMTX__ "hhX"
+#define __UINT8_FMTo__ "hho"
+#define __UINT8_FMTu__ "hhu"
+#define __UINT8_FMTx__ "hhx"
+#define __UINT8_MAX__ 255
+#define __UINT8_TYPE__ unsigned char
+#define __UINTMAX_C_SUFFIX__ UL
+#define __UINTMAX_FMTX__ "lX"
+#define __UINTMAX_FMTo__ "lo"
+#define __UINTMAX_FMTu__ "lu"
+#define __UINTMAX_FMTx__ "lx"
+#define __UINTMAX_MAX__ 18446744073709551615UL
+#define __UINTMAX_TYPE__ long unsigned int
+#define __UINTMAX_WIDTH__ 64
+#define __UINTPTR_FMTX__ "lX"
+#define __UINTPTR_FMTo__ "lo"
+#define __UINTPTR_FMTu__ "lu"
+#define __UINTPTR_FMTx__ "lx"
+#define __UINTPTR_MAX__ 18446744073709551615UL
+#define __UINTPTR_TYPE__ long unsigned int
+#define __UINTPTR_WIDTH__ 64
+#define __UINT_FAST16_FMTX__ "hX"
+#define __UINT_FAST16_FMTo__ "ho"
+#define __UINT_FAST16_FMTu__ "hu"
+#define __UINT_FAST16_FMTx__ "hx"
+#define __UINT_FAST16_MAX__ 65535
+#define __UINT_FAST16_TYPE__ unsigned short
+#define __UINT_FAST32_FMTX__ "X"
+#define __UINT_FAST32_FMTo__ "o"
+#define __UINT_FAST32_FMTu__ "u"
+#define __UINT_FAST32_FMTx__ "x"
+#define __UINT_FAST32_MAX__ 4294967295U
+#define __UINT_FAST32_TYPE__ unsigned int
+#define __UINT_FAST64_FMTX__ "lX"
+#define __UINT_FAST64_FMTo__ "lo"
+#define __UINT_FAST64_FMTu__ "lu"
+#define __UINT_FAST64_FMTx__ "lx"
+#define __UINT_FAST64_MAX__ 18446744073709551615UL
+#define __UINT_FAST64_TYPE__ long unsigned int
+#define __UINT_FAST8_FMTX__ "hhX"
+#define __UINT_FAST8_FMTo__ "hho"
+#define __UINT_FAST8_FMTu__ "hhu"
+#define __UINT_FAST8_FMTx__ "hhx"
+#define __UINT_FAST8_MAX__ 255
+#define __UINT_FAST8_TYPE__ unsigned char
+#define __UINT_LEAST16_FMTX__ "hX"
+#define __UINT_LEAST16_FMTo__ "ho"
+#define __UINT_LEAST16_FMTu__ "hu"
+#define __UINT_LEAST16_FMTx__ "hx"
+#define __UINT_LEAST16_MAX__ 65535
+#define __UINT_LEAST16_TYPE__ unsigned short
+#define __UINT_LEAST32_FMTX__ "X"
+#define __UINT_LEAST32_FMTo__ "o"
+#define __UINT_LEAST32_FMTu__ "u"
+#define __UINT_LEAST32_FMTx__ "x"
+#define __UINT_LEAST32_MAX__ 4294967295U
+#define __UINT_LEAST32_TYPE__ unsigned int
+#define __UINT_LEAST64_FMTX__ "lX"
+#define __UINT_LEAST64_FMTo__ "lo"
+#define __UINT_LEAST64_FMTu__ "lu"
+#define __UINT_LEAST64_FMTx__ "lx"
+#define __UINT_LEAST64_MAX__ 18446744073709551615UL
+#define __UINT_LEAST64_TYPE__ long unsigned int
+#define __UINT_LEAST8_FMTX__ "hhX"
+#define __UINT_LEAST8_FMTo__ "hho"
+#define __UINT_LEAST8_FMTu__ "hhu"
+#define __UINT_LEAST8_FMTx__ "hhx"
+#define __UINT_LEAST8_MAX__ 255
+#define __UINT_LEAST8_TYPE__ unsigned char
+#define __USER_LABEL_PREFIX__ _
+#define __VERSION__ "4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)"
+#define __WCHAR_MAX__ 2147483647
+#define __WCHAR_TYPE__ int
+#define __WCHAR_WIDTH__ 32
+#define __WINT_TYPE__ int
+#define __WINT_WIDTH__ 32
+#define __amd64 1
+#define __amd64__ 1
+#define __apple_build_version__ 8020042
+#define __block __attribute__((__blocks__(byref)))
+#define __clang__ 1
+#define __clang_major__ 8
+#define __clang_minor__ 1
+#define __clang_patchlevel__ 0
+#define __clang_version__ "8.1.0 (clang-802.0.42)"
+#define __core2 1
+#define __core2__ 1
+#define __cplusplus 201103L
+#define __cpp_alias_templates 200704
+#define __cpp_attributes 200809
+#define __cpp_constexpr 200704
+#define __cpp_decltype 200707
+#define __cpp_delegating_constructors 200604
+#define __cpp_exceptions 199711
+#define __cpp_inheriting_constructors 200802
+#define __cpp_initializer_lists 200806
+#define __cpp_lambdas 200907
+#define __cpp_nsdmi 200809
+#define __cpp_range_based_for 200907
+#define __cpp_raw_strings 200710
+#define __cpp_ref_qualifiers 200710
+#define __cpp_rtti 199711
+#define __cpp_rvalue_references 200610
+#define __cpp_static_assert 200410
+#define __cpp_unicode_characters 200704
+#define __cpp_unicode_literals 200710
+#define __cpp_user_defined_literals 200809
+#define __cpp_variadic_templates 200704
+#define __llvm__ 1
+#define __nonnull _Nonnull
+#define __null_unspecified _Null_unspecified
+#define __nullable _Nullable
+#define __pic__ 2
+#define __private_extern__ extern
+#define __strong 
+#define __tune_core2__ 1
+#define __unsafe_unretained 
+#define __weak __attribute__((objc_gc(weak)))
+#define __x86_64 1
+#define __x86_64__ 1

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -38,7 +38,7 @@
 
 using namespace Tiled;
 
-QSize OrthogonalRenderer::mapSize() const
+QSize OrthogonalRenderer::workSize(const QRect &workSpace) const
 {
     return QSize(map()->width() * map()->tileWidth(),
                  map()->height() * map()->tileHeight());

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -40,14 +40,14 @@ using namespace Tiled;
 
 QSize OrthogonalRenderer::workSize(const WorkSpace &workSpace) const
 {
-    return QSize(map()->width() * map()->tileWidth(),
-                 map()->height() * map()->tileHeight());
+    return QSize(workSpace.width() * workSpace.tileWidth(),
+                 workSpace.height() * workSpace.tileHeight());
 }
 
 QRect OrthogonalRenderer::boundingRect(const QRect &rect, const WorkSpace &workSpace) const
 {
-    const int tileWidth = map()->tileWidth();
-    const int tileHeight = map()->tileHeight();
+    const int tileWidth = workSpace.tileWidth();
+    const int tileHeight = workSpace.tileHeight();
 
     return QRect(rect.x() * tileWidth,
                  rect.y() * tileHeight,
@@ -182,8 +182,8 @@ QPainterPath OrthogonalRenderer::shape(const MapObject *object, const WorkSpace 
 void OrthogonalRenderer::drawGrid(QPainter *painter, const QRectF &rect, const WorkSpace &workSpace,
                                   QColor gridColor) const
 {
-    const int tileWidth = map()->tileWidth();
-    const int tileHeight = map()->tileHeight();
+    const int tileWidth = workSpace.tileWidth();
+    const int tileHeight = workSpace.tileHeight();
 
     if (tileWidth <= 0 || tileHeight <= 0)
         return;
@@ -191,9 +191,9 @@ void OrthogonalRenderer::drawGrid(QPainter *painter, const QRectF &rect, const W
     const int startX = qMax(0, (int) (rect.x() / tileWidth) * tileWidth);
     const int startY = qMax(0, (int) (rect.y() / tileHeight) * tileHeight);
     const int endX = qMin(qCeil(rect.right()),
-                          map()->width() * tileWidth + 1);
+                          workSpace.width() * tileWidth + 1);
     const int endY = qMin(qCeil(rect.bottom()),
-                          map()->height() * tileHeight + 1);
+                          workSpace.height() * tileHeight + 1);
 
     QPen gridPen = makeGridPen(painter->device(), gridColor);
 
@@ -218,8 +218,8 @@ void OrthogonalRenderer::drawTileLayer(QPainter *painter,
                                        const QRectF &exposed) const
 {
 
-    const int tileWidth = map()->tileWidth();
-    const int tileHeight = map()->tileHeight();
+    const int tileWidth = workSpace.tileWidth();
+    const int tileHeight = workSpace.tileHeight();
     if (tileWidth <= 0 || tileHeight <= 0)
         return;
 
@@ -291,7 +291,7 @@ void OrthogonalRenderer::drawTileLayer(QPainter *painter,
                 continue;
 
             Tile *tile = cell.tile();
-            QSize size = tile ? tile->size() : map()->tileSize();
+            QSize size = tile ? tile->size() : workSpace.tileSize();
             renderer.render(cell,
                             QPointF(x * tileWidth, (y + 1) * tileHeight),
                             size,
@@ -469,26 +469,26 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
 
 QPointF OrthogonalRenderer::pixelToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
-    return QPointF(x / map()->tileWidth(),
-                   y / map()->tileHeight());
+    return QPointF(x / workSpace.tileWidth(),
+                   y / workSpace.tileHeight());
 }
 
 QPointF OrthogonalRenderer::tileToPixelCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
-    return QPointF(x * map()->tileWidth(),
-                   y * map()->tileHeight());
+    return QPointF(x * workSpace.tileWidth(),
+                   y * workSpace.tileHeight());
 }
 
 QPointF OrthogonalRenderer::screenToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
-    return QPointF(x / map()->tileWidth(),
-                   y / map()->tileHeight());
+    return QPointF(x / workSpace.tileWidth(),
+                   y / workSpace.tileHeight());
 }
 
 QPointF OrthogonalRenderer::tileToScreenCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
-    return QPointF(x * map()->tileWidth(),
-                   y * map()->tileHeight());
+    return QPointF(x * workSpace.tileWidth(),
+                   y * workSpace.tileHeight());
 }
 
 QPointF OrthogonalRenderer::screenToPixelCoords(qreal x, qreal y, const WorkSpace &workSpace) const

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -38,13 +38,13 @@
 
 using namespace Tiled;
 
-QSize OrthogonalRenderer::workSize(const QRect &workSpace) const
+QSize OrthogonalRenderer::workSize(const WorkSpace &workSpace) const
 {
     return QSize(map()->width() * map()->tileWidth(),
                  map()->height() * map()->tileHeight());
 }
 
-QRect OrthogonalRenderer::boundingRect(const QRect &rect, const QRect &workSpace) const
+QRect OrthogonalRenderer::boundingRect(const QRect &rect, const WorkSpace &workSpace) const
 {
     const int tileWidth = map()->tileWidth();
     const int tileHeight = map()->tileHeight();
@@ -55,7 +55,7 @@ QRect OrthogonalRenderer::boundingRect(const QRect &rect, const QRect &workSpace
                  rect.height() * tileHeight);
 }
 
-QRectF OrthogonalRenderer::boundingRect(const MapObject *object, const QRect &workSpace) const
+QRectF OrthogonalRenderer::boundingRect(const MapObject *object, const WorkSpace &workSpace) const
 {
     const QRectF bounds = object->bounds();
 
@@ -124,7 +124,7 @@ QRectF OrthogonalRenderer::boundingRect(const MapObject *object, const QRect &wo
     return boundingRect;
 }
 
-QPainterPath OrthogonalRenderer::shape(const MapObject *object, const QRect &workSpace) const
+QPainterPath OrthogonalRenderer::shape(const MapObject *object, const WorkSpace &workSpace) const
 {
     QPainterPath path;
 
@@ -179,7 +179,7 @@ QPainterPath OrthogonalRenderer::shape(const MapObject *object, const QRect &wor
     return path;
 }
 
-void OrthogonalRenderer::drawGrid(QPainter *painter, const QRectF &rect, const QRect &workSpace,
+void OrthogonalRenderer::drawGrid(QPainter *painter, const QRectF &rect, const WorkSpace &workSpace,
                                   QColor gridColor) const
 {
     const int tileWidth = map()->tileWidth();
@@ -214,7 +214,7 @@ void OrthogonalRenderer::drawGrid(QPainter *painter, const QRectF &rect, const Q
 
 void OrthogonalRenderer::drawTileLayer(QPainter *painter,
                                        const TileLayer *layer,
-									   const QRect &workSpace,
+									   const WorkSpace &workSpace,
                                        const QRectF &exposed) const
 {
 
@@ -306,7 +306,7 @@ void OrthogonalRenderer::drawTileLayer(QPainter *painter,
 
 void OrthogonalRenderer::drawTileSelection(QPainter *painter,
                                            const QRegion &region,
-										   const QRect &workSpace,
+										   const WorkSpace &workSpace,
                                            const QColor &color,
                                            const QRectF &exposed) const
 {
@@ -318,7 +318,7 @@ void OrthogonalRenderer::drawTileSelection(QPainter *painter,
 }
 
 void OrthogonalRenderer::drawMapObject(QPainter *painter,
-		                               const QRect &workSpace,
+		                               const WorkSpace &workSpace,
                                        const MapObject *object,
                                        const QColor &color) const
 {
@@ -467,36 +467,36 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
     painter->restore();
 }
 
-QPointF OrthogonalRenderer::pixelToTileCoords(qreal x, qreal y, const QRect &workSpace) const
+QPointF OrthogonalRenderer::pixelToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
     return QPointF(x / map()->tileWidth(),
                    y / map()->tileHeight());
 }
 
-QPointF OrthogonalRenderer::tileToPixelCoords(qreal x, qreal y, const QRect &workSpace) const
+QPointF OrthogonalRenderer::tileToPixelCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
     return QPointF(x * map()->tileWidth(),
                    y * map()->tileHeight());
 }
 
-QPointF OrthogonalRenderer::screenToTileCoords(qreal x, qreal y, const QRect &workSpace) const
+QPointF OrthogonalRenderer::screenToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
     return QPointF(x / map()->tileWidth(),
                    y / map()->tileHeight());
 }
 
-QPointF OrthogonalRenderer::tileToScreenCoords(qreal x, qreal y, const QRect &workSpace) const
+QPointF OrthogonalRenderer::tileToScreenCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
     return QPointF(x * map()->tileWidth(),
                    y * map()->tileHeight());
 }
 
-QPointF OrthogonalRenderer::screenToPixelCoords(qreal x, qreal y, const QRect &workSpace) const
+QPointF OrthogonalRenderer::screenToPixelCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
     return QPointF(x, y);
 }
 
-QPointF OrthogonalRenderer::pixelToScreenCoords(qreal x, qreal y, const QRect &workSpace) const
+QPointF OrthogonalRenderer::pixelToScreenCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
     return QPointF(x, y);
 }

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -44,7 +44,7 @@ QSize OrthogonalRenderer::mapSize() const
                  map()->height() * map()->tileHeight());
 }
 
-QRect OrthogonalRenderer::boundingRect(const QRect &rect) const
+QRect OrthogonalRenderer::boundingRect(const QRect &rect, const QRect &workSize) const
 {
     const int tileWidth = map()->tileWidth();
     const int tileHeight = map()->tileHeight();
@@ -55,7 +55,7 @@ QRect OrthogonalRenderer::boundingRect(const QRect &rect) const
                  rect.height() * tileHeight);
 }
 
-QRectF OrthogonalRenderer::boundingRect(const MapObject *object) const
+QRectF OrthogonalRenderer::boundingRect(const MapObject *object, const QRect &workSize) const
 {
     const QRectF bounds = object->bounds();
 
@@ -107,7 +107,7 @@ QRectF OrthogonalRenderer::boundingRect(const MapObject *object) const
 
             const QPointF &pos = object->position();
             const QPolygonF polygon = object->polygon().translated(pos);
-            QPolygonF screenPolygon = pixelToScreenCoords(polygon);
+            QPolygonF screenPolygon = pixelToScreenCoords(polygon, workSize);
             boundingRect = screenPolygon.boundingRect().adjusted(-extraSpace,
                                                                  -extraSpace,
                                                                  extraSpace + 1,
@@ -124,12 +124,12 @@ QRectF OrthogonalRenderer::boundingRect(const MapObject *object) const
     return boundingRect;
 }
 
-QPainterPath OrthogonalRenderer::shape(const MapObject *object) const
+QPainterPath OrthogonalRenderer::shape(const MapObject *object, const QRect &workSize) const
 {
     QPainterPath path;
 
     if (!object->cell().isEmpty()) {
-        path.addRect(boundingRect(object));
+        path.addRect(boundingRect(object, workSize));
     } else {
         switch (object->shape()) {
         case MapObject::Rectangle: {
@@ -146,7 +146,7 @@ QPainterPath OrthogonalRenderer::shape(const MapObject *object) const
         case MapObject::Polyline: {
             const QPointF &pos = object->position();
             const QPolygonF polygon = object->polygon().translated(pos);
-            const QPolygonF screenPolygon = pixelToScreenCoords(polygon);
+            const QPolygonF screenPolygon = pixelToScreenCoords(polygon, workSize);
             if (object->shape() == MapObject::Polygon) {
                 path.addPolygon(screenPolygon);
             } else {
@@ -179,7 +179,7 @@ QPainterPath OrthogonalRenderer::shape(const MapObject *object) const
     return path;
 }
 
-void OrthogonalRenderer::drawGrid(QPainter *painter, const QRectF &rect,
+void OrthogonalRenderer::drawGrid(QPainter *painter, const QRectF &rect, const QRect &workSize,
                                   QColor gridColor) const
 {
     const int tileWidth = map()->tileWidth();
@@ -214,6 +214,7 @@ void OrthogonalRenderer::drawGrid(QPainter *painter, const QRectF &rect,
 
 void OrthogonalRenderer::drawTileLayer(QPainter *painter,
                                        const TileLayer *layer,
+									   const QRect &workSize,
                                        const QRectF &exposed) const
 {
 
@@ -305,17 +306,19 @@ void OrthogonalRenderer::drawTileLayer(QPainter *painter,
 
 void OrthogonalRenderer::drawTileSelection(QPainter *painter,
                                            const QRegion &region,
+										   const QRect &workSize,
                                            const QColor &color,
                                            const QRectF &exposed) const
 {
     foreach (const QRect &r, region.rects()) {
-        const QRectF toFill = QRectF(boundingRect(r)).intersected(exposed);
+        const QRectF toFill = QRectF(boundingRect(r, workSize)).intersected(exposed);
         if (!toFill.isEmpty())
             painter->fillRect(toFill, color);
     }
 }
 
 void OrthogonalRenderer::drawMapObject(QPainter *painter,
+		                               const QRect &workSize,
                                        const MapObject *object,
                                        const QColor &color) const
 {
@@ -396,7 +399,7 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
         }
 
         case MapObject::Polyline: {
-            QPolygonF screenPolygon = pixelToScreenCoords(object->polygon());
+            QPolygonF screenPolygon = pixelToScreenCoords(object->polygon(), workSize);
 
             QPen thickShadowPen(shadowPen);
             QPen thickLinePen(linePen);
@@ -417,7 +420,7 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
         }
 
         case MapObject::Polygon: {
-            QPolygonF screenPolygon = pixelToScreenCoords(object->polygon());
+            QPolygonF screenPolygon = pixelToScreenCoords(object->polygon(), workSize);
 
             QPen thickShadowPen(shadowPen);
             QPen thickLinePen(linePen);
@@ -464,36 +467,36 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
     painter->restore();
 }
 
-QPointF OrthogonalRenderer::pixelToTileCoords(qreal x, qreal y) const
+QPointF OrthogonalRenderer::pixelToTileCoords(qreal x, qreal y, const QRect &workSize) const
 {
     return QPointF(x / map()->tileWidth(),
                    y / map()->tileHeight());
 }
 
-QPointF OrthogonalRenderer::tileToPixelCoords(qreal x, qreal y) const
+QPointF OrthogonalRenderer::tileToPixelCoords(qreal x, qreal y, const QRect &workSize) const
 {
     return QPointF(x * map()->tileWidth(),
                    y * map()->tileHeight());
 }
 
-QPointF OrthogonalRenderer::screenToTileCoords(qreal x, qreal y) const
+QPointF OrthogonalRenderer::screenToTileCoords(qreal x, qreal y, const QRect &workSize) const
 {
     return QPointF(x / map()->tileWidth(),
                    y / map()->tileHeight());
 }
 
-QPointF OrthogonalRenderer::tileToScreenCoords(qreal x, qreal y) const
+QPointF OrthogonalRenderer::tileToScreenCoords(qreal x, qreal y, const QRect &workSize) const
 {
     return QPointF(x * map()->tileWidth(),
                    y * map()->tileHeight());
 }
 
-QPointF OrthogonalRenderer::screenToPixelCoords(qreal x, qreal y) const
+QPointF OrthogonalRenderer::screenToPixelCoords(qreal x, qreal y, const QRect &workSize) const
 {
     return QPointF(x, y);
 }
 
-QPointF OrthogonalRenderer::pixelToScreenCoords(qreal x, qreal y) const
+QPointF OrthogonalRenderer::pixelToScreenCoords(qreal x, qreal y, const QRect &workSize) const
 {
     return QPointF(x, y);
 }

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -44,7 +44,7 @@ QSize OrthogonalRenderer::mapSize() const
                  map()->height() * map()->tileHeight());
 }
 
-QRect OrthogonalRenderer::boundingRect(const QRect &rect, const QRect &workSize) const
+QRect OrthogonalRenderer::boundingRect(const QRect &rect, const QRect &workSpace) const
 {
     const int tileWidth = map()->tileWidth();
     const int tileHeight = map()->tileHeight();
@@ -55,7 +55,7 @@ QRect OrthogonalRenderer::boundingRect(const QRect &rect, const QRect &workSize)
                  rect.height() * tileHeight);
 }
 
-QRectF OrthogonalRenderer::boundingRect(const MapObject *object, const QRect &workSize) const
+QRectF OrthogonalRenderer::boundingRect(const MapObject *object, const QRect &workSpace) const
 {
     const QRectF bounds = object->bounds();
 
@@ -107,7 +107,7 @@ QRectF OrthogonalRenderer::boundingRect(const MapObject *object, const QRect &wo
 
             const QPointF &pos = object->position();
             const QPolygonF polygon = object->polygon().translated(pos);
-            QPolygonF screenPolygon = pixelToScreenCoords(polygon, workSize);
+            QPolygonF screenPolygon = pixelToScreenCoords(polygon, workSpace);
             boundingRect = screenPolygon.boundingRect().adjusted(-extraSpace,
                                                                  -extraSpace,
                                                                  extraSpace + 1,
@@ -124,12 +124,12 @@ QRectF OrthogonalRenderer::boundingRect(const MapObject *object, const QRect &wo
     return boundingRect;
 }
 
-QPainterPath OrthogonalRenderer::shape(const MapObject *object, const QRect &workSize) const
+QPainterPath OrthogonalRenderer::shape(const MapObject *object, const QRect &workSpace) const
 {
     QPainterPath path;
 
     if (!object->cell().isEmpty()) {
-        path.addRect(boundingRect(object, workSize));
+        path.addRect(boundingRect(object, workSpace));
     } else {
         switch (object->shape()) {
         case MapObject::Rectangle: {
@@ -146,7 +146,7 @@ QPainterPath OrthogonalRenderer::shape(const MapObject *object, const QRect &wor
         case MapObject::Polyline: {
             const QPointF &pos = object->position();
             const QPolygonF polygon = object->polygon().translated(pos);
-            const QPolygonF screenPolygon = pixelToScreenCoords(polygon, workSize);
+            const QPolygonF screenPolygon = pixelToScreenCoords(polygon, workSpace);
             if (object->shape() == MapObject::Polygon) {
                 path.addPolygon(screenPolygon);
             } else {
@@ -179,7 +179,7 @@ QPainterPath OrthogonalRenderer::shape(const MapObject *object, const QRect &wor
     return path;
 }
 
-void OrthogonalRenderer::drawGrid(QPainter *painter, const QRectF &rect, const QRect &workSize,
+void OrthogonalRenderer::drawGrid(QPainter *painter, const QRectF &rect, const QRect &workSpace,
                                   QColor gridColor) const
 {
     const int tileWidth = map()->tileWidth();
@@ -214,7 +214,7 @@ void OrthogonalRenderer::drawGrid(QPainter *painter, const QRectF &rect, const Q
 
 void OrthogonalRenderer::drawTileLayer(QPainter *painter,
                                        const TileLayer *layer,
-									   const QRect &workSize,
+									   const QRect &workSpace,
                                        const QRectF &exposed) const
 {
 
@@ -306,19 +306,19 @@ void OrthogonalRenderer::drawTileLayer(QPainter *painter,
 
 void OrthogonalRenderer::drawTileSelection(QPainter *painter,
                                            const QRegion &region,
-										   const QRect &workSize,
+										   const QRect &workSpace,
                                            const QColor &color,
                                            const QRectF &exposed) const
 {
     foreach (const QRect &r, region.rects()) {
-        const QRectF toFill = QRectF(boundingRect(r, workSize)).intersected(exposed);
+        const QRectF toFill = QRectF(boundingRect(r, workSpace)).intersected(exposed);
         if (!toFill.isEmpty())
             painter->fillRect(toFill, color);
     }
 }
 
 void OrthogonalRenderer::drawMapObject(QPainter *painter,
-		                               const QRect &workSize,
+		                               const QRect &workSpace,
                                        const MapObject *object,
                                        const QColor &color) const
 {
@@ -399,7 +399,7 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
         }
 
         case MapObject::Polyline: {
-            QPolygonF screenPolygon = pixelToScreenCoords(object->polygon(), workSize);
+            QPolygonF screenPolygon = pixelToScreenCoords(object->polygon(), workSpace);
 
             QPen thickShadowPen(shadowPen);
             QPen thickLinePen(linePen);
@@ -420,7 +420,7 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
         }
 
         case MapObject::Polygon: {
-            QPolygonF screenPolygon = pixelToScreenCoords(object->polygon(), workSize);
+            QPolygonF screenPolygon = pixelToScreenCoords(object->polygon(), workSpace);
 
             QPen thickShadowPen(shadowPen);
             QPen thickLinePen(linePen);
@@ -467,36 +467,36 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
     painter->restore();
 }
 
-QPointF OrthogonalRenderer::pixelToTileCoords(qreal x, qreal y, const QRect &workSize) const
+QPointF OrthogonalRenderer::pixelToTileCoords(qreal x, qreal y, const QRect &workSpace) const
 {
     return QPointF(x / map()->tileWidth(),
                    y / map()->tileHeight());
 }
 
-QPointF OrthogonalRenderer::tileToPixelCoords(qreal x, qreal y, const QRect &workSize) const
+QPointF OrthogonalRenderer::tileToPixelCoords(qreal x, qreal y, const QRect &workSpace) const
 {
     return QPointF(x * map()->tileWidth(),
                    y * map()->tileHeight());
 }
 
-QPointF OrthogonalRenderer::screenToTileCoords(qreal x, qreal y, const QRect &workSize) const
+QPointF OrthogonalRenderer::screenToTileCoords(qreal x, qreal y, const QRect &workSpace) const
 {
     return QPointF(x / map()->tileWidth(),
                    y / map()->tileHeight());
 }
 
-QPointF OrthogonalRenderer::tileToScreenCoords(qreal x, qreal y, const QRect &workSize) const
+QPointF OrthogonalRenderer::tileToScreenCoords(qreal x, qreal y, const QRect &workSpace) const
 {
     return QPointF(x * map()->tileWidth(),
                    y * map()->tileHeight());
 }
 
-QPointF OrthogonalRenderer::screenToPixelCoords(qreal x, qreal y, const QRect &workSize) const
+QPointF OrthogonalRenderer::screenToPixelCoords(qreal x, qreal y, const QRect &workSpace) const
 {
     return QPointF(x, y);
 }
 
-QPointF OrthogonalRenderer::pixelToScreenCoords(qreal x, qreal y, const QRect &workSize) const
+QPointF OrthogonalRenderer::pixelToScreenCoords(qreal x, qreal y, const QRect &workSpace) const
 {
     return QPointF(x, y);
 }

--- a/src/libtiled/orthogonalrenderer.h
+++ b/src/libtiled/orthogonalrenderer.h
@@ -43,43 +43,45 @@ public:
 
     QSize mapSize() const override;
 
-    QRect boundingRect(const QRect &rect) const override;
+    QRect boundingRect(const QRect &rect, const QRect &workSize) const override;
 
-    QRectF boundingRect(const MapObject *object) const override;
-    QPainterPath shape(const MapObject *object) const override;
+    QRectF boundingRect(const MapObject *object, const QRect &workSize) const override;
+    QPainterPath shape(const MapObject *object, const QRect &workSize) const override;
 
-    void drawGrid(QPainter *painter, const QRectF &rect,
+    void drawGrid(QPainter *painter, const QRectF &rect, const QRect &workSize,
                   QColor gridColor) const override;
 
-    void drawTileLayer(QPainter *painter, const TileLayer *layer,
+    void drawTileLayer(QPainter *painter, const TileLayer *layer, const QRect &workSize,
                        const QRectF &exposed = QRectF()) const override;
 
     void drawTileSelection(QPainter *painter,
                            const QRegion &region,
+						   const QRect &workSize,
                            const QColor &color,
                            const QRectF &exposed) const override;
 
     void drawMapObject(QPainter *painter,
+			           const QRect &workSize,
                        const MapObject *object,
                        const QColor &color) const override;
 
     using MapRenderer::pixelToTileCoords;
-    QPointF pixelToTileCoords(qreal x, qreal y) const override;
+    QPointF pixelToTileCoords(qreal x, qreal y, const QRect &workSize) const override;
 
     using MapRenderer::tileToPixelCoords;
-    QPointF tileToPixelCoords(qreal x, qreal y) const override;
+    QPointF tileToPixelCoords(qreal x, qreal y, const QRect &workSize) const override;
 
     using MapRenderer::screenToTileCoords;
-    QPointF screenToTileCoords(qreal x, qreal y) const override;
+    QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSize) const override;
 
     using MapRenderer::tileToScreenCoords;
-    QPointF tileToScreenCoords(qreal x, qreal y) const override;
+    QPointF tileToScreenCoords(qreal x, qreal y, const QRect &workSize) const override;
 
     using MapRenderer::screenToPixelCoords;
-    QPointF screenToPixelCoords(qreal x, qreal y) const override;
+    QPointF screenToPixelCoords(qreal x, qreal y, const QRect &workSize) const override;
 
     using MapRenderer::pixelToScreenCoords;
-    QPointF pixelToScreenCoords(qreal x, qreal y) const override;
+    QPointF pixelToScreenCoords(qreal x, qreal y, const QRect &workSize) const override;
 };
 
 } // namespace Tiled

--- a/src/libtiled/orthogonalrenderer.h
+++ b/src/libtiled/orthogonalrenderer.h
@@ -43,45 +43,45 @@ public:
 
     QSize mapSize() const override;
 
-    QRect boundingRect(const QRect &rect, const QRect &workSize) const override;
+    QRect boundingRect(const QRect &rect, const QRect &workSpace) const override;
 
-    QRectF boundingRect(const MapObject *object, const QRect &workSize) const override;
-    QPainterPath shape(const MapObject *object, const QRect &workSize) const override;
+    QRectF boundingRect(const MapObject *object, const QRect &workSpace) const override;
+    QPainterPath shape(const MapObject *object, const QRect &workSpace) const override;
 
-    void drawGrid(QPainter *painter, const QRectF &rect, const QRect &workSize,
+    void drawGrid(QPainter *painter, const QRectF &rect, const QRect &workSpace,
                   QColor gridColor) const override;
 
-    void drawTileLayer(QPainter *painter, const TileLayer *layer, const QRect &workSize,
+    void drawTileLayer(QPainter *painter, const TileLayer *layer, const QRect &workSpace,
                        const QRectF &exposed = QRectF()) const override;
 
     void drawTileSelection(QPainter *painter,
                            const QRegion &region,
-						   const QRect &workSize,
+						   const QRect &workSpace,
                            const QColor &color,
                            const QRectF &exposed) const override;
 
     void drawMapObject(QPainter *painter,
-			           const QRect &workSize,
+			           const QRect &workSpace,
                        const MapObject *object,
                        const QColor &color) const override;
 
     using MapRenderer::pixelToTileCoords;
-    QPointF pixelToTileCoords(qreal x, qreal y, const QRect &workSize) const override;
+    QPointF pixelToTileCoords(qreal x, qreal y, const QRect &workSpace) const override;
 
     using MapRenderer::tileToPixelCoords;
-    QPointF tileToPixelCoords(qreal x, qreal y, const QRect &workSize) const override;
+    QPointF tileToPixelCoords(qreal x, qreal y, const QRect &workSpace) const override;
 
     using MapRenderer::screenToTileCoords;
-    QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSize) const override;
+    QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSpace) const override;
 
     using MapRenderer::tileToScreenCoords;
-    QPointF tileToScreenCoords(qreal x, qreal y, const QRect &workSize) const override;
+    QPointF tileToScreenCoords(qreal x, qreal y, const QRect &workSpace) const override;
 
     using MapRenderer::screenToPixelCoords;
-    QPointF screenToPixelCoords(qreal x, qreal y, const QRect &workSize) const override;
+    QPointF screenToPixelCoords(qreal x, qreal y, const QRect &workSpace) const override;
 
     using MapRenderer::pixelToScreenCoords;
-    QPointF pixelToScreenCoords(qreal x, qreal y, const QRect &workSize) const override;
+    QPointF pixelToScreenCoords(qreal x, qreal y, const QRect &workSpace) const override;
 };
 
 } // namespace Tiled

--- a/src/libtiled/orthogonalrenderer.h
+++ b/src/libtiled/orthogonalrenderer.h
@@ -41,7 +41,7 @@ class TILEDSHARED_EXPORT OrthogonalRenderer : public MapRenderer
 public:
     OrthogonalRenderer(const Map *map) : MapRenderer(map) {}
 
-    QSize mapSize() const override;
+    QSize workSize(const QRect &workSpace) const override;
 
     QRect boundingRect(const QRect &rect, const QRect &workSpace) const override;
 

--- a/src/libtiled/orthogonalrenderer.h
+++ b/src/libtiled/orthogonalrenderer.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "maprenderer.h"
+#include "workspace.h"
 
 namespace Tiled {
 
@@ -41,47 +42,47 @@ class TILEDSHARED_EXPORT OrthogonalRenderer : public MapRenderer
 public:
     OrthogonalRenderer(const Map *map) : MapRenderer(map) {}
 
-    QSize workSize(const QRect &workSpace) const override;
+    QSize workSize(const WorkSpace &workSpace) const override;
 
-    QRect boundingRect(const QRect &rect, const QRect &workSpace) const override;
+    QRect boundingRect(const QRect &rect, const WorkSpace &workSpace) const override;
 
-    QRectF boundingRect(const MapObject *object, const QRect &workSpace) const override;
-    QPainterPath shape(const MapObject *object, const QRect &workSpace) const override;
+    QRectF boundingRect(const MapObject *object, const WorkSpace &workSpace) const override;
+    QPainterPath shape(const MapObject *object, const WorkSpace &workSpace) const override;
 
-    void drawGrid(QPainter *painter, const QRectF &rect, const QRect &workSpace,
+    void drawGrid(QPainter *painter, const QRectF &rect, const WorkSpace &workSpace,
                   QColor gridColor) const override;
 
-    void drawTileLayer(QPainter *painter, const TileLayer *layer, const QRect &workSpace,
+    void drawTileLayer(QPainter *painter, const TileLayer *layer, const WorkSpace &workSpace,
                        const QRectF &exposed = QRectF()) const override;
 
     void drawTileSelection(QPainter *painter,
                            const QRegion &region,
-						   const QRect &workSpace,
+						   const WorkSpace &workSpace,
                            const QColor &color,
                            const QRectF &exposed) const override;
 
     void drawMapObject(QPainter *painter,
-			           const QRect &workSpace,
+			           const WorkSpace &workSpace,
                        const MapObject *object,
                        const QColor &color) const override;
 
     using MapRenderer::pixelToTileCoords;
-    QPointF pixelToTileCoords(qreal x, qreal y, const QRect &workSpace) const override;
+    QPointF pixelToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const override;
 
     using MapRenderer::tileToPixelCoords;
-    QPointF tileToPixelCoords(qreal x, qreal y, const QRect &workSpace) const override;
+    QPointF tileToPixelCoords(qreal x, qreal y, const WorkSpace &workSpace) const override;
 
     using MapRenderer::screenToTileCoords;
-    QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSpace) const override;
+    QPointF screenToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const override;
 
     using MapRenderer::tileToScreenCoords;
-    QPointF tileToScreenCoords(qreal x, qreal y, const QRect &workSpace) const override;
+    QPointF tileToScreenCoords(qreal x, qreal y, const WorkSpace &workSpace) const override;
 
     using MapRenderer::screenToPixelCoords;
-    QPointF screenToPixelCoords(qreal x, qreal y, const QRect &workSpace) const override;
+    QPointF screenToPixelCoords(qreal x, qreal y, const WorkSpace &workSpace) const override;
 
     using MapRenderer::pixelToScreenCoords;
-    QPointF pixelToScreenCoords(qreal x, qreal y, const QRect &workSpace) const override;
+    QPointF pixelToScreenCoords(qreal x, qreal y, const WorkSpace &workSpace) const override;
 };
 
 } // namespace Tiled

--- a/src/libtiled/staggeredrenderer.cpp
+++ b/src/libtiled/staggeredrenderer.cpp
@@ -39,9 +39,9 @@ using namespace Tiled;
  * This override exists because the method used by the HexagonalRenderer
  * does not produce nice results for isometric shapes in the tile corners.
  */
-QPointF StaggeredRenderer::screenToTileCoords(qreal x, qreal y) const
+QPointF StaggeredRenderer::screenToTileCoords(qreal x, qreal y, const QRect &workSize) const
 {
-    const RenderParams p(map());
+    const RenderParams p(map(), workSize);
 
     if (p.staggerX)
         x -= p.staggerEven ? p.sideOffsetX : 0;

--- a/src/libtiled/staggeredrenderer.cpp
+++ b/src/libtiled/staggeredrenderer.cpp
@@ -39,9 +39,9 @@ using namespace Tiled;
  * This override exists because the method used by the HexagonalRenderer
  * does not produce nice results for isometric shapes in the tile corners.
  */
-QPointF StaggeredRenderer::screenToTileCoords(qreal x, qreal y, const QRect &workSize) const
+QPointF StaggeredRenderer::screenToTileCoords(qreal x, qreal y, const QRect &workSpace) const
 {
-    const RenderParams p(map(), workSize);
+    const RenderParams p(map(), workSpace);
 
     if (p.staggerX)
         x -= p.staggerEven ? p.sideOffsetX : 0;

--- a/src/libtiled/staggeredrenderer.cpp
+++ b/src/libtiled/staggeredrenderer.cpp
@@ -39,7 +39,7 @@ using namespace Tiled;
  * This override exists because the method used by the HexagonalRenderer
  * does not produce nice results for isometric shapes in the tile corners.
  */
-QPointF StaggeredRenderer::screenToTileCoords(qreal x, qreal y, const QRect &workSpace) const
+QPointF StaggeredRenderer::screenToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const
 {
     const RenderParams p(map(), workSpace);
 

--- a/src/libtiled/staggeredrenderer.h
+++ b/src/libtiled/staggeredrenderer.h
@@ -78,7 +78,7 @@ public:
     StaggeredRenderer(const Map *map) : HexagonalRenderer(map) {}
 
     using HexagonalRenderer::screenToTileCoords;
-    QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSize) const override;
+    QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSpace) const override;
 };
 
 } // namespace Tiled

--- a/src/libtiled/staggeredrenderer.h
+++ b/src/libtiled/staggeredrenderer.h
@@ -78,7 +78,7 @@ public:
     StaggeredRenderer(const Map *map) : HexagonalRenderer(map) {}
 
     using HexagonalRenderer::screenToTileCoords;
-    QPointF screenToTileCoords(qreal x, qreal y) const override;
+    QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSize) const override;
 };
 
 } // namespace Tiled

--- a/src/libtiled/staggeredrenderer.h
+++ b/src/libtiled/staggeredrenderer.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "hexagonalrenderer.h"
+#include "workspace.h"
 
 namespace Tiled {
 
@@ -78,7 +79,7 @@ public:
     StaggeredRenderer(const Map *map) : HexagonalRenderer(map) {}
 
     using HexagonalRenderer::screenToTileCoords;
-    QPointF screenToTileCoords(qreal x, qreal y, const QRect &workSpace) const override;
+    QPointF screenToTileCoords(qreal x, qreal y, const WorkSpace &workSpace) const override;
 };
 
 } // namespace Tiled

--- a/src/libtiled/tilelayer.h
+++ b/src/libtiled/tilelayer.h
@@ -320,7 +320,14 @@ public:
     /**
      * Constructor.
      */
-    TileLayer(const QString &name, int x, int y, int width, int height);
+    TileLayer(
+			const QString &name,
+			int x,
+			int y,
+			int width,
+			int height,
+			int tileWidth,
+			int tileHeight);
 
     /**
      * Returns the width of this layer.
@@ -332,12 +339,24 @@ public:
      */
     int height() const { return mHeight; }
 
+	/**
+	 * Return the tile width of this layer
+	 */
+	int tileWidth() const { return mTileWidth; }
+
+	/**
+	 * Return the tile height of this layer
+	 */
+	int tileHeight() const { return mTileHeight; }
+
     /**
      * Returns the size of this layer.
      */
     QSize size() const { return QSize(mWidth, mHeight); }
 
     void setSize(const QSize &size);
+
+	void setTileSize(const QSize &size);
 
     /**
      * Returns the bounds of this layer.
@@ -504,6 +523,8 @@ protected:
 private:
     int mWidth;
     int mHeight;
+	int mTileWidth;
+	int mTileHeight;
     Cell mEmptyCell;
     QHash<QPoint, Chunk> mChunks;
     mutable QSet<SharedTileset> mUsedTilesets;
@@ -559,6 +580,15 @@ inline void TileLayer::setSize(const QSize &size)
 {
     mWidth = size.width();
     mHeight = size.height();
+}
+
+/**
+ * Sets the tile size of this layer.
+ */
+inline void TileLayer::setTileSize(const QSize &size)
+{
+    mTileWidth = size.width();
+    mTileHeight = size.height();
 }
 
 /**

--- a/src/libtiled/tilelayer.h
+++ b/src/libtiled/tilelayer.h
@@ -354,6 +354,11 @@ public:
      */
     QSize size() const { return QSize(mWidth, mHeight); }
 
+    /**
+     * Returns the size of this layer.
+     */
+    QSize tileSize() const { return QSize(mTileWidth, mTileHeight); }
+
     void setSize(const QSize &size);
 
 	void setTileSize(const QSize &size);

--- a/src/libtiled/varianttomapconverter.cpp
+++ b/src/libtiled/varianttomapconverter.cpp
@@ -346,11 +346,12 @@ TileLayer *VariantToMapConverter::toTileLayer(const QVariantMap &variantMap)
     const int height = variantMap[QLatin1String("height")].toInt();
     const QVariant dataVariant = variantMap[QLatin1String("data")];
 
+	// LUCA TODO: Don't know where the tile sizes are found here
     typedef QScopedPointer<TileLayer> TileLayerPtr;
     TileLayerPtr tileLayer(new TileLayer(name,
                                          variantMap[QLatin1String("x")].toInt(),
                                          variantMap[QLatin1String("y")].toInt(),
-                                         width, height));
+                                         width, height, 0, 0));
 
     const qreal opacity = variantMap[QLatin1String("opacity")].toReal();
     const bool visible = variantMap[QLatin1String("visible")].toBool();

--- a/src/libtiled/workspace.h
+++ b/src/libtiled/workspace.h
@@ -5,7 +5,6 @@
 #include "tilelayer.h"
 
 namespace Tiled {
-namespace Internal {
 
 class WorkSpace
 {
@@ -17,11 +16,27 @@ public:
 		, mTileHeight(tileHeight)
 	{}
 
+	WorkSpace()
+		: mWidth(0)
+		, mHeight(0)
+		, mTileWidth(0)
+		, mTileHeight(0)
+	{}
+
 	 int width() const { return mWidth; }
 	 int height() const { return mHeight; }
 	 int tileWidth() const { return mTileWidth; }
 	 int tileHeight() const { return mTileHeight; }
-}
 
-}
+	 void setWidth(const int width) { mWidth = width; }
+	 void setHeight(const int height) { mHeight = height; }
+	 void setTileWidth(const int tileWidth) { mTileWidth = tileWidth; }
+	 void setTileHeight(const int tileHeight) { mTileHeight = tileHeight; }
+private:
+	  int mWidth;
+	  int mHeight;
+	  int mTileWidth;
+	  int mTileHeight;
+};
+
 }

--- a/src/libtiled/workspace.h
+++ b/src/libtiled/workspace.h
@@ -27,6 +27,7 @@ public:
 	 int height() const { return mHeight; }
 	 int tileWidth() const { return mTileWidth; }
 	 int tileHeight() const { return mTileHeight; }
+	 QSize tileSize() const { return QSize(mWidth, mHeight); }
 
 	 void setWidth(const int width) { mWidth = width; }
 	 void setHeight(const int height) { mHeight = height; }

--- a/src/plugins/csv/moc_predefs.h
+++ b/src/plugins/csv/moc_predefs.h
@@ -1,0 +1,357 @@
+#define OBJC_NEW_PROPERTIES 1
+#define _LP64 1
+#define __APPLE_CC__ 6000
+#define __APPLE__ 1
+#define __ATOMIC_ACQUIRE 2
+#define __ATOMIC_ACQ_REL 4
+#define __ATOMIC_CONSUME 1
+#define __ATOMIC_RELAXED 0
+#define __ATOMIC_RELEASE 3
+#define __ATOMIC_SEQ_CST 5
+#define __BIGGEST_ALIGNMENT__ 16
+#define __BLOCKS__ 1
+#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __CHAR16_TYPE__ unsigned short
+#define __CHAR32_TYPE__ unsigned int
+#define __CHAR_BIT__ 8
+#define __CONSTANT_CFSTRINGS__ 1
+#define __DBL_DECIMAL_DIG__ 17
+#define __DBL_DENORM_MIN__ 4.9406564584124654e-324
+#define __DBL_DIG__ 15
+#define __DBL_EPSILON__ 2.2204460492503131e-16
+#define __DBL_HAS_DENORM__ 1
+#define __DBL_HAS_INFINITY__ 1
+#define __DBL_HAS_QUIET_NAN__ 1
+#define __DBL_MANT_DIG__ 53
+#define __DBL_MAX_10_EXP__ 308
+#define __DBL_MAX_EXP__ 1024
+#define __DBL_MAX__ 1.7976931348623157e+308
+#define __DBL_MIN_10_EXP__ (-307)
+#define __DBL_MIN_EXP__ (-1021)
+#define __DBL_MIN__ 2.2250738585072014e-308
+#define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
+#define __DEPRECATED 1
+#define __DYNAMIC__ 1
+#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101000
+#define __EXCEPTIONS 1
+#define __FINITE_MATH_ONLY__ 0
+#define __FLT_DECIMAL_DIG__ 9
+#define __FLT_DENORM_MIN__ 1.40129846e-45F
+#define __FLT_DIG__ 6
+#define __FLT_EPSILON__ 1.19209290e-7F
+#define __FLT_EVAL_METHOD__ 0
+#define __FLT_HAS_DENORM__ 1
+#define __FLT_HAS_INFINITY__ 1
+#define __FLT_HAS_QUIET_NAN__ 1
+#define __FLT_MANT_DIG__ 24
+#define __FLT_MAX_10_EXP__ 38
+#define __FLT_MAX_EXP__ 128
+#define __FLT_MAX__ 3.40282347e+38F
+#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT_MIN_EXP__ (-125)
+#define __FLT_MIN__ 1.17549435e-38F
+#define __FLT_RADIX__ 2
+#define __FXSR__ 1
+#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+#define __GCC_ATOMIC_INT_LOCK_FREE 2
+#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
+#define __GLIBCXX_BITSIZE_INT_N_0 128
+#define __GLIBCXX_TYPE_INT_N_0 __int128
+#define __GNUC_GNU_INLINE__ 1
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 1
+#define __GNUC__ 4
+#define __GNUG__ 4
+#define __GXX_ABI_VERSION 1002
+#define __GXX_EXPERIMENTAL_CXX0X__ 1
+#define __GXX_RTTI 1
+#define __GXX_WEAK__ 1
+#define __INT16_C_SUFFIX__ 
+#define __INT16_FMTd__ "hd"
+#define __INT16_FMTi__ "hi"
+#define __INT16_MAX__ 32767
+#define __INT16_TYPE__ short
+#define __INT32_C_SUFFIX__ 
+#define __INT32_FMTd__ "d"
+#define __INT32_FMTi__ "i"
+#define __INT32_MAX__ 2147483647
+#define __INT32_TYPE__ int
+#define __INT64_C_SUFFIX__ LL
+#define __INT64_FMTd__ "lld"
+#define __INT64_FMTi__ "lli"
+#define __INT64_MAX__ 9223372036854775807LL
+#define __INT64_TYPE__ long long int
+#define __INT8_C_SUFFIX__ 
+#define __INT8_FMTd__ "hhd"
+#define __INT8_FMTi__ "hhi"
+#define __INT8_MAX__ 127
+#define __INT8_TYPE__ signed char
+#define __INTMAX_C_SUFFIX__ L
+#define __INTMAX_FMTd__ "ld"
+#define __INTMAX_FMTi__ "li"
+#define __INTMAX_MAX__ 9223372036854775807L
+#define __INTMAX_TYPE__ long int
+#define __INTMAX_WIDTH__ 64
+#define __INTPTR_FMTd__ "ld"
+#define __INTPTR_FMTi__ "li"
+#define __INTPTR_MAX__ 9223372036854775807L
+#define __INTPTR_TYPE__ long int
+#define __INTPTR_WIDTH__ 64
+#define __INT_FAST16_FMTd__ "hd"
+#define __INT_FAST16_FMTi__ "hi"
+#define __INT_FAST16_MAX__ 32767
+#define __INT_FAST16_TYPE__ short
+#define __INT_FAST32_FMTd__ "d"
+#define __INT_FAST32_FMTi__ "i"
+#define __INT_FAST32_MAX__ 2147483647
+#define __INT_FAST32_TYPE__ int
+#define __INT_FAST64_FMTd__ "ld"
+#define __INT_FAST64_FMTi__ "li"
+#define __INT_FAST64_MAX__ 9223372036854775807L
+#define __INT_FAST64_TYPE__ long int
+#define __INT_FAST8_FMTd__ "hhd"
+#define __INT_FAST8_FMTi__ "hhi"
+#define __INT_FAST8_MAX__ 127
+#define __INT_FAST8_TYPE__ signed char
+#define __INT_LEAST16_FMTd__ "hd"
+#define __INT_LEAST16_FMTi__ "hi"
+#define __INT_LEAST16_MAX__ 32767
+#define __INT_LEAST16_TYPE__ short
+#define __INT_LEAST32_FMTd__ "d"
+#define __INT_LEAST32_FMTi__ "i"
+#define __INT_LEAST32_MAX__ 2147483647
+#define __INT_LEAST32_TYPE__ int
+#define __INT_LEAST64_FMTd__ "ld"
+#define __INT_LEAST64_FMTi__ "li"
+#define __INT_LEAST64_MAX__ 9223372036854775807L
+#define __INT_LEAST64_TYPE__ long int
+#define __INT_LEAST8_FMTd__ "hhd"
+#define __INT_LEAST8_FMTi__ "hhi"
+#define __INT_LEAST8_MAX__ 127
+#define __INT_LEAST8_TYPE__ signed char
+#define __INT_MAX__ 2147483647
+#define __LDBL_DECIMAL_DIG__ 21
+#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+#define __LDBL_DIG__ 18
+#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
+#define __LDBL_HAS_DENORM__ 1
+#define __LDBL_HAS_INFINITY__ 1
+#define __LDBL_HAS_QUIET_NAN__ 1
+#define __LDBL_MANT_DIG__ 64
+#define __LDBL_MAX_10_EXP__ 4932
+#define __LDBL_MAX_EXP__ 16384
+#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+#define __LDBL_MIN_10_EXP__ (-4931)
+#define __LDBL_MIN_EXP__ (-16381)
+#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+#define __LITTLE_ENDIAN__ 1
+#define __LONG_LONG_MAX__ 9223372036854775807LL
+#define __LONG_MAX__ 9223372036854775807L
+#define __LP64__ 1
+#define __MACH__ 1
+#define __MMX__ 1
+#define __NO_MATH_INLINES 1
+#define __OBJC_BOOL_IS_BOOL 0
+#define __OPTIMIZE__ 1
+#define __ORDER_BIG_ENDIAN__ 4321
+#define __ORDER_LITTLE_ENDIAN__ 1234
+#define __ORDER_PDP_ENDIAN__ 3412
+#define __PIC__ 2
+#define __POINTER_WIDTH__ 64
+#define __PRAGMA_REDEFINE_EXTNAME 1
+#define __PTRDIFF_FMTd__ "ld"
+#define __PTRDIFF_FMTi__ "li"
+#define __PTRDIFF_MAX__ 9223372036854775807L
+#define __PTRDIFF_TYPE__ long int
+#define __PTRDIFF_WIDTH__ 64
+#define __REGISTER_PREFIX__ 
+#define __SCHAR_MAX__ 127
+#define __SHRT_MAX__ 32767
+#define __SIG_ATOMIC_MAX__ 2147483647
+#define __SIG_ATOMIC_WIDTH__ 32
+#define __SIZEOF_DOUBLE__ 8
+#define __SIZEOF_FLOAT__ 4
+#define __SIZEOF_INT128__ 16
+#define __SIZEOF_INT__ 4
+#define __SIZEOF_LONG_DOUBLE__ 16
+#define __SIZEOF_LONG_LONG__ 8
+#define __SIZEOF_LONG__ 8
+#define __SIZEOF_POINTER__ 8
+#define __SIZEOF_PTRDIFF_T__ 8
+#define __SIZEOF_SHORT__ 2
+#define __SIZEOF_SIZE_T__ 8
+#define __SIZEOF_WCHAR_T__ 4
+#define __SIZEOF_WINT_T__ 4
+#define __SIZE_FMTX__ "lX"
+#define __SIZE_FMTo__ "lo"
+#define __SIZE_FMTu__ "lu"
+#define __SIZE_FMTx__ "lx"
+#define __SIZE_MAX__ 18446744073709551615UL
+#define __SIZE_TYPE__ long unsigned int
+#define __SIZE_WIDTH__ 64
+#define __SSE2_MATH__ 1
+#define __SSE2__ 1
+#define __SSE3__ 1
+#define __SSE_MATH__ 1
+#define __SSE__ 1
+#define __SSP__ 1
+#define __SSSE3__ 1
+#define __STDC_HOSTED__ 1
+#define __STDC_UTF_16__ 1
+#define __STDC_UTF_32__ 1
+#define __STDC__ 1
+#define __UINT16_C_SUFFIX__ 
+#define __UINT16_FMTX__ "hX"
+#define __UINT16_FMTo__ "ho"
+#define __UINT16_FMTu__ "hu"
+#define __UINT16_FMTx__ "hx"
+#define __UINT16_MAX__ 65535
+#define __UINT16_TYPE__ unsigned short
+#define __UINT32_C_SUFFIX__ U
+#define __UINT32_FMTX__ "X"
+#define __UINT32_FMTo__ "o"
+#define __UINT32_FMTu__ "u"
+#define __UINT32_FMTx__ "x"
+#define __UINT32_MAX__ 4294967295U
+#define __UINT32_TYPE__ unsigned int
+#define __UINT64_C_SUFFIX__ ULL
+#define __UINT64_FMTX__ "llX"
+#define __UINT64_FMTo__ "llo"
+#define __UINT64_FMTu__ "llu"
+#define __UINT64_FMTx__ "llx"
+#define __UINT64_MAX__ 18446744073709551615ULL
+#define __UINT64_TYPE__ long long unsigned int
+#define __UINT8_C_SUFFIX__ 
+#define __UINT8_FMTX__ "hhX"
+#define __UINT8_FMTo__ "hho"
+#define __UINT8_FMTu__ "hhu"
+#define __UINT8_FMTx__ "hhx"
+#define __UINT8_MAX__ 255
+#define __UINT8_TYPE__ unsigned char
+#define __UINTMAX_C_SUFFIX__ UL
+#define __UINTMAX_FMTX__ "lX"
+#define __UINTMAX_FMTo__ "lo"
+#define __UINTMAX_FMTu__ "lu"
+#define __UINTMAX_FMTx__ "lx"
+#define __UINTMAX_MAX__ 18446744073709551615UL
+#define __UINTMAX_TYPE__ long unsigned int
+#define __UINTMAX_WIDTH__ 64
+#define __UINTPTR_FMTX__ "lX"
+#define __UINTPTR_FMTo__ "lo"
+#define __UINTPTR_FMTu__ "lu"
+#define __UINTPTR_FMTx__ "lx"
+#define __UINTPTR_MAX__ 18446744073709551615UL
+#define __UINTPTR_TYPE__ long unsigned int
+#define __UINTPTR_WIDTH__ 64
+#define __UINT_FAST16_FMTX__ "hX"
+#define __UINT_FAST16_FMTo__ "ho"
+#define __UINT_FAST16_FMTu__ "hu"
+#define __UINT_FAST16_FMTx__ "hx"
+#define __UINT_FAST16_MAX__ 65535
+#define __UINT_FAST16_TYPE__ unsigned short
+#define __UINT_FAST32_FMTX__ "X"
+#define __UINT_FAST32_FMTo__ "o"
+#define __UINT_FAST32_FMTu__ "u"
+#define __UINT_FAST32_FMTx__ "x"
+#define __UINT_FAST32_MAX__ 4294967295U
+#define __UINT_FAST32_TYPE__ unsigned int
+#define __UINT_FAST64_FMTX__ "lX"
+#define __UINT_FAST64_FMTo__ "lo"
+#define __UINT_FAST64_FMTu__ "lu"
+#define __UINT_FAST64_FMTx__ "lx"
+#define __UINT_FAST64_MAX__ 18446744073709551615UL
+#define __UINT_FAST64_TYPE__ long unsigned int
+#define __UINT_FAST8_FMTX__ "hhX"
+#define __UINT_FAST8_FMTo__ "hho"
+#define __UINT_FAST8_FMTu__ "hhu"
+#define __UINT_FAST8_FMTx__ "hhx"
+#define __UINT_FAST8_MAX__ 255
+#define __UINT_FAST8_TYPE__ unsigned char
+#define __UINT_LEAST16_FMTX__ "hX"
+#define __UINT_LEAST16_FMTo__ "ho"
+#define __UINT_LEAST16_FMTu__ "hu"
+#define __UINT_LEAST16_FMTx__ "hx"
+#define __UINT_LEAST16_MAX__ 65535
+#define __UINT_LEAST16_TYPE__ unsigned short
+#define __UINT_LEAST32_FMTX__ "X"
+#define __UINT_LEAST32_FMTo__ "o"
+#define __UINT_LEAST32_FMTu__ "u"
+#define __UINT_LEAST32_FMTx__ "x"
+#define __UINT_LEAST32_MAX__ 4294967295U
+#define __UINT_LEAST32_TYPE__ unsigned int
+#define __UINT_LEAST64_FMTX__ "lX"
+#define __UINT_LEAST64_FMTo__ "lo"
+#define __UINT_LEAST64_FMTu__ "lu"
+#define __UINT_LEAST64_FMTx__ "lx"
+#define __UINT_LEAST64_MAX__ 18446744073709551615UL
+#define __UINT_LEAST64_TYPE__ long unsigned int
+#define __UINT_LEAST8_FMTX__ "hhX"
+#define __UINT_LEAST8_FMTo__ "hho"
+#define __UINT_LEAST8_FMTu__ "hhu"
+#define __UINT_LEAST8_FMTx__ "hhx"
+#define __UINT_LEAST8_MAX__ 255
+#define __UINT_LEAST8_TYPE__ unsigned char
+#define __USER_LABEL_PREFIX__ _
+#define __VERSION__ "4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)"
+#define __WCHAR_MAX__ 2147483647
+#define __WCHAR_TYPE__ int
+#define __WCHAR_WIDTH__ 32
+#define __WINT_TYPE__ int
+#define __WINT_WIDTH__ 32
+#define __amd64 1
+#define __amd64__ 1
+#define __apple_build_version__ 8020042
+#define __block __attribute__((__blocks__(byref)))
+#define __clang__ 1
+#define __clang_major__ 8
+#define __clang_minor__ 1
+#define __clang_patchlevel__ 0
+#define __clang_version__ "8.1.0 (clang-802.0.42)"
+#define __core2 1
+#define __core2__ 1
+#define __cplusplus 201103L
+#define __cpp_alias_templates 200704
+#define __cpp_attributes 200809
+#define __cpp_constexpr 200704
+#define __cpp_decltype 200707
+#define __cpp_delegating_constructors 200604
+#define __cpp_exceptions 199711
+#define __cpp_inheriting_constructors 200802
+#define __cpp_initializer_lists 200806
+#define __cpp_lambdas 200907
+#define __cpp_nsdmi 200809
+#define __cpp_range_based_for 200907
+#define __cpp_raw_strings 200710
+#define __cpp_ref_qualifiers 200710
+#define __cpp_rtti 199711
+#define __cpp_rvalue_references 200610
+#define __cpp_static_assert 200410
+#define __cpp_unicode_characters 200704
+#define __cpp_unicode_literals 200710
+#define __cpp_user_defined_literals 200809
+#define __cpp_variadic_templates 200704
+#define __llvm__ 1
+#define __nonnull _Nonnull
+#define __null_unspecified _Null_unspecified
+#define __nullable _Nullable
+#define __pic__ 2
+#define __private_extern__ extern
+#define __strong 
+#define __tune_core2__ 1
+#define __unsafe_unretained 
+#define __weak __attribute__((objc_gc(weak)))
+#define __x86_64 1
+#define __x86_64__ 1

--- a/src/plugins/defold/moc_predefs.h
+++ b/src/plugins/defold/moc_predefs.h
@@ -1,0 +1,357 @@
+#define OBJC_NEW_PROPERTIES 1
+#define _LP64 1
+#define __APPLE_CC__ 6000
+#define __APPLE__ 1
+#define __ATOMIC_ACQUIRE 2
+#define __ATOMIC_ACQ_REL 4
+#define __ATOMIC_CONSUME 1
+#define __ATOMIC_RELAXED 0
+#define __ATOMIC_RELEASE 3
+#define __ATOMIC_SEQ_CST 5
+#define __BIGGEST_ALIGNMENT__ 16
+#define __BLOCKS__ 1
+#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __CHAR16_TYPE__ unsigned short
+#define __CHAR32_TYPE__ unsigned int
+#define __CHAR_BIT__ 8
+#define __CONSTANT_CFSTRINGS__ 1
+#define __DBL_DECIMAL_DIG__ 17
+#define __DBL_DENORM_MIN__ 4.9406564584124654e-324
+#define __DBL_DIG__ 15
+#define __DBL_EPSILON__ 2.2204460492503131e-16
+#define __DBL_HAS_DENORM__ 1
+#define __DBL_HAS_INFINITY__ 1
+#define __DBL_HAS_QUIET_NAN__ 1
+#define __DBL_MANT_DIG__ 53
+#define __DBL_MAX_10_EXP__ 308
+#define __DBL_MAX_EXP__ 1024
+#define __DBL_MAX__ 1.7976931348623157e+308
+#define __DBL_MIN_10_EXP__ (-307)
+#define __DBL_MIN_EXP__ (-1021)
+#define __DBL_MIN__ 2.2250738585072014e-308
+#define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
+#define __DEPRECATED 1
+#define __DYNAMIC__ 1
+#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101000
+#define __EXCEPTIONS 1
+#define __FINITE_MATH_ONLY__ 0
+#define __FLT_DECIMAL_DIG__ 9
+#define __FLT_DENORM_MIN__ 1.40129846e-45F
+#define __FLT_DIG__ 6
+#define __FLT_EPSILON__ 1.19209290e-7F
+#define __FLT_EVAL_METHOD__ 0
+#define __FLT_HAS_DENORM__ 1
+#define __FLT_HAS_INFINITY__ 1
+#define __FLT_HAS_QUIET_NAN__ 1
+#define __FLT_MANT_DIG__ 24
+#define __FLT_MAX_10_EXP__ 38
+#define __FLT_MAX_EXP__ 128
+#define __FLT_MAX__ 3.40282347e+38F
+#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT_MIN_EXP__ (-125)
+#define __FLT_MIN__ 1.17549435e-38F
+#define __FLT_RADIX__ 2
+#define __FXSR__ 1
+#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+#define __GCC_ATOMIC_INT_LOCK_FREE 2
+#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
+#define __GLIBCXX_BITSIZE_INT_N_0 128
+#define __GLIBCXX_TYPE_INT_N_0 __int128
+#define __GNUC_GNU_INLINE__ 1
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 1
+#define __GNUC__ 4
+#define __GNUG__ 4
+#define __GXX_ABI_VERSION 1002
+#define __GXX_EXPERIMENTAL_CXX0X__ 1
+#define __GXX_RTTI 1
+#define __GXX_WEAK__ 1
+#define __INT16_C_SUFFIX__ 
+#define __INT16_FMTd__ "hd"
+#define __INT16_FMTi__ "hi"
+#define __INT16_MAX__ 32767
+#define __INT16_TYPE__ short
+#define __INT32_C_SUFFIX__ 
+#define __INT32_FMTd__ "d"
+#define __INT32_FMTi__ "i"
+#define __INT32_MAX__ 2147483647
+#define __INT32_TYPE__ int
+#define __INT64_C_SUFFIX__ LL
+#define __INT64_FMTd__ "lld"
+#define __INT64_FMTi__ "lli"
+#define __INT64_MAX__ 9223372036854775807LL
+#define __INT64_TYPE__ long long int
+#define __INT8_C_SUFFIX__ 
+#define __INT8_FMTd__ "hhd"
+#define __INT8_FMTi__ "hhi"
+#define __INT8_MAX__ 127
+#define __INT8_TYPE__ signed char
+#define __INTMAX_C_SUFFIX__ L
+#define __INTMAX_FMTd__ "ld"
+#define __INTMAX_FMTi__ "li"
+#define __INTMAX_MAX__ 9223372036854775807L
+#define __INTMAX_TYPE__ long int
+#define __INTMAX_WIDTH__ 64
+#define __INTPTR_FMTd__ "ld"
+#define __INTPTR_FMTi__ "li"
+#define __INTPTR_MAX__ 9223372036854775807L
+#define __INTPTR_TYPE__ long int
+#define __INTPTR_WIDTH__ 64
+#define __INT_FAST16_FMTd__ "hd"
+#define __INT_FAST16_FMTi__ "hi"
+#define __INT_FAST16_MAX__ 32767
+#define __INT_FAST16_TYPE__ short
+#define __INT_FAST32_FMTd__ "d"
+#define __INT_FAST32_FMTi__ "i"
+#define __INT_FAST32_MAX__ 2147483647
+#define __INT_FAST32_TYPE__ int
+#define __INT_FAST64_FMTd__ "ld"
+#define __INT_FAST64_FMTi__ "li"
+#define __INT_FAST64_MAX__ 9223372036854775807L
+#define __INT_FAST64_TYPE__ long int
+#define __INT_FAST8_FMTd__ "hhd"
+#define __INT_FAST8_FMTi__ "hhi"
+#define __INT_FAST8_MAX__ 127
+#define __INT_FAST8_TYPE__ signed char
+#define __INT_LEAST16_FMTd__ "hd"
+#define __INT_LEAST16_FMTi__ "hi"
+#define __INT_LEAST16_MAX__ 32767
+#define __INT_LEAST16_TYPE__ short
+#define __INT_LEAST32_FMTd__ "d"
+#define __INT_LEAST32_FMTi__ "i"
+#define __INT_LEAST32_MAX__ 2147483647
+#define __INT_LEAST32_TYPE__ int
+#define __INT_LEAST64_FMTd__ "ld"
+#define __INT_LEAST64_FMTi__ "li"
+#define __INT_LEAST64_MAX__ 9223372036854775807L
+#define __INT_LEAST64_TYPE__ long int
+#define __INT_LEAST8_FMTd__ "hhd"
+#define __INT_LEAST8_FMTi__ "hhi"
+#define __INT_LEAST8_MAX__ 127
+#define __INT_LEAST8_TYPE__ signed char
+#define __INT_MAX__ 2147483647
+#define __LDBL_DECIMAL_DIG__ 21
+#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+#define __LDBL_DIG__ 18
+#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
+#define __LDBL_HAS_DENORM__ 1
+#define __LDBL_HAS_INFINITY__ 1
+#define __LDBL_HAS_QUIET_NAN__ 1
+#define __LDBL_MANT_DIG__ 64
+#define __LDBL_MAX_10_EXP__ 4932
+#define __LDBL_MAX_EXP__ 16384
+#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+#define __LDBL_MIN_10_EXP__ (-4931)
+#define __LDBL_MIN_EXP__ (-16381)
+#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+#define __LITTLE_ENDIAN__ 1
+#define __LONG_LONG_MAX__ 9223372036854775807LL
+#define __LONG_MAX__ 9223372036854775807L
+#define __LP64__ 1
+#define __MACH__ 1
+#define __MMX__ 1
+#define __NO_MATH_INLINES 1
+#define __OBJC_BOOL_IS_BOOL 0
+#define __OPTIMIZE__ 1
+#define __ORDER_BIG_ENDIAN__ 4321
+#define __ORDER_LITTLE_ENDIAN__ 1234
+#define __ORDER_PDP_ENDIAN__ 3412
+#define __PIC__ 2
+#define __POINTER_WIDTH__ 64
+#define __PRAGMA_REDEFINE_EXTNAME 1
+#define __PTRDIFF_FMTd__ "ld"
+#define __PTRDIFF_FMTi__ "li"
+#define __PTRDIFF_MAX__ 9223372036854775807L
+#define __PTRDIFF_TYPE__ long int
+#define __PTRDIFF_WIDTH__ 64
+#define __REGISTER_PREFIX__ 
+#define __SCHAR_MAX__ 127
+#define __SHRT_MAX__ 32767
+#define __SIG_ATOMIC_MAX__ 2147483647
+#define __SIG_ATOMIC_WIDTH__ 32
+#define __SIZEOF_DOUBLE__ 8
+#define __SIZEOF_FLOAT__ 4
+#define __SIZEOF_INT128__ 16
+#define __SIZEOF_INT__ 4
+#define __SIZEOF_LONG_DOUBLE__ 16
+#define __SIZEOF_LONG_LONG__ 8
+#define __SIZEOF_LONG__ 8
+#define __SIZEOF_POINTER__ 8
+#define __SIZEOF_PTRDIFF_T__ 8
+#define __SIZEOF_SHORT__ 2
+#define __SIZEOF_SIZE_T__ 8
+#define __SIZEOF_WCHAR_T__ 4
+#define __SIZEOF_WINT_T__ 4
+#define __SIZE_FMTX__ "lX"
+#define __SIZE_FMTo__ "lo"
+#define __SIZE_FMTu__ "lu"
+#define __SIZE_FMTx__ "lx"
+#define __SIZE_MAX__ 18446744073709551615UL
+#define __SIZE_TYPE__ long unsigned int
+#define __SIZE_WIDTH__ 64
+#define __SSE2_MATH__ 1
+#define __SSE2__ 1
+#define __SSE3__ 1
+#define __SSE_MATH__ 1
+#define __SSE__ 1
+#define __SSP__ 1
+#define __SSSE3__ 1
+#define __STDC_HOSTED__ 1
+#define __STDC_UTF_16__ 1
+#define __STDC_UTF_32__ 1
+#define __STDC__ 1
+#define __UINT16_C_SUFFIX__ 
+#define __UINT16_FMTX__ "hX"
+#define __UINT16_FMTo__ "ho"
+#define __UINT16_FMTu__ "hu"
+#define __UINT16_FMTx__ "hx"
+#define __UINT16_MAX__ 65535
+#define __UINT16_TYPE__ unsigned short
+#define __UINT32_C_SUFFIX__ U
+#define __UINT32_FMTX__ "X"
+#define __UINT32_FMTo__ "o"
+#define __UINT32_FMTu__ "u"
+#define __UINT32_FMTx__ "x"
+#define __UINT32_MAX__ 4294967295U
+#define __UINT32_TYPE__ unsigned int
+#define __UINT64_C_SUFFIX__ ULL
+#define __UINT64_FMTX__ "llX"
+#define __UINT64_FMTo__ "llo"
+#define __UINT64_FMTu__ "llu"
+#define __UINT64_FMTx__ "llx"
+#define __UINT64_MAX__ 18446744073709551615ULL
+#define __UINT64_TYPE__ long long unsigned int
+#define __UINT8_C_SUFFIX__ 
+#define __UINT8_FMTX__ "hhX"
+#define __UINT8_FMTo__ "hho"
+#define __UINT8_FMTu__ "hhu"
+#define __UINT8_FMTx__ "hhx"
+#define __UINT8_MAX__ 255
+#define __UINT8_TYPE__ unsigned char
+#define __UINTMAX_C_SUFFIX__ UL
+#define __UINTMAX_FMTX__ "lX"
+#define __UINTMAX_FMTo__ "lo"
+#define __UINTMAX_FMTu__ "lu"
+#define __UINTMAX_FMTx__ "lx"
+#define __UINTMAX_MAX__ 18446744073709551615UL
+#define __UINTMAX_TYPE__ long unsigned int
+#define __UINTMAX_WIDTH__ 64
+#define __UINTPTR_FMTX__ "lX"
+#define __UINTPTR_FMTo__ "lo"
+#define __UINTPTR_FMTu__ "lu"
+#define __UINTPTR_FMTx__ "lx"
+#define __UINTPTR_MAX__ 18446744073709551615UL
+#define __UINTPTR_TYPE__ long unsigned int
+#define __UINTPTR_WIDTH__ 64
+#define __UINT_FAST16_FMTX__ "hX"
+#define __UINT_FAST16_FMTo__ "ho"
+#define __UINT_FAST16_FMTu__ "hu"
+#define __UINT_FAST16_FMTx__ "hx"
+#define __UINT_FAST16_MAX__ 65535
+#define __UINT_FAST16_TYPE__ unsigned short
+#define __UINT_FAST32_FMTX__ "X"
+#define __UINT_FAST32_FMTo__ "o"
+#define __UINT_FAST32_FMTu__ "u"
+#define __UINT_FAST32_FMTx__ "x"
+#define __UINT_FAST32_MAX__ 4294967295U
+#define __UINT_FAST32_TYPE__ unsigned int
+#define __UINT_FAST64_FMTX__ "lX"
+#define __UINT_FAST64_FMTo__ "lo"
+#define __UINT_FAST64_FMTu__ "lu"
+#define __UINT_FAST64_FMTx__ "lx"
+#define __UINT_FAST64_MAX__ 18446744073709551615UL
+#define __UINT_FAST64_TYPE__ long unsigned int
+#define __UINT_FAST8_FMTX__ "hhX"
+#define __UINT_FAST8_FMTo__ "hho"
+#define __UINT_FAST8_FMTu__ "hhu"
+#define __UINT_FAST8_FMTx__ "hhx"
+#define __UINT_FAST8_MAX__ 255
+#define __UINT_FAST8_TYPE__ unsigned char
+#define __UINT_LEAST16_FMTX__ "hX"
+#define __UINT_LEAST16_FMTo__ "ho"
+#define __UINT_LEAST16_FMTu__ "hu"
+#define __UINT_LEAST16_FMTx__ "hx"
+#define __UINT_LEAST16_MAX__ 65535
+#define __UINT_LEAST16_TYPE__ unsigned short
+#define __UINT_LEAST32_FMTX__ "X"
+#define __UINT_LEAST32_FMTo__ "o"
+#define __UINT_LEAST32_FMTu__ "u"
+#define __UINT_LEAST32_FMTx__ "x"
+#define __UINT_LEAST32_MAX__ 4294967295U
+#define __UINT_LEAST32_TYPE__ unsigned int
+#define __UINT_LEAST64_FMTX__ "lX"
+#define __UINT_LEAST64_FMTo__ "lo"
+#define __UINT_LEAST64_FMTu__ "lu"
+#define __UINT_LEAST64_FMTx__ "lx"
+#define __UINT_LEAST64_MAX__ 18446744073709551615UL
+#define __UINT_LEAST64_TYPE__ long unsigned int
+#define __UINT_LEAST8_FMTX__ "hhX"
+#define __UINT_LEAST8_FMTo__ "hho"
+#define __UINT_LEAST8_FMTu__ "hhu"
+#define __UINT_LEAST8_FMTx__ "hhx"
+#define __UINT_LEAST8_MAX__ 255
+#define __UINT_LEAST8_TYPE__ unsigned char
+#define __USER_LABEL_PREFIX__ _
+#define __VERSION__ "4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)"
+#define __WCHAR_MAX__ 2147483647
+#define __WCHAR_TYPE__ int
+#define __WCHAR_WIDTH__ 32
+#define __WINT_TYPE__ int
+#define __WINT_WIDTH__ 32
+#define __amd64 1
+#define __amd64__ 1
+#define __apple_build_version__ 8020042
+#define __block __attribute__((__blocks__(byref)))
+#define __clang__ 1
+#define __clang_major__ 8
+#define __clang_minor__ 1
+#define __clang_patchlevel__ 0
+#define __clang_version__ "8.1.0 (clang-802.0.42)"
+#define __core2 1
+#define __core2__ 1
+#define __cplusplus 201103L
+#define __cpp_alias_templates 200704
+#define __cpp_attributes 200809
+#define __cpp_constexpr 200704
+#define __cpp_decltype 200707
+#define __cpp_delegating_constructors 200604
+#define __cpp_exceptions 199711
+#define __cpp_inheriting_constructors 200802
+#define __cpp_initializer_lists 200806
+#define __cpp_lambdas 200907
+#define __cpp_nsdmi 200809
+#define __cpp_range_based_for 200907
+#define __cpp_raw_strings 200710
+#define __cpp_ref_qualifiers 200710
+#define __cpp_rtti 199711
+#define __cpp_rvalue_references 200610
+#define __cpp_static_assert 200410
+#define __cpp_unicode_characters 200704
+#define __cpp_unicode_literals 200710
+#define __cpp_user_defined_literals 200809
+#define __cpp_variadic_templates 200704
+#define __llvm__ 1
+#define __nonnull _Nonnull
+#define __null_unspecified _Null_unspecified
+#define __nullable _Nullable
+#define __pic__ 2
+#define __private_extern__ extern
+#define __strong 
+#define __tune_core2__ 1
+#define __unsafe_unretained 
+#define __weak __attribute__((objc_gc(weak)))
+#define __x86_64 1
+#define __x86_64__ 1

--- a/src/plugins/droidcraft/droidcraftplugin.cpp
+++ b/src/plugins/droidcraft/droidcraftplugin.cpp
@@ -67,7 +67,7 @@ Tiled::Map *DroidcraftPlugin::read(const QString &fileName)
     map->addTileset(mapTileset);
 
     // Fill layer
-    TileLayer *mapLayer = new TileLayer("map", 0, 0, 48, 48);
+    TileLayer *mapLayer = new TileLayer("map", 0, 0, 48, 48, 32, 32);
 
     // Load
     for (int i = 0; i < 48 * 48; i++) {

--- a/src/plugins/droidcraft/moc_predefs.h
+++ b/src/plugins/droidcraft/moc_predefs.h
@@ -1,0 +1,357 @@
+#define OBJC_NEW_PROPERTIES 1
+#define _LP64 1
+#define __APPLE_CC__ 6000
+#define __APPLE__ 1
+#define __ATOMIC_ACQUIRE 2
+#define __ATOMIC_ACQ_REL 4
+#define __ATOMIC_CONSUME 1
+#define __ATOMIC_RELAXED 0
+#define __ATOMIC_RELEASE 3
+#define __ATOMIC_SEQ_CST 5
+#define __BIGGEST_ALIGNMENT__ 16
+#define __BLOCKS__ 1
+#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __CHAR16_TYPE__ unsigned short
+#define __CHAR32_TYPE__ unsigned int
+#define __CHAR_BIT__ 8
+#define __CONSTANT_CFSTRINGS__ 1
+#define __DBL_DECIMAL_DIG__ 17
+#define __DBL_DENORM_MIN__ 4.9406564584124654e-324
+#define __DBL_DIG__ 15
+#define __DBL_EPSILON__ 2.2204460492503131e-16
+#define __DBL_HAS_DENORM__ 1
+#define __DBL_HAS_INFINITY__ 1
+#define __DBL_HAS_QUIET_NAN__ 1
+#define __DBL_MANT_DIG__ 53
+#define __DBL_MAX_10_EXP__ 308
+#define __DBL_MAX_EXP__ 1024
+#define __DBL_MAX__ 1.7976931348623157e+308
+#define __DBL_MIN_10_EXP__ (-307)
+#define __DBL_MIN_EXP__ (-1021)
+#define __DBL_MIN__ 2.2250738585072014e-308
+#define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
+#define __DEPRECATED 1
+#define __DYNAMIC__ 1
+#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101000
+#define __EXCEPTIONS 1
+#define __FINITE_MATH_ONLY__ 0
+#define __FLT_DECIMAL_DIG__ 9
+#define __FLT_DENORM_MIN__ 1.40129846e-45F
+#define __FLT_DIG__ 6
+#define __FLT_EPSILON__ 1.19209290e-7F
+#define __FLT_EVAL_METHOD__ 0
+#define __FLT_HAS_DENORM__ 1
+#define __FLT_HAS_INFINITY__ 1
+#define __FLT_HAS_QUIET_NAN__ 1
+#define __FLT_MANT_DIG__ 24
+#define __FLT_MAX_10_EXP__ 38
+#define __FLT_MAX_EXP__ 128
+#define __FLT_MAX__ 3.40282347e+38F
+#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT_MIN_EXP__ (-125)
+#define __FLT_MIN__ 1.17549435e-38F
+#define __FLT_RADIX__ 2
+#define __FXSR__ 1
+#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+#define __GCC_ATOMIC_INT_LOCK_FREE 2
+#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
+#define __GLIBCXX_BITSIZE_INT_N_0 128
+#define __GLIBCXX_TYPE_INT_N_0 __int128
+#define __GNUC_GNU_INLINE__ 1
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 1
+#define __GNUC__ 4
+#define __GNUG__ 4
+#define __GXX_ABI_VERSION 1002
+#define __GXX_EXPERIMENTAL_CXX0X__ 1
+#define __GXX_RTTI 1
+#define __GXX_WEAK__ 1
+#define __INT16_C_SUFFIX__ 
+#define __INT16_FMTd__ "hd"
+#define __INT16_FMTi__ "hi"
+#define __INT16_MAX__ 32767
+#define __INT16_TYPE__ short
+#define __INT32_C_SUFFIX__ 
+#define __INT32_FMTd__ "d"
+#define __INT32_FMTi__ "i"
+#define __INT32_MAX__ 2147483647
+#define __INT32_TYPE__ int
+#define __INT64_C_SUFFIX__ LL
+#define __INT64_FMTd__ "lld"
+#define __INT64_FMTi__ "lli"
+#define __INT64_MAX__ 9223372036854775807LL
+#define __INT64_TYPE__ long long int
+#define __INT8_C_SUFFIX__ 
+#define __INT8_FMTd__ "hhd"
+#define __INT8_FMTi__ "hhi"
+#define __INT8_MAX__ 127
+#define __INT8_TYPE__ signed char
+#define __INTMAX_C_SUFFIX__ L
+#define __INTMAX_FMTd__ "ld"
+#define __INTMAX_FMTi__ "li"
+#define __INTMAX_MAX__ 9223372036854775807L
+#define __INTMAX_TYPE__ long int
+#define __INTMAX_WIDTH__ 64
+#define __INTPTR_FMTd__ "ld"
+#define __INTPTR_FMTi__ "li"
+#define __INTPTR_MAX__ 9223372036854775807L
+#define __INTPTR_TYPE__ long int
+#define __INTPTR_WIDTH__ 64
+#define __INT_FAST16_FMTd__ "hd"
+#define __INT_FAST16_FMTi__ "hi"
+#define __INT_FAST16_MAX__ 32767
+#define __INT_FAST16_TYPE__ short
+#define __INT_FAST32_FMTd__ "d"
+#define __INT_FAST32_FMTi__ "i"
+#define __INT_FAST32_MAX__ 2147483647
+#define __INT_FAST32_TYPE__ int
+#define __INT_FAST64_FMTd__ "ld"
+#define __INT_FAST64_FMTi__ "li"
+#define __INT_FAST64_MAX__ 9223372036854775807L
+#define __INT_FAST64_TYPE__ long int
+#define __INT_FAST8_FMTd__ "hhd"
+#define __INT_FAST8_FMTi__ "hhi"
+#define __INT_FAST8_MAX__ 127
+#define __INT_FAST8_TYPE__ signed char
+#define __INT_LEAST16_FMTd__ "hd"
+#define __INT_LEAST16_FMTi__ "hi"
+#define __INT_LEAST16_MAX__ 32767
+#define __INT_LEAST16_TYPE__ short
+#define __INT_LEAST32_FMTd__ "d"
+#define __INT_LEAST32_FMTi__ "i"
+#define __INT_LEAST32_MAX__ 2147483647
+#define __INT_LEAST32_TYPE__ int
+#define __INT_LEAST64_FMTd__ "ld"
+#define __INT_LEAST64_FMTi__ "li"
+#define __INT_LEAST64_MAX__ 9223372036854775807L
+#define __INT_LEAST64_TYPE__ long int
+#define __INT_LEAST8_FMTd__ "hhd"
+#define __INT_LEAST8_FMTi__ "hhi"
+#define __INT_LEAST8_MAX__ 127
+#define __INT_LEAST8_TYPE__ signed char
+#define __INT_MAX__ 2147483647
+#define __LDBL_DECIMAL_DIG__ 21
+#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+#define __LDBL_DIG__ 18
+#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
+#define __LDBL_HAS_DENORM__ 1
+#define __LDBL_HAS_INFINITY__ 1
+#define __LDBL_HAS_QUIET_NAN__ 1
+#define __LDBL_MANT_DIG__ 64
+#define __LDBL_MAX_10_EXP__ 4932
+#define __LDBL_MAX_EXP__ 16384
+#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+#define __LDBL_MIN_10_EXP__ (-4931)
+#define __LDBL_MIN_EXP__ (-16381)
+#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+#define __LITTLE_ENDIAN__ 1
+#define __LONG_LONG_MAX__ 9223372036854775807LL
+#define __LONG_MAX__ 9223372036854775807L
+#define __LP64__ 1
+#define __MACH__ 1
+#define __MMX__ 1
+#define __NO_MATH_INLINES 1
+#define __OBJC_BOOL_IS_BOOL 0
+#define __OPTIMIZE__ 1
+#define __ORDER_BIG_ENDIAN__ 4321
+#define __ORDER_LITTLE_ENDIAN__ 1234
+#define __ORDER_PDP_ENDIAN__ 3412
+#define __PIC__ 2
+#define __POINTER_WIDTH__ 64
+#define __PRAGMA_REDEFINE_EXTNAME 1
+#define __PTRDIFF_FMTd__ "ld"
+#define __PTRDIFF_FMTi__ "li"
+#define __PTRDIFF_MAX__ 9223372036854775807L
+#define __PTRDIFF_TYPE__ long int
+#define __PTRDIFF_WIDTH__ 64
+#define __REGISTER_PREFIX__ 
+#define __SCHAR_MAX__ 127
+#define __SHRT_MAX__ 32767
+#define __SIG_ATOMIC_MAX__ 2147483647
+#define __SIG_ATOMIC_WIDTH__ 32
+#define __SIZEOF_DOUBLE__ 8
+#define __SIZEOF_FLOAT__ 4
+#define __SIZEOF_INT128__ 16
+#define __SIZEOF_INT__ 4
+#define __SIZEOF_LONG_DOUBLE__ 16
+#define __SIZEOF_LONG_LONG__ 8
+#define __SIZEOF_LONG__ 8
+#define __SIZEOF_POINTER__ 8
+#define __SIZEOF_PTRDIFF_T__ 8
+#define __SIZEOF_SHORT__ 2
+#define __SIZEOF_SIZE_T__ 8
+#define __SIZEOF_WCHAR_T__ 4
+#define __SIZEOF_WINT_T__ 4
+#define __SIZE_FMTX__ "lX"
+#define __SIZE_FMTo__ "lo"
+#define __SIZE_FMTu__ "lu"
+#define __SIZE_FMTx__ "lx"
+#define __SIZE_MAX__ 18446744073709551615UL
+#define __SIZE_TYPE__ long unsigned int
+#define __SIZE_WIDTH__ 64
+#define __SSE2_MATH__ 1
+#define __SSE2__ 1
+#define __SSE3__ 1
+#define __SSE_MATH__ 1
+#define __SSE__ 1
+#define __SSP__ 1
+#define __SSSE3__ 1
+#define __STDC_HOSTED__ 1
+#define __STDC_UTF_16__ 1
+#define __STDC_UTF_32__ 1
+#define __STDC__ 1
+#define __UINT16_C_SUFFIX__ 
+#define __UINT16_FMTX__ "hX"
+#define __UINT16_FMTo__ "ho"
+#define __UINT16_FMTu__ "hu"
+#define __UINT16_FMTx__ "hx"
+#define __UINT16_MAX__ 65535
+#define __UINT16_TYPE__ unsigned short
+#define __UINT32_C_SUFFIX__ U
+#define __UINT32_FMTX__ "X"
+#define __UINT32_FMTo__ "o"
+#define __UINT32_FMTu__ "u"
+#define __UINT32_FMTx__ "x"
+#define __UINT32_MAX__ 4294967295U
+#define __UINT32_TYPE__ unsigned int
+#define __UINT64_C_SUFFIX__ ULL
+#define __UINT64_FMTX__ "llX"
+#define __UINT64_FMTo__ "llo"
+#define __UINT64_FMTu__ "llu"
+#define __UINT64_FMTx__ "llx"
+#define __UINT64_MAX__ 18446744073709551615ULL
+#define __UINT64_TYPE__ long long unsigned int
+#define __UINT8_C_SUFFIX__ 
+#define __UINT8_FMTX__ "hhX"
+#define __UINT8_FMTo__ "hho"
+#define __UINT8_FMTu__ "hhu"
+#define __UINT8_FMTx__ "hhx"
+#define __UINT8_MAX__ 255
+#define __UINT8_TYPE__ unsigned char
+#define __UINTMAX_C_SUFFIX__ UL
+#define __UINTMAX_FMTX__ "lX"
+#define __UINTMAX_FMTo__ "lo"
+#define __UINTMAX_FMTu__ "lu"
+#define __UINTMAX_FMTx__ "lx"
+#define __UINTMAX_MAX__ 18446744073709551615UL
+#define __UINTMAX_TYPE__ long unsigned int
+#define __UINTMAX_WIDTH__ 64
+#define __UINTPTR_FMTX__ "lX"
+#define __UINTPTR_FMTo__ "lo"
+#define __UINTPTR_FMTu__ "lu"
+#define __UINTPTR_FMTx__ "lx"
+#define __UINTPTR_MAX__ 18446744073709551615UL
+#define __UINTPTR_TYPE__ long unsigned int
+#define __UINTPTR_WIDTH__ 64
+#define __UINT_FAST16_FMTX__ "hX"
+#define __UINT_FAST16_FMTo__ "ho"
+#define __UINT_FAST16_FMTu__ "hu"
+#define __UINT_FAST16_FMTx__ "hx"
+#define __UINT_FAST16_MAX__ 65535
+#define __UINT_FAST16_TYPE__ unsigned short
+#define __UINT_FAST32_FMTX__ "X"
+#define __UINT_FAST32_FMTo__ "o"
+#define __UINT_FAST32_FMTu__ "u"
+#define __UINT_FAST32_FMTx__ "x"
+#define __UINT_FAST32_MAX__ 4294967295U
+#define __UINT_FAST32_TYPE__ unsigned int
+#define __UINT_FAST64_FMTX__ "lX"
+#define __UINT_FAST64_FMTo__ "lo"
+#define __UINT_FAST64_FMTu__ "lu"
+#define __UINT_FAST64_FMTx__ "lx"
+#define __UINT_FAST64_MAX__ 18446744073709551615UL
+#define __UINT_FAST64_TYPE__ long unsigned int
+#define __UINT_FAST8_FMTX__ "hhX"
+#define __UINT_FAST8_FMTo__ "hho"
+#define __UINT_FAST8_FMTu__ "hhu"
+#define __UINT_FAST8_FMTx__ "hhx"
+#define __UINT_FAST8_MAX__ 255
+#define __UINT_FAST8_TYPE__ unsigned char
+#define __UINT_LEAST16_FMTX__ "hX"
+#define __UINT_LEAST16_FMTo__ "ho"
+#define __UINT_LEAST16_FMTu__ "hu"
+#define __UINT_LEAST16_FMTx__ "hx"
+#define __UINT_LEAST16_MAX__ 65535
+#define __UINT_LEAST16_TYPE__ unsigned short
+#define __UINT_LEAST32_FMTX__ "X"
+#define __UINT_LEAST32_FMTo__ "o"
+#define __UINT_LEAST32_FMTu__ "u"
+#define __UINT_LEAST32_FMTx__ "x"
+#define __UINT_LEAST32_MAX__ 4294967295U
+#define __UINT_LEAST32_TYPE__ unsigned int
+#define __UINT_LEAST64_FMTX__ "lX"
+#define __UINT_LEAST64_FMTo__ "lo"
+#define __UINT_LEAST64_FMTu__ "lu"
+#define __UINT_LEAST64_FMTx__ "lx"
+#define __UINT_LEAST64_MAX__ 18446744073709551615UL
+#define __UINT_LEAST64_TYPE__ long unsigned int
+#define __UINT_LEAST8_FMTX__ "hhX"
+#define __UINT_LEAST8_FMTo__ "hho"
+#define __UINT_LEAST8_FMTu__ "hhu"
+#define __UINT_LEAST8_FMTx__ "hhx"
+#define __UINT_LEAST8_MAX__ 255
+#define __UINT_LEAST8_TYPE__ unsigned char
+#define __USER_LABEL_PREFIX__ _
+#define __VERSION__ "4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)"
+#define __WCHAR_MAX__ 2147483647
+#define __WCHAR_TYPE__ int
+#define __WCHAR_WIDTH__ 32
+#define __WINT_TYPE__ int
+#define __WINT_WIDTH__ 32
+#define __amd64 1
+#define __amd64__ 1
+#define __apple_build_version__ 8020042
+#define __block __attribute__((__blocks__(byref)))
+#define __clang__ 1
+#define __clang_major__ 8
+#define __clang_minor__ 1
+#define __clang_patchlevel__ 0
+#define __clang_version__ "8.1.0 (clang-802.0.42)"
+#define __core2 1
+#define __core2__ 1
+#define __cplusplus 201103L
+#define __cpp_alias_templates 200704
+#define __cpp_attributes 200809
+#define __cpp_constexpr 200704
+#define __cpp_decltype 200707
+#define __cpp_delegating_constructors 200604
+#define __cpp_exceptions 199711
+#define __cpp_inheriting_constructors 200802
+#define __cpp_initializer_lists 200806
+#define __cpp_lambdas 200907
+#define __cpp_nsdmi 200809
+#define __cpp_range_based_for 200907
+#define __cpp_raw_strings 200710
+#define __cpp_ref_qualifiers 200710
+#define __cpp_rtti 199711
+#define __cpp_rvalue_references 200610
+#define __cpp_static_assert 200410
+#define __cpp_unicode_characters 200704
+#define __cpp_unicode_literals 200710
+#define __cpp_user_defined_literals 200809
+#define __cpp_variadic_templates 200704
+#define __llvm__ 1
+#define __nonnull _Nonnull
+#define __null_unspecified _Null_unspecified
+#define __nullable _Nullable
+#define __pic__ 2
+#define __private_extern__ extern
+#define __strong 
+#define __tune_core2__ 1
+#define __unsafe_unretained 
+#define __weak __attribute__((objc_gc(weak)))
+#define __x86_64 1
+#define __x86_64__ 1

--- a/src/plugins/flare/flareplugin.cpp
+++ b/src/plugins/flare/flareplugin.cpp
@@ -159,7 +159,8 @@ Tiled::Map *FlarePlugin::read(const QString &fileName)
 
                 if (key == QLatin1String("type")) {
                     tilelayer = new TileLayer(value, 0, 0,
-                                              map->width(),map->height());
+                                              map->width(), map->height(),
+											  map->tileWidth(), map->tileHeight());
                     map->addLayer(tilelayer);
                 } else if (key == QLatin1String("format")) {
                     if (value == QLatin1String("dec")) {

--- a/src/plugins/flare/moc_predefs.h
+++ b/src/plugins/flare/moc_predefs.h
@@ -1,0 +1,357 @@
+#define OBJC_NEW_PROPERTIES 1
+#define _LP64 1
+#define __APPLE_CC__ 6000
+#define __APPLE__ 1
+#define __ATOMIC_ACQUIRE 2
+#define __ATOMIC_ACQ_REL 4
+#define __ATOMIC_CONSUME 1
+#define __ATOMIC_RELAXED 0
+#define __ATOMIC_RELEASE 3
+#define __ATOMIC_SEQ_CST 5
+#define __BIGGEST_ALIGNMENT__ 16
+#define __BLOCKS__ 1
+#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __CHAR16_TYPE__ unsigned short
+#define __CHAR32_TYPE__ unsigned int
+#define __CHAR_BIT__ 8
+#define __CONSTANT_CFSTRINGS__ 1
+#define __DBL_DECIMAL_DIG__ 17
+#define __DBL_DENORM_MIN__ 4.9406564584124654e-324
+#define __DBL_DIG__ 15
+#define __DBL_EPSILON__ 2.2204460492503131e-16
+#define __DBL_HAS_DENORM__ 1
+#define __DBL_HAS_INFINITY__ 1
+#define __DBL_HAS_QUIET_NAN__ 1
+#define __DBL_MANT_DIG__ 53
+#define __DBL_MAX_10_EXP__ 308
+#define __DBL_MAX_EXP__ 1024
+#define __DBL_MAX__ 1.7976931348623157e+308
+#define __DBL_MIN_10_EXP__ (-307)
+#define __DBL_MIN_EXP__ (-1021)
+#define __DBL_MIN__ 2.2250738585072014e-308
+#define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
+#define __DEPRECATED 1
+#define __DYNAMIC__ 1
+#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101000
+#define __EXCEPTIONS 1
+#define __FINITE_MATH_ONLY__ 0
+#define __FLT_DECIMAL_DIG__ 9
+#define __FLT_DENORM_MIN__ 1.40129846e-45F
+#define __FLT_DIG__ 6
+#define __FLT_EPSILON__ 1.19209290e-7F
+#define __FLT_EVAL_METHOD__ 0
+#define __FLT_HAS_DENORM__ 1
+#define __FLT_HAS_INFINITY__ 1
+#define __FLT_HAS_QUIET_NAN__ 1
+#define __FLT_MANT_DIG__ 24
+#define __FLT_MAX_10_EXP__ 38
+#define __FLT_MAX_EXP__ 128
+#define __FLT_MAX__ 3.40282347e+38F
+#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT_MIN_EXP__ (-125)
+#define __FLT_MIN__ 1.17549435e-38F
+#define __FLT_RADIX__ 2
+#define __FXSR__ 1
+#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+#define __GCC_ATOMIC_INT_LOCK_FREE 2
+#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
+#define __GLIBCXX_BITSIZE_INT_N_0 128
+#define __GLIBCXX_TYPE_INT_N_0 __int128
+#define __GNUC_GNU_INLINE__ 1
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 1
+#define __GNUC__ 4
+#define __GNUG__ 4
+#define __GXX_ABI_VERSION 1002
+#define __GXX_EXPERIMENTAL_CXX0X__ 1
+#define __GXX_RTTI 1
+#define __GXX_WEAK__ 1
+#define __INT16_C_SUFFIX__ 
+#define __INT16_FMTd__ "hd"
+#define __INT16_FMTi__ "hi"
+#define __INT16_MAX__ 32767
+#define __INT16_TYPE__ short
+#define __INT32_C_SUFFIX__ 
+#define __INT32_FMTd__ "d"
+#define __INT32_FMTi__ "i"
+#define __INT32_MAX__ 2147483647
+#define __INT32_TYPE__ int
+#define __INT64_C_SUFFIX__ LL
+#define __INT64_FMTd__ "lld"
+#define __INT64_FMTi__ "lli"
+#define __INT64_MAX__ 9223372036854775807LL
+#define __INT64_TYPE__ long long int
+#define __INT8_C_SUFFIX__ 
+#define __INT8_FMTd__ "hhd"
+#define __INT8_FMTi__ "hhi"
+#define __INT8_MAX__ 127
+#define __INT8_TYPE__ signed char
+#define __INTMAX_C_SUFFIX__ L
+#define __INTMAX_FMTd__ "ld"
+#define __INTMAX_FMTi__ "li"
+#define __INTMAX_MAX__ 9223372036854775807L
+#define __INTMAX_TYPE__ long int
+#define __INTMAX_WIDTH__ 64
+#define __INTPTR_FMTd__ "ld"
+#define __INTPTR_FMTi__ "li"
+#define __INTPTR_MAX__ 9223372036854775807L
+#define __INTPTR_TYPE__ long int
+#define __INTPTR_WIDTH__ 64
+#define __INT_FAST16_FMTd__ "hd"
+#define __INT_FAST16_FMTi__ "hi"
+#define __INT_FAST16_MAX__ 32767
+#define __INT_FAST16_TYPE__ short
+#define __INT_FAST32_FMTd__ "d"
+#define __INT_FAST32_FMTi__ "i"
+#define __INT_FAST32_MAX__ 2147483647
+#define __INT_FAST32_TYPE__ int
+#define __INT_FAST64_FMTd__ "ld"
+#define __INT_FAST64_FMTi__ "li"
+#define __INT_FAST64_MAX__ 9223372036854775807L
+#define __INT_FAST64_TYPE__ long int
+#define __INT_FAST8_FMTd__ "hhd"
+#define __INT_FAST8_FMTi__ "hhi"
+#define __INT_FAST8_MAX__ 127
+#define __INT_FAST8_TYPE__ signed char
+#define __INT_LEAST16_FMTd__ "hd"
+#define __INT_LEAST16_FMTi__ "hi"
+#define __INT_LEAST16_MAX__ 32767
+#define __INT_LEAST16_TYPE__ short
+#define __INT_LEAST32_FMTd__ "d"
+#define __INT_LEAST32_FMTi__ "i"
+#define __INT_LEAST32_MAX__ 2147483647
+#define __INT_LEAST32_TYPE__ int
+#define __INT_LEAST64_FMTd__ "ld"
+#define __INT_LEAST64_FMTi__ "li"
+#define __INT_LEAST64_MAX__ 9223372036854775807L
+#define __INT_LEAST64_TYPE__ long int
+#define __INT_LEAST8_FMTd__ "hhd"
+#define __INT_LEAST8_FMTi__ "hhi"
+#define __INT_LEAST8_MAX__ 127
+#define __INT_LEAST8_TYPE__ signed char
+#define __INT_MAX__ 2147483647
+#define __LDBL_DECIMAL_DIG__ 21
+#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+#define __LDBL_DIG__ 18
+#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
+#define __LDBL_HAS_DENORM__ 1
+#define __LDBL_HAS_INFINITY__ 1
+#define __LDBL_HAS_QUIET_NAN__ 1
+#define __LDBL_MANT_DIG__ 64
+#define __LDBL_MAX_10_EXP__ 4932
+#define __LDBL_MAX_EXP__ 16384
+#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+#define __LDBL_MIN_10_EXP__ (-4931)
+#define __LDBL_MIN_EXP__ (-16381)
+#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+#define __LITTLE_ENDIAN__ 1
+#define __LONG_LONG_MAX__ 9223372036854775807LL
+#define __LONG_MAX__ 9223372036854775807L
+#define __LP64__ 1
+#define __MACH__ 1
+#define __MMX__ 1
+#define __NO_MATH_INLINES 1
+#define __OBJC_BOOL_IS_BOOL 0
+#define __OPTIMIZE__ 1
+#define __ORDER_BIG_ENDIAN__ 4321
+#define __ORDER_LITTLE_ENDIAN__ 1234
+#define __ORDER_PDP_ENDIAN__ 3412
+#define __PIC__ 2
+#define __POINTER_WIDTH__ 64
+#define __PRAGMA_REDEFINE_EXTNAME 1
+#define __PTRDIFF_FMTd__ "ld"
+#define __PTRDIFF_FMTi__ "li"
+#define __PTRDIFF_MAX__ 9223372036854775807L
+#define __PTRDIFF_TYPE__ long int
+#define __PTRDIFF_WIDTH__ 64
+#define __REGISTER_PREFIX__ 
+#define __SCHAR_MAX__ 127
+#define __SHRT_MAX__ 32767
+#define __SIG_ATOMIC_MAX__ 2147483647
+#define __SIG_ATOMIC_WIDTH__ 32
+#define __SIZEOF_DOUBLE__ 8
+#define __SIZEOF_FLOAT__ 4
+#define __SIZEOF_INT128__ 16
+#define __SIZEOF_INT__ 4
+#define __SIZEOF_LONG_DOUBLE__ 16
+#define __SIZEOF_LONG_LONG__ 8
+#define __SIZEOF_LONG__ 8
+#define __SIZEOF_POINTER__ 8
+#define __SIZEOF_PTRDIFF_T__ 8
+#define __SIZEOF_SHORT__ 2
+#define __SIZEOF_SIZE_T__ 8
+#define __SIZEOF_WCHAR_T__ 4
+#define __SIZEOF_WINT_T__ 4
+#define __SIZE_FMTX__ "lX"
+#define __SIZE_FMTo__ "lo"
+#define __SIZE_FMTu__ "lu"
+#define __SIZE_FMTx__ "lx"
+#define __SIZE_MAX__ 18446744073709551615UL
+#define __SIZE_TYPE__ long unsigned int
+#define __SIZE_WIDTH__ 64
+#define __SSE2_MATH__ 1
+#define __SSE2__ 1
+#define __SSE3__ 1
+#define __SSE_MATH__ 1
+#define __SSE__ 1
+#define __SSP__ 1
+#define __SSSE3__ 1
+#define __STDC_HOSTED__ 1
+#define __STDC_UTF_16__ 1
+#define __STDC_UTF_32__ 1
+#define __STDC__ 1
+#define __UINT16_C_SUFFIX__ 
+#define __UINT16_FMTX__ "hX"
+#define __UINT16_FMTo__ "ho"
+#define __UINT16_FMTu__ "hu"
+#define __UINT16_FMTx__ "hx"
+#define __UINT16_MAX__ 65535
+#define __UINT16_TYPE__ unsigned short
+#define __UINT32_C_SUFFIX__ U
+#define __UINT32_FMTX__ "X"
+#define __UINT32_FMTo__ "o"
+#define __UINT32_FMTu__ "u"
+#define __UINT32_FMTx__ "x"
+#define __UINT32_MAX__ 4294967295U
+#define __UINT32_TYPE__ unsigned int
+#define __UINT64_C_SUFFIX__ ULL
+#define __UINT64_FMTX__ "llX"
+#define __UINT64_FMTo__ "llo"
+#define __UINT64_FMTu__ "llu"
+#define __UINT64_FMTx__ "llx"
+#define __UINT64_MAX__ 18446744073709551615ULL
+#define __UINT64_TYPE__ long long unsigned int
+#define __UINT8_C_SUFFIX__ 
+#define __UINT8_FMTX__ "hhX"
+#define __UINT8_FMTo__ "hho"
+#define __UINT8_FMTu__ "hhu"
+#define __UINT8_FMTx__ "hhx"
+#define __UINT8_MAX__ 255
+#define __UINT8_TYPE__ unsigned char
+#define __UINTMAX_C_SUFFIX__ UL
+#define __UINTMAX_FMTX__ "lX"
+#define __UINTMAX_FMTo__ "lo"
+#define __UINTMAX_FMTu__ "lu"
+#define __UINTMAX_FMTx__ "lx"
+#define __UINTMAX_MAX__ 18446744073709551615UL
+#define __UINTMAX_TYPE__ long unsigned int
+#define __UINTMAX_WIDTH__ 64
+#define __UINTPTR_FMTX__ "lX"
+#define __UINTPTR_FMTo__ "lo"
+#define __UINTPTR_FMTu__ "lu"
+#define __UINTPTR_FMTx__ "lx"
+#define __UINTPTR_MAX__ 18446744073709551615UL
+#define __UINTPTR_TYPE__ long unsigned int
+#define __UINTPTR_WIDTH__ 64
+#define __UINT_FAST16_FMTX__ "hX"
+#define __UINT_FAST16_FMTo__ "ho"
+#define __UINT_FAST16_FMTu__ "hu"
+#define __UINT_FAST16_FMTx__ "hx"
+#define __UINT_FAST16_MAX__ 65535
+#define __UINT_FAST16_TYPE__ unsigned short
+#define __UINT_FAST32_FMTX__ "X"
+#define __UINT_FAST32_FMTo__ "o"
+#define __UINT_FAST32_FMTu__ "u"
+#define __UINT_FAST32_FMTx__ "x"
+#define __UINT_FAST32_MAX__ 4294967295U
+#define __UINT_FAST32_TYPE__ unsigned int
+#define __UINT_FAST64_FMTX__ "lX"
+#define __UINT_FAST64_FMTo__ "lo"
+#define __UINT_FAST64_FMTu__ "lu"
+#define __UINT_FAST64_FMTx__ "lx"
+#define __UINT_FAST64_MAX__ 18446744073709551615UL
+#define __UINT_FAST64_TYPE__ long unsigned int
+#define __UINT_FAST8_FMTX__ "hhX"
+#define __UINT_FAST8_FMTo__ "hho"
+#define __UINT_FAST8_FMTu__ "hhu"
+#define __UINT_FAST8_FMTx__ "hhx"
+#define __UINT_FAST8_MAX__ 255
+#define __UINT_FAST8_TYPE__ unsigned char
+#define __UINT_LEAST16_FMTX__ "hX"
+#define __UINT_LEAST16_FMTo__ "ho"
+#define __UINT_LEAST16_FMTu__ "hu"
+#define __UINT_LEAST16_FMTx__ "hx"
+#define __UINT_LEAST16_MAX__ 65535
+#define __UINT_LEAST16_TYPE__ unsigned short
+#define __UINT_LEAST32_FMTX__ "X"
+#define __UINT_LEAST32_FMTo__ "o"
+#define __UINT_LEAST32_FMTu__ "u"
+#define __UINT_LEAST32_FMTx__ "x"
+#define __UINT_LEAST32_MAX__ 4294967295U
+#define __UINT_LEAST32_TYPE__ unsigned int
+#define __UINT_LEAST64_FMTX__ "lX"
+#define __UINT_LEAST64_FMTo__ "lo"
+#define __UINT_LEAST64_FMTu__ "lu"
+#define __UINT_LEAST64_FMTx__ "lx"
+#define __UINT_LEAST64_MAX__ 18446744073709551615UL
+#define __UINT_LEAST64_TYPE__ long unsigned int
+#define __UINT_LEAST8_FMTX__ "hhX"
+#define __UINT_LEAST8_FMTo__ "hho"
+#define __UINT_LEAST8_FMTu__ "hhu"
+#define __UINT_LEAST8_FMTx__ "hhx"
+#define __UINT_LEAST8_MAX__ 255
+#define __UINT_LEAST8_TYPE__ unsigned char
+#define __USER_LABEL_PREFIX__ _
+#define __VERSION__ "4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)"
+#define __WCHAR_MAX__ 2147483647
+#define __WCHAR_TYPE__ int
+#define __WCHAR_WIDTH__ 32
+#define __WINT_TYPE__ int
+#define __WINT_WIDTH__ 32
+#define __amd64 1
+#define __amd64__ 1
+#define __apple_build_version__ 8020042
+#define __block __attribute__((__blocks__(byref)))
+#define __clang__ 1
+#define __clang_major__ 8
+#define __clang_minor__ 1
+#define __clang_patchlevel__ 0
+#define __clang_version__ "8.1.0 (clang-802.0.42)"
+#define __core2 1
+#define __core2__ 1
+#define __cplusplus 201103L
+#define __cpp_alias_templates 200704
+#define __cpp_attributes 200809
+#define __cpp_constexpr 200704
+#define __cpp_decltype 200707
+#define __cpp_delegating_constructors 200604
+#define __cpp_exceptions 199711
+#define __cpp_inheriting_constructors 200802
+#define __cpp_initializer_lists 200806
+#define __cpp_lambdas 200907
+#define __cpp_nsdmi 200809
+#define __cpp_range_based_for 200907
+#define __cpp_raw_strings 200710
+#define __cpp_ref_qualifiers 200710
+#define __cpp_rtti 199711
+#define __cpp_rvalue_references 200610
+#define __cpp_static_assert 200410
+#define __cpp_unicode_characters 200704
+#define __cpp_unicode_literals 200710
+#define __cpp_user_defined_literals 200809
+#define __cpp_variadic_templates 200704
+#define __llvm__ 1
+#define __nonnull _Nonnull
+#define __null_unspecified _Null_unspecified
+#define __nullable _Nullable
+#define __pic__ 2
+#define __private_extern__ extern
+#define __strong 
+#define __tune_core2__ 1
+#define __unsafe_unretained 
+#define __weak __attribute__((objc_gc(weak)))
+#define __x86_64 1
+#define __x86_64__ 1

--- a/src/plugins/gmx/moc_predefs.h
+++ b/src/plugins/gmx/moc_predefs.h
@@ -1,0 +1,357 @@
+#define OBJC_NEW_PROPERTIES 1
+#define _LP64 1
+#define __APPLE_CC__ 6000
+#define __APPLE__ 1
+#define __ATOMIC_ACQUIRE 2
+#define __ATOMIC_ACQ_REL 4
+#define __ATOMIC_CONSUME 1
+#define __ATOMIC_RELAXED 0
+#define __ATOMIC_RELEASE 3
+#define __ATOMIC_SEQ_CST 5
+#define __BIGGEST_ALIGNMENT__ 16
+#define __BLOCKS__ 1
+#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __CHAR16_TYPE__ unsigned short
+#define __CHAR32_TYPE__ unsigned int
+#define __CHAR_BIT__ 8
+#define __CONSTANT_CFSTRINGS__ 1
+#define __DBL_DECIMAL_DIG__ 17
+#define __DBL_DENORM_MIN__ 4.9406564584124654e-324
+#define __DBL_DIG__ 15
+#define __DBL_EPSILON__ 2.2204460492503131e-16
+#define __DBL_HAS_DENORM__ 1
+#define __DBL_HAS_INFINITY__ 1
+#define __DBL_HAS_QUIET_NAN__ 1
+#define __DBL_MANT_DIG__ 53
+#define __DBL_MAX_10_EXP__ 308
+#define __DBL_MAX_EXP__ 1024
+#define __DBL_MAX__ 1.7976931348623157e+308
+#define __DBL_MIN_10_EXP__ (-307)
+#define __DBL_MIN_EXP__ (-1021)
+#define __DBL_MIN__ 2.2250738585072014e-308
+#define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
+#define __DEPRECATED 1
+#define __DYNAMIC__ 1
+#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101000
+#define __EXCEPTIONS 1
+#define __FINITE_MATH_ONLY__ 0
+#define __FLT_DECIMAL_DIG__ 9
+#define __FLT_DENORM_MIN__ 1.40129846e-45F
+#define __FLT_DIG__ 6
+#define __FLT_EPSILON__ 1.19209290e-7F
+#define __FLT_EVAL_METHOD__ 0
+#define __FLT_HAS_DENORM__ 1
+#define __FLT_HAS_INFINITY__ 1
+#define __FLT_HAS_QUIET_NAN__ 1
+#define __FLT_MANT_DIG__ 24
+#define __FLT_MAX_10_EXP__ 38
+#define __FLT_MAX_EXP__ 128
+#define __FLT_MAX__ 3.40282347e+38F
+#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT_MIN_EXP__ (-125)
+#define __FLT_MIN__ 1.17549435e-38F
+#define __FLT_RADIX__ 2
+#define __FXSR__ 1
+#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+#define __GCC_ATOMIC_INT_LOCK_FREE 2
+#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
+#define __GLIBCXX_BITSIZE_INT_N_0 128
+#define __GLIBCXX_TYPE_INT_N_0 __int128
+#define __GNUC_GNU_INLINE__ 1
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 1
+#define __GNUC__ 4
+#define __GNUG__ 4
+#define __GXX_ABI_VERSION 1002
+#define __GXX_EXPERIMENTAL_CXX0X__ 1
+#define __GXX_RTTI 1
+#define __GXX_WEAK__ 1
+#define __INT16_C_SUFFIX__ 
+#define __INT16_FMTd__ "hd"
+#define __INT16_FMTi__ "hi"
+#define __INT16_MAX__ 32767
+#define __INT16_TYPE__ short
+#define __INT32_C_SUFFIX__ 
+#define __INT32_FMTd__ "d"
+#define __INT32_FMTi__ "i"
+#define __INT32_MAX__ 2147483647
+#define __INT32_TYPE__ int
+#define __INT64_C_SUFFIX__ LL
+#define __INT64_FMTd__ "lld"
+#define __INT64_FMTi__ "lli"
+#define __INT64_MAX__ 9223372036854775807LL
+#define __INT64_TYPE__ long long int
+#define __INT8_C_SUFFIX__ 
+#define __INT8_FMTd__ "hhd"
+#define __INT8_FMTi__ "hhi"
+#define __INT8_MAX__ 127
+#define __INT8_TYPE__ signed char
+#define __INTMAX_C_SUFFIX__ L
+#define __INTMAX_FMTd__ "ld"
+#define __INTMAX_FMTi__ "li"
+#define __INTMAX_MAX__ 9223372036854775807L
+#define __INTMAX_TYPE__ long int
+#define __INTMAX_WIDTH__ 64
+#define __INTPTR_FMTd__ "ld"
+#define __INTPTR_FMTi__ "li"
+#define __INTPTR_MAX__ 9223372036854775807L
+#define __INTPTR_TYPE__ long int
+#define __INTPTR_WIDTH__ 64
+#define __INT_FAST16_FMTd__ "hd"
+#define __INT_FAST16_FMTi__ "hi"
+#define __INT_FAST16_MAX__ 32767
+#define __INT_FAST16_TYPE__ short
+#define __INT_FAST32_FMTd__ "d"
+#define __INT_FAST32_FMTi__ "i"
+#define __INT_FAST32_MAX__ 2147483647
+#define __INT_FAST32_TYPE__ int
+#define __INT_FAST64_FMTd__ "ld"
+#define __INT_FAST64_FMTi__ "li"
+#define __INT_FAST64_MAX__ 9223372036854775807L
+#define __INT_FAST64_TYPE__ long int
+#define __INT_FAST8_FMTd__ "hhd"
+#define __INT_FAST8_FMTi__ "hhi"
+#define __INT_FAST8_MAX__ 127
+#define __INT_FAST8_TYPE__ signed char
+#define __INT_LEAST16_FMTd__ "hd"
+#define __INT_LEAST16_FMTi__ "hi"
+#define __INT_LEAST16_MAX__ 32767
+#define __INT_LEAST16_TYPE__ short
+#define __INT_LEAST32_FMTd__ "d"
+#define __INT_LEAST32_FMTi__ "i"
+#define __INT_LEAST32_MAX__ 2147483647
+#define __INT_LEAST32_TYPE__ int
+#define __INT_LEAST64_FMTd__ "ld"
+#define __INT_LEAST64_FMTi__ "li"
+#define __INT_LEAST64_MAX__ 9223372036854775807L
+#define __INT_LEAST64_TYPE__ long int
+#define __INT_LEAST8_FMTd__ "hhd"
+#define __INT_LEAST8_FMTi__ "hhi"
+#define __INT_LEAST8_MAX__ 127
+#define __INT_LEAST8_TYPE__ signed char
+#define __INT_MAX__ 2147483647
+#define __LDBL_DECIMAL_DIG__ 21
+#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+#define __LDBL_DIG__ 18
+#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
+#define __LDBL_HAS_DENORM__ 1
+#define __LDBL_HAS_INFINITY__ 1
+#define __LDBL_HAS_QUIET_NAN__ 1
+#define __LDBL_MANT_DIG__ 64
+#define __LDBL_MAX_10_EXP__ 4932
+#define __LDBL_MAX_EXP__ 16384
+#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+#define __LDBL_MIN_10_EXP__ (-4931)
+#define __LDBL_MIN_EXP__ (-16381)
+#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+#define __LITTLE_ENDIAN__ 1
+#define __LONG_LONG_MAX__ 9223372036854775807LL
+#define __LONG_MAX__ 9223372036854775807L
+#define __LP64__ 1
+#define __MACH__ 1
+#define __MMX__ 1
+#define __NO_MATH_INLINES 1
+#define __OBJC_BOOL_IS_BOOL 0
+#define __OPTIMIZE__ 1
+#define __ORDER_BIG_ENDIAN__ 4321
+#define __ORDER_LITTLE_ENDIAN__ 1234
+#define __ORDER_PDP_ENDIAN__ 3412
+#define __PIC__ 2
+#define __POINTER_WIDTH__ 64
+#define __PRAGMA_REDEFINE_EXTNAME 1
+#define __PTRDIFF_FMTd__ "ld"
+#define __PTRDIFF_FMTi__ "li"
+#define __PTRDIFF_MAX__ 9223372036854775807L
+#define __PTRDIFF_TYPE__ long int
+#define __PTRDIFF_WIDTH__ 64
+#define __REGISTER_PREFIX__ 
+#define __SCHAR_MAX__ 127
+#define __SHRT_MAX__ 32767
+#define __SIG_ATOMIC_MAX__ 2147483647
+#define __SIG_ATOMIC_WIDTH__ 32
+#define __SIZEOF_DOUBLE__ 8
+#define __SIZEOF_FLOAT__ 4
+#define __SIZEOF_INT128__ 16
+#define __SIZEOF_INT__ 4
+#define __SIZEOF_LONG_DOUBLE__ 16
+#define __SIZEOF_LONG_LONG__ 8
+#define __SIZEOF_LONG__ 8
+#define __SIZEOF_POINTER__ 8
+#define __SIZEOF_PTRDIFF_T__ 8
+#define __SIZEOF_SHORT__ 2
+#define __SIZEOF_SIZE_T__ 8
+#define __SIZEOF_WCHAR_T__ 4
+#define __SIZEOF_WINT_T__ 4
+#define __SIZE_FMTX__ "lX"
+#define __SIZE_FMTo__ "lo"
+#define __SIZE_FMTu__ "lu"
+#define __SIZE_FMTx__ "lx"
+#define __SIZE_MAX__ 18446744073709551615UL
+#define __SIZE_TYPE__ long unsigned int
+#define __SIZE_WIDTH__ 64
+#define __SSE2_MATH__ 1
+#define __SSE2__ 1
+#define __SSE3__ 1
+#define __SSE_MATH__ 1
+#define __SSE__ 1
+#define __SSP__ 1
+#define __SSSE3__ 1
+#define __STDC_HOSTED__ 1
+#define __STDC_UTF_16__ 1
+#define __STDC_UTF_32__ 1
+#define __STDC__ 1
+#define __UINT16_C_SUFFIX__ 
+#define __UINT16_FMTX__ "hX"
+#define __UINT16_FMTo__ "ho"
+#define __UINT16_FMTu__ "hu"
+#define __UINT16_FMTx__ "hx"
+#define __UINT16_MAX__ 65535
+#define __UINT16_TYPE__ unsigned short
+#define __UINT32_C_SUFFIX__ U
+#define __UINT32_FMTX__ "X"
+#define __UINT32_FMTo__ "o"
+#define __UINT32_FMTu__ "u"
+#define __UINT32_FMTx__ "x"
+#define __UINT32_MAX__ 4294967295U
+#define __UINT32_TYPE__ unsigned int
+#define __UINT64_C_SUFFIX__ ULL
+#define __UINT64_FMTX__ "llX"
+#define __UINT64_FMTo__ "llo"
+#define __UINT64_FMTu__ "llu"
+#define __UINT64_FMTx__ "llx"
+#define __UINT64_MAX__ 18446744073709551615ULL
+#define __UINT64_TYPE__ long long unsigned int
+#define __UINT8_C_SUFFIX__ 
+#define __UINT8_FMTX__ "hhX"
+#define __UINT8_FMTo__ "hho"
+#define __UINT8_FMTu__ "hhu"
+#define __UINT8_FMTx__ "hhx"
+#define __UINT8_MAX__ 255
+#define __UINT8_TYPE__ unsigned char
+#define __UINTMAX_C_SUFFIX__ UL
+#define __UINTMAX_FMTX__ "lX"
+#define __UINTMAX_FMTo__ "lo"
+#define __UINTMAX_FMTu__ "lu"
+#define __UINTMAX_FMTx__ "lx"
+#define __UINTMAX_MAX__ 18446744073709551615UL
+#define __UINTMAX_TYPE__ long unsigned int
+#define __UINTMAX_WIDTH__ 64
+#define __UINTPTR_FMTX__ "lX"
+#define __UINTPTR_FMTo__ "lo"
+#define __UINTPTR_FMTu__ "lu"
+#define __UINTPTR_FMTx__ "lx"
+#define __UINTPTR_MAX__ 18446744073709551615UL
+#define __UINTPTR_TYPE__ long unsigned int
+#define __UINTPTR_WIDTH__ 64
+#define __UINT_FAST16_FMTX__ "hX"
+#define __UINT_FAST16_FMTo__ "ho"
+#define __UINT_FAST16_FMTu__ "hu"
+#define __UINT_FAST16_FMTx__ "hx"
+#define __UINT_FAST16_MAX__ 65535
+#define __UINT_FAST16_TYPE__ unsigned short
+#define __UINT_FAST32_FMTX__ "X"
+#define __UINT_FAST32_FMTo__ "o"
+#define __UINT_FAST32_FMTu__ "u"
+#define __UINT_FAST32_FMTx__ "x"
+#define __UINT_FAST32_MAX__ 4294967295U
+#define __UINT_FAST32_TYPE__ unsigned int
+#define __UINT_FAST64_FMTX__ "lX"
+#define __UINT_FAST64_FMTo__ "lo"
+#define __UINT_FAST64_FMTu__ "lu"
+#define __UINT_FAST64_FMTx__ "lx"
+#define __UINT_FAST64_MAX__ 18446744073709551615UL
+#define __UINT_FAST64_TYPE__ long unsigned int
+#define __UINT_FAST8_FMTX__ "hhX"
+#define __UINT_FAST8_FMTo__ "hho"
+#define __UINT_FAST8_FMTu__ "hhu"
+#define __UINT_FAST8_FMTx__ "hhx"
+#define __UINT_FAST8_MAX__ 255
+#define __UINT_FAST8_TYPE__ unsigned char
+#define __UINT_LEAST16_FMTX__ "hX"
+#define __UINT_LEAST16_FMTo__ "ho"
+#define __UINT_LEAST16_FMTu__ "hu"
+#define __UINT_LEAST16_FMTx__ "hx"
+#define __UINT_LEAST16_MAX__ 65535
+#define __UINT_LEAST16_TYPE__ unsigned short
+#define __UINT_LEAST32_FMTX__ "X"
+#define __UINT_LEAST32_FMTo__ "o"
+#define __UINT_LEAST32_FMTu__ "u"
+#define __UINT_LEAST32_FMTx__ "x"
+#define __UINT_LEAST32_MAX__ 4294967295U
+#define __UINT_LEAST32_TYPE__ unsigned int
+#define __UINT_LEAST64_FMTX__ "lX"
+#define __UINT_LEAST64_FMTo__ "lo"
+#define __UINT_LEAST64_FMTu__ "lu"
+#define __UINT_LEAST64_FMTx__ "lx"
+#define __UINT_LEAST64_MAX__ 18446744073709551615UL
+#define __UINT_LEAST64_TYPE__ long unsigned int
+#define __UINT_LEAST8_FMTX__ "hhX"
+#define __UINT_LEAST8_FMTo__ "hho"
+#define __UINT_LEAST8_FMTu__ "hhu"
+#define __UINT_LEAST8_FMTx__ "hhx"
+#define __UINT_LEAST8_MAX__ 255
+#define __UINT_LEAST8_TYPE__ unsigned char
+#define __USER_LABEL_PREFIX__ _
+#define __VERSION__ "4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)"
+#define __WCHAR_MAX__ 2147483647
+#define __WCHAR_TYPE__ int
+#define __WCHAR_WIDTH__ 32
+#define __WINT_TYPE__ int
+#define __WINT_WIDTH__ 32
+#define __amd64 1
+#define __amd64__ 1
+#define __apple_build_version__ 8020042
+#define __block __attribute__((__blocks__(byref)))
+#define __clang__ 1
+#define __clang_major__ 8
+#define __clang_minor__ 1
+#define __clang_patchlevel__ 0
+#define __clang_version__ "8.1.0 (clang-802.0.42)"
+#define __core2 1
+#define __core2__ 1
+#define __cplusplus 201103L
+#define __cpp_alias_templates 200704
+#define __cpp_attributes 200809
+#define __cpp_constexpr 200704
+#define __cpp_decltype 200707
+#define __cpp_delegating_constructors 200604
+#define __cpp_exceptions 199711
+#define __cpp_inheriting_constructors 200802
+#define __cpp_initializer_lists 200806
+#define __cpp_lambdas 200907
+#define __cpp_nsdmi 200809
+#define __cpp_range_based_for 200907
+#define __cpp_raw_strings 200710
+#define __cpp_ref_qualifiers 200710
+#define __cpp_rtti 199711
+#define __cpp_rvalue_references 200610
+#define __cpp_static_assert 200410
+#define __cpp_unicode_characters 200704
+#define __cpp_unicode_literals 200710
+#define __cpp_user_defined_literals 200809
+#define __cpp_variadic_templates 200704
+#define __llvm__ 1
+#define __nonnull _Nonnull
+#define __null_unspecified _Null_unspecified
+#define __nullable _Nullable
+#define __pic__ 2
+#define __private_extern__ extern
+#define __strong 
+#define __tune_core2__ 1
+#define __unsafe_unretained 
+#define __weak __attribute__((objc_gc(weak)))
+#define __x86_64 1
+#define __x86_64__ 1

--- a/src/plugins/json/moc_predefs.h
+++ b/src/plugins/json/moc_predefs.h
@@ -1,0 +1,357 @@
+#define OBJC_NEW_PROPERTIES 1
+#define _LP64 1
+#define __APPLE_CC__ 6000
+#define __APPLE__ 1
+#define __ATOMIC_ACQUIRE 2
+#define __ATOMIC_ACQ_REL 4
+#define __ATOMIC_CONSUME 1
+#define __ATOMIC_RELAXED 0
+#define __ATOMIC_RELEASE 3
+#define __ATOMIC_SEQ_CST 5
+#define __BIGGEST_ALIGNMENT__ 16
+#define __BLOCKS__ 1
+#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __CHAR16_TYPE__ unsigned short
+#define __CHAR32_TYPE__ unsigned int
+#define __CHAR_BIT__ 8
+#define __CONSTANT_CFSTRINGS__ 1
+#define __DBL_DECIMAL_DIG__ 17
+#define __DBL_DENORM_MIN__ 4.9406564584124654e-324
+#define __DBL_DIG__ 15
+#define __DBL_EPSILON__ 2.2204460492503131e-16
+#define __DBL_HAS_DENORM__ 1
+#define __DBL_HAS_INFINITY__ 1
+#define __DBL_HAS_QUIET_NAN__ 1
+#define __DBL_MANT_DIG__ 53
+#define __DBL_MAX_10_EXP__ 308
+#define __DBL_MAX_EXP__ 1024
+#define __DBL_MAX__ 1.7976931348623157e+308
+#define __DBL_MIN_10_EXP__ (-307)
+#define __DBL_MIN_EXP__ (-1021)
+#define __DBL_MIN__ 2.2250738585072014e-308
+#define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
+#define __DEPRECATED 1
+#define __DYNAMIC__ 1
+#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101000
+#define __EXCEPTIONS 1
+#define __FINITE_MATH_ONLY__ 0
+#define __FLT_DECIMAL_DIG__ 9
+#define __FLT_DENORM_MIN__ 1.40129846e-45F
+#define __FLT_DIG__ 6
+#define __FLT_EPSILON__ 1.19209290e-7F
+#define __FLT_EVAL_METHOD__ 0
+#define __FLT_HAS_DENORM__ 1
+#define __FLT_HAS_INFINITY__ 1
+#define __FLT_HAS_QUIET_NAN__ 1
+#define __FLT_MANT_DIG__ 24
+#define __FLT_MAX_10_EXP__ 38
+#define __FLT_MAX_EXP__ 128
+#define __FLT_MAX__ 3.40282347e+38F
+#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT_MIN_EXP__ (-125)
+#define __FLT_MIN__ 1.17549435e-38F
+#define __FLT_RADIX__ 2
+#define __FXSR__ 1
+#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+#define __GCC_ATOMIC_INT_LOCK_FREE 2
+#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
+#define __GLIBCXX_BITSIZE_INT_N_0 128
+#define __GLIBCXX_TYPE_INT_N_0 __int128
+#define __GNUC_GNU_INLINE__ 1
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 1
+#define __GNUC__ 4
+#define __GNUG__ 4
+#define __GXX_ABI_VERSION 1002
+#define __GXX_EXPERIMENTAL_CXX0X__ 1
+#define __GXX_RTTI 1
+#define __GXX_WEAK__ 1
+#define __INT16_C_SUFFIX__ 
+#define __INT16_FMTd__ "hd"
+#define __INT16_FMTi__ "hi"
+#define __INT16_MAX__ 32767
+#define __INT16_TYPE__ short
+#define __INT32_C_SUFFIX__ 
+#define __INT32_FMTd__ "d"
+#define __INT32_FMTi__ "i"
+#define __INT32_MAX__ 2147483647
+#define __INT32_TYPE__ int
+#define __INT64_C_SUFFIX__ LL
+#define __INT64_FMTd__ "lld"
+#define __INT64_FMTi__ "lli"
+#define __INT64_MAX__ 9223372036854775807LL
+#define __INT64_TYPE__ long long int
+#define __INT8_C_SUFFIX__ 
+#define __INT8_FMTd__ "hhd"
+#define __INT8_FMTi__ "hhi"
+#define __INT8_MAX__ 127
+#define __INT8_TYPE__ signed char
+#define __INTMAX_C_SUFFIX__ L
+#define __INTMAX_FMTd__ "ld"
+#define __INTMAX_FMTi__ "li"
+#define __INTMAX_MAX__ 9223372036854775807L
+#define __INTMAX_TYPE__ long int
+#define __INTMAX_WIDTH__ 64
+#define __INTPTR_FMTd__ "ld"
+#define __INTPTR_FMTi__ "li"
+#define __INTPTR_MAX__ 9223372036854775807L
+#define __INTPTR_TYPE__ long int
+#define __INTPTR_WIDTH__ 64
+#define __INT_FAST16_FMTd__ "hd"
+#define __INT_FAST16_FMTi__ "hi"
+#define __INT_FAST16_MAX__ 32767
+#define __INT_FAST16_TYPE__ short
+#define __INT_FAST32_FMTd__ "d"
+#define __INT_FAST32_FMTi__ "i"
+#define __INT_FAST32_MAX__ 2147483647
+#define __INT_FAST32_TYPE__ int
+#define __INT_FAST64_FMTd__ "ld"
+#define __INT_FAST64_FMTi__ "li"
+#define __INT_FAST64_MAX__ 9223372036854775807L
+#define __INT_FAST64_TYPE__ long int
+#define __INT_FAST8_FMTd__ "hhd"
+#define __INT_FAST8_FMTi__ "hhi"
+#define __INT_FAST8_MAX__ 127
+#define __INT_FAST8_TYPE__ signed char
+#define __INT_LEAST16_FMTd__ "hd"
+#define __INT_LEAST16_FMTi__ "hi"
+#define __INT_LEAST16_MAX__ 32767
+#define __INT_LEAST16_TYPE__ short
+#define __INT_LEAST32_FMTd__ "d"
+#define __INT_LEAST32_FMTi__ "i"
+#define __INT_LEAST32_MAX__ 2147483647
+#define __INT_LEAST32_TYPE__ int
+#define __INT_LEAST64_FMTd__ "ld"
+#define __INT_LEAST64_FMTi__ "li"
+#define __INT_LEAST64_MAX__ 9223372036854775807L
+#define __INT_LEAST64_TYPE__ long int
+#define __INT_LEAST8_FMTd__ "hhd"
+#define __INT_LEAST8_FMTi__ "hhi"
+#define __INT_LEAST8_MAX__ 127
+#define __INT_LEAST8_TYPE__ signed char
+#define __INT_MAX__ 2147483647
+#define __LDBL_DECIMAL_DIG__ 21
+#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+#define __LDBL_DIG__ 18
+#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
+#define __LDBL_HAS_DENORM__ 1
+#define __LDBL_HAS_INFINITY__ 1
+#define __LDBL_HAS_QUIET_NAN__ 1
+#define __LDBL_MANT_DIG__ 64
+#define __LDBL_MAX_10_EXP__ 4932
+#define __LDBL_MAX_EXP__ 16384
+#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+#define __LDBL_MIN_10_EXP__ (-4931)
+#define __LDBL_MIN_EXP__ (-16381)
+#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+#define __LITTLE_ENDIAN__ 1
+#define __LONG_LONG_MAX__ 9223372036854775807LL
+#define __LONG_MAX__ 9223372036854775807L
+#define __LP64__ 1
+#define __MACH__ 1
+#define __MMX__ 1
+#define __NO_MATH_INLINES 1
+#define __OBJC_BOOL_IS_BOOL 0
+#define __OPTIMIZE__ 1
+#define __ORDER_BIG_ENDIAN__ 4321
+#define __ORDER_LITTLE_ENDIAN__ 1234
+#define __ORDER_PDP_ENDIAN__ 3412
+#define __PIC__ 2
+#define __POINTER_WIDTH__ 64
+#define __PRAGMA_REDEFINE_EXTNAME 1
+#define __PTRDIFF_FMTd__ "ld"
+#define __PTRDIFF_FMTi__ "li"
+#define __PTRDIFF_MAX__ 9223372036854775807L
+#define __PTRDIFF_TYPE__ long int
+#define __PTRDIFF_WIDTH__ 64
+#define __REGISTER_PREFIX__ 
+#define __SCHAR_MAX__ 127
+#define __SHRT_MAX__ 32767
+#define __SIG_ATOMIC_MAX__ 2147483647
+#define __SIG_ATOMIC_WIDTH__ 32
+#define __SIZEOF_DOUBLE__ 8
+#define __SIZEOF_FLOAT__ 4
+#define __SIZEOF_INT128__ 16
+#define __SIZEOF_INT__ 4
+#define __SIZEOF_LONG_DOUBLE__ 16
+#define __SIZEOF_LONG_LONG__ 8
+#define __SIZEOF_LONG__ 8
+#define __SIZEOF_POINTER__ 8
+#define __SIZEOF_PTRDIFF_T__ 8
+#define __SIZEOF_SHORT__ 2
+#define __SIZEOF_SIZE_T__ 8
+#define __SIZEOF_WCHAR_T__ 4
+#define __SIZEOF_WINT_T__ 4
+#define __SIZE_FMTX__ "lX"
+#define __SIZE_FMTo__ "lo"
+#define __SIZE_FMTu__ "lu"
+#define __SIZE_FMTx__ "lx"
+#define __SIZE_MAX__ 18446744073709551615UL
+#define __SIZE_TYPE__ long unsigned int
+#define __SIZE_WIDTH__ 64
+#define __SSE2_MATH__ 1
+#define __SSE2__ 1
+#define __SSE3__ 1
+#define __SSE_MATH__ 1
+#define __SSE__ 1
+#define __SSP__ 1
+#define __SSSE3__ 1
+#define __STDC_HOSTED__ 1
+#define __STDC_UTF_16__ 1
+#define __STDC_UTF_32__ 1
+#define __STDC__ 1
+#define __UINT16_C_SUFFIX__ 
+#define __UINT16_FMTX__ "hX"
+#define __UINT16_FMTo__ "ho"
+#define __UINT16_FMTu__ "hu"
+#define __UINT16_FMTx__ "hx"
+#define __UINT16_MAX__ 65535
+#define __UINT16_TYPE__ unsigned short
+#define __UINT32_C_SUFFIX__ U
+#define __UINT32_FMTX__ "X"
+#define __UINT32_FMTo__ "o"
+#define __UINT32_FMTu__ "u"
+#define __UINT32_FMTx__ "x"
+#define __UINT32_MAX__ 4294967295U
+#define __UINT32_TYPE__ unsigned int
+#define __UINT64_C_SUFFIX__ ULL
+#define __UINT64_FMTX__ "llX"
+#define __UINT64_FMTo__ "llo"
+#define __UINT64_FMTu__ "llu"
+#define __UINT64_FMTx__ "llx"
+#define __UINT64_MAX__ 18446744073709551615ULL
+#define __UINT64_TYPE__ long long unsigned int
+#define __UINT8_C_SUFFIX__ 
+#define __UINT8_FMTX__ "hhX"
+#define __UINT8_FMTo__ "hho"
+#define __UINT8_FMTu__ "hhu"
+#define __UINT8_FMTx__ "hhx"
+#define __UINT8_MAX__ 255
+#define __UINT8_TYPE__ unsigned char
+#define __UINTMAX_C_SUFFIX__ UL
+#define __UINTMAX_FMTX__ "lX"
+#define __UINTMAX_FMTo__ "lo"
+#define __UINTMAX_FMTu__ "lu"
+#define __UINTMAX_FMTx__ "lx"
+#define __UINTMAX_MAX__ 18446744073709551615UL
+#define __UINTMAX_TYPE__ long unsigned int
+#define __UINTMAX_WIDTH__ 64
+#define __UINTPTR_FMTX__ "lX"
+#define __UINTPTR_FMTo__ "lo"
+#define __UINTPTR_FMTu__ "lu"
+#define __UINTPTR_FMTx__ "lx"
+#define __UINTPTR_MAX__ 18446744073709551615UL
+#define __UINTPTR_TYPE__ long unsigned int
+#define __UINTPTR_WIDTH__ 64
+#define __UINT_FAST16_FMTX__ "hX"
+#define __UINT_FAST16_FMTo__ "ho"
+#define __UINT_FAST16_FMTu__ "hu"
+#define __UINT_FAST16_FMTx__ "hx"
+#define __UINT_FAST16_MAX__ 65535
+#define __UINT_FAST16_TYPE__ unsigned short
+#define __UINT_FAST32_FMTX__ "X"
+#define __UINT_FAST32_FMTo__ "o"
+#define __UINT_FAST32_FMTu__ "u"
+#define __UINT_FAST32_FMTx__ "x"
+#define __UINT_FAST32_MAX__ 4294967295U
+#define __UINT_FAST32_TYPE__ unsigned int
+#define __UINT_FAST64_FMTX__ "lX"
+#define __UINT_FAST64_FMTo__ "lo"
+#define __UINT_FAST64_FMTu__ "lu"
+#define __UINT_FAST64_FMTx__ "lx"
+#define __UINT_FAST64_MAX__ 18446744073709551615UL
+#define __UINT_FAST64_TYPE__ long unsigned int
+#define __UINT_FAST8_FMTX__ "hhX"
+#define __UINT_FAST8_FMTo__ "hho"
+#define __UINT_FAST8_FMTu__ "hhu"
+#define __UINT_FAST8_FMTx__ "hhx"
+#define __UINT_FAST8_MAX__ 255
+#define __UINT_FAST8_TYPE__ unsigned char
+#define __UINT_LEAST16_FMTX__ "hX"
+#define __UINT_LEAST16_FMTo__ "ho"
+#define __UINT_LEAST16_FMTu__ "hu"
+#define __UINT_LEAST16_FMTx__ "hx"
+#define __UINT_LEAST16_MAX__ 65535
+#define __UINT_LEAST16_TYPE__ unsigned short
+#define __UINT_LEAST32_FMTX__ "X"
+#define __UINT_LEAST32_FMTo__ "o"
+#define __UINT_LEAST32_FMTu__ "u"
+#define __UINT_LEAST32_FMTx__ "x"
+#define __UINT_LEAST32_MAX__ 4294967295U
+#define __UINT_LEAST32_TYPE__ unsigned int
+#define __UINT_LEAST64_FMTX__ "lX"
+#define __UINT_LEAST64_FMTo__ "lo"
+#define __UINT_LEAST64_FMTu__ "lu"
+#define __UINT_LEAST64_FMTx__ "lx"
+#define __UINT_LEAST64_MAX__ 18446744073709551615UL
+#define __UINT_LEAST64_TYPE__ long unsigned int
+#define __UINT_LEAST8_FMTX__ "hhX"
+#define __UINT_LEAST8_FMTo__ "hho"
+#define __UINT_LEAST8_FMTu__ "hhu"
+#define __UINT_LEAST8_FMTx__ "hhx"
+#define __UINT_LEAST8_MAX__ 255
+#define __UINT_LEAST8_TYPE__ unsigned char
+#define __USER_LABEL_PREFIX__ _
+#define __VERSION__ "4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)"
+#define __WCHAR_MAX__ 2147483647
+#define __WCHAR_TYPE__ int
+#define __WCHAR_WIDTH__ 32
+#define __WINT_TYPE__ int
+#define __WINT_WIDTH__ 32
+#define __amd64 1
+#define __amd64__ 1
+#define __apple_build_version__ 8020042
+#define __block __attribute__((__blocks__(byref)))
+#define __clang__ 1
+#define __clang_major__ 8
+#define __clang_minor__ 1
+#define __clang_patchlevel__ 0
+#define __clang_version__ "8.1.0 (clang-802.0.42)"
+#define __core2 1
+#define __core2__ 1
+#define __cplusplus 201103L
+#define __cpp_alias_templates 200704
+#define __cpp_attributes 200809
+#define __cpp_constexpr 200704
+#define __cpp_decltype 200707
+#define __cpp_delegating_constructors 200604
+#define __cpp_exceptions 199711
+#define __cpp_inheriting_constructors 200802
+#define __cpp_initializer_lists 200806
+#define __cpp_lambdas 200907
+#define __cpp_nsdmi 200809
+#define __cpp_range_based_for 200907
+#define __cpp_raw_strings 200710
+#define __cpp_ref_qualifiers 200710
+#define __cpp_rtti 199711
+#define __cpp_rvalue_references 200610
+#define __cpp_static_assert 200410
+#define __cpp_unicode_characters 200704
+#define __cpp_unicode_literals 200710
+#define __cpp_user_defined_literals 200809
+#define __cpp_variadic_templates 200704
+#define __llvm__ 1
+#define __nonnull _Nonnull
+#define __null_unspecified _Null_unspecified
+#define __nullable _Nullable
+#define __pic__ 2
+#define __private_extern__ extern
+#define __strong 
+#define __tune_core2__ 1
+#define __unsafe_unretained 
+#define __weak __attribute__((objc_gc(weak)))
+#define __x86_64 1
+#define __x86_64__ 1

--- a/src/plugins/lua/moc_predefs.h
+++ b/src/plugins/lua/moc_predefs.h
@@ -1,0 +1,357 @@
+#define OBJC_NEW_PROPERTIES 1
+#define _LP64 1
+#define __APPLE_CC__ 6000
+#define __APPLE__ 1
+#define __ATOMIC_ACQUIRE 2
+#define __ATOMIC_ACQ_REL 4
+#define __ATOMIC_CONSUME 1
+#define __ATOMIC_RELAXED 0
+#define __ATOMIC_RELEASE 3
+#define __ATOMIC_SEQ_CST 5
+#define __BIGGEST_ALIGNMENT__ 16
+#define __BLOCKS__ 1
+#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __CHAR16_TYPE__ unsigned short
+#define __CHAR32_TYPE__ unsigned int
+#define __CHAR_BIT__ 8
+#define __CONSTANT_CFSTRINGS__ 1
+#define __DBL_DECIMAL_DIG__ 17
+#define __DBL_DENORM_MIN__ 4.9406564584124654e-324
+#define __DBL_DIG__ 15
+#define __DBL_EPSILON__ 2.2204460492503131e-16
+#define __DBL_HAS_DENORM__ 1
+#define __DBL_HAS_INFINITY__ 1
+#define __DBL_HAS_QUIET_NAN__ 1
+#define __DBL_MANT_DIG__ 53
+#define __DBL_MAX_10_EXP__ 308
+#define __DBL_MAX_EXP__ 1024
+#define __DBL_MAX__ 1.7976931348623157e+308
+#define __DBL_MIN_10_EXP__ (-307)
+#define __DBL_MIN_EXP__ (-1021)
+#define __DBL_MIN__ 2.2250738585072014e-308
+#define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
+#define __DEPRECATED 1
+#define __DYNAMIC__ 1
+#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101000
+#define __EXCEPTIONS 1
+#define __FINITE_MATH_ONLY__ 0
+#define __FLT_DECIMAL_DIG__ 9
+#define __FLT_DENORM_MIN__ 1.40129846e-45F
+#define __FLT_DIG__ 6
+#define __FLT_EPSILON__ 1.19209290e-7F
+#define __FLT_EVAL_METHOD__ 0
+#define __FLT_HAS_DENORM__ 1
+#define __FLT_HAS_INFINITY__ 1
+#define __FLT_HAS_QUIET_NAN__ 1
+#define __FLT_MANT_DIG__ 24
+#define __FLT_MAX_10_EXP__ 38
+#define __FLT_MAX_EXP__ 128
+#define __FLT_MAX__ 3.40282347e+38F
+#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT_MIN_EXP__ (-125)
+#define __FLT_MIN__ 1.17549435e-38F
+#define __FLT_RADIX__ 2
+#define __FXSR__ 1
+#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+#define __GCC_ATOMIC_INT_LOCK_FREE 2
+#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
+#define __GLIBCXX_BITSIZE_INT_N_0 128
+#define __GLIBCXX_TYPE_INT_N_0 __int128
+#define __GNUC_GNU_INLINE__ 1
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 1
+#define __GNUC__ 4
+#define __GNUG__ 4
+#define __GXX_ABI_VERSION 1002
+#define __GXX_EXPERIMENTAL_CXX0X__ 1
+#define __GXX_RTTI 1
+#define __GXX_WEAK__ 1
+#define __INT16_C_SUFFIX__ 
+#define __INT16_FMTd__ "hd"
+#define __INT16_FMTi__ "hi"
+#define __INT16_MAX__ 32767
+#define __INT16_TYPE__ short
+#define __INT32_C_SUFFIX__ 
+#define __INT32_FMTd__ "d"
+#define __INT32_FMTi__ "i"
+#define __INT32_MAX__ 2147483647
+#define __INT32_TYPE__ int
+#define __INT64_C_SUFFIX__ LL
+#define __INT64_FMTd__ "lld"
+#define __INT64_FMTi__ "lli"
+#define __INT64_MAX__ 9223372036854775807LL
+#define __INT64_TYPE__ long long int
+#define __INT8_C_SUFFIX__ 
+#define __INT8_FMTd__ "hhd"
+#define __INT8_FMTi__ "hhi"
+#define __INT8_MAX__ 127
+#define __INT8_TYPE__ signed char
+#define __INTMAX_C_SUFFIX__ L
+#define __INTMAX_FMTd__ "ld"
+#define __INTMAX_FMTi__ "li"
+#define __INTMAX_MAX__ 9223372036854775807L
+#define __INTMAX_TYPE__ long int
+#define __INTMAX_WIDTH__ 64
+#define __INTPTR_FMTd__ "ld"
+#define __INTPTR_FMTi__ "li"
+#define __INTPTR_MAX__ 9223372036854775807L
+#define __INTPTR_TYPE__ long int
+#define __INTPTR_WIDTH__ 64
+#define __INT_FAST16_FMTd__ "hd"
+#define __INT_FAST16_FMTi__ "hi"
+#define __INT_FAST16_MAX__ 32767
+#define __INT_FAST16_TYPE__ short
+#define __INT_FAST32_FMTd__ "d"
+#define __INT_FAST32_FMTi__ "i"
+#define __INT_FAST32_MAX__ 2147483647
+#define __INT_FAST32_TYPE__ int
+#define __INT_FAST64_FMTd__ "ld"
+#define __INT_FAST64_FMTi__ "li"
+#define __INT_FAST64_MAX__ 9223372036854775807L
+#define __INT_FAST64_TYPE__ long int
+#define __INT_FAST8_FMTd__ "hhd"
+#define __INT_FAST8_FMTi__ "hhi"
+#define __INT_FAST8_MAX__ 127
+#define __INT_FAST8_TYPE__ signed char
+#define __INT_LEAST16_FMTd__ "hd"
+#define __INT_LEAST16_FMTi__ "hi"
+#define __INT_LEAST16_MAX__ 32767
+#define __INT_LEAST16_TYPE__ short
+#define __INT_LEAST32_FMTd__ "d"
+#define __INT_LEAST32_FMTi__ "i"
+#define __INT_LEAST32_MAX__ 2147483647
+#define __INT_LEAST32_TYPE__ int
+#define __INT_LEAST64_FMTd__ "ld"
+#define __INT_LEAST64_FMTi__ "li"
+#define __INT_LEAST64_MAX__ 9223372036854775807L
+#define __INT_LEAST64_TYPE__ long int
+#define __INT_LEAST8_FMTd__ "hhd"
+#define __INT_LEAST8_FMTi__ "hhi"
+#define __INT_LEAST8_MAX__ 127
+#define __INT_LEAST8_TYPE__ signed char
+#define __INT_MAX__ 2147483647
+#define __LDBL_DECIMAL_DIG__ 21
+#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+#define __LDBL_DIG__ 18
+#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
+#define __LDBL_HAS_DENORM__ 1
+#define __LDBL_HAS_INFINITY__ 1
+#define __LDBL_HAS_QUIET_NAN__ 1
+#define __LDBL_MANT_DIG__ 64
+#define __LDBL_MAX_10_EXP__ 4932
+#define __LDBL_MAX_EXP__ 16384
+#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+#define __LDBL_MIN_10_EXP__ (-4931)
+#define __LDBL_MIN_EXP__ (-16381)
+#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+#define __LITTLE_ENDIAN__ 1
+#define __LONG_LONG_MAX__ 9223372036854775807LL
+#define __LONG_MAX__ 9223372036854775807L
+#define __LP64__ 1
+#define __MACH__ 1
+#define __MMX__ 1
+#define __NO_MATH_INLINES 1
+#define __OBJC_BOOL_IS_BOOL 0
+#define __OPTIMIZE__ 1
+#define __ORDER_BIG_ENDIAN__ 4321
+#define __ORDER_LITTLE_ENDIAN__ 1234
+#define __ORDER_PDP_ENDIAN__ 3412
+#define __PIC__ 2
+#define __POINTER_WIDTH__ 64
+#define __PRAGMA_REDEFINE_EXTNAME 1
+#define __PTRDIFF_FMTd__ "ld"
+#define __PTRDIFF_FMTi__ "li"
+#define __PTRDIFF_MAX__ 9223372036854775807L
+#define __PTRDIFF_TYPE__ long int
+#define __PTRDIFF_WIDTH__ 64
+#define __REGISTER_PREFIX__ 
+#define __SCHAR_MAX__ 127
+#define __SHRT_MAX__ 32767
+#define __SIG_ATOMIC_MAX__ 2147483647
+#define __SIG_ATOMIC_WIDTH__ 32
+#define __SIZEOF_DOUBLE__ 8
+#define __SIZEOF_FLOAT__ 4
+#define __SIZEOF_INT128__ 16
+#define __SIZEOF_INT__ 4
+#define __SIZEOF_LONG_DOUBLE__ 16
+#define __SIZEOF_LONG_LONG__ 8
+#define __SIZEOF_LONG__ 8
+#define __SIZEOF_POINTER__ 8
+#define __SIZEOF_PTRDIFF_T__ 8
+#define __SIZEOF_SHORT__ 2
+#define __SIZEOF_SIZE_T__ 8
+#define __SIZEOF_WCHAR_T__ 4
+#define __SIZEOF_WINT_T__ 4
+#define __SIZE_FMTX__ "lX"
+#define __SIZE_FMTo__ "lo"
+#define __SIZE_FMTu__ "lu"
+#define __SIZE_FMTx__ "lx"
+#define __SIZE_MAX__ 18446744073709551615UL
+#define __SIZE_TYPE__ long unsigned int
+#define __SIZE_WIDTH__ 64
+#define __SSE2_MATH__ 1
+#define __SSE2__ 1
+#define __SSE3__ 1
+#define __SSE_MATH__ 1
+#define __SSE__ 1
+#define __SSP__ 1
+#define __SSSE3__ 1
+#define __STDC_HOSTED__ 1
+#define __STDC_UTF_16__ 1
+#define __STDC_UTF_32__ 1
+#define __STDC__ 1
+#define __UINT16_C_SUFFIX__ 
+#define __UINT16_FMTX__ "hX"
+#define __UINT16_FMTo__ "ho"
+#define __UINT16_FMTu__ "hu"
+#define __UINT16_FMTx__ "hx"
+#define __UINT16_MAX__ 65535
+#define __UINT16_TYPE__ unsigned short
+#define __UINT32_C_SUFFIX__ U
+#define __UINT32_FMTX__ "X"
+#define __UINT32_FMTo__ "o"
+#define __UINT32_FMTu__ "u"
+#define __UINT32_FMTx__ "x"
+#define __UINT32_MAX__ 4294967295U
+#define __UINT32_TYPE__ unsigned int
+#define __UINT64_C_SUFFIX__ ULL
+#define __UINT64_FMTX__ "llX"
+#define __UINT64_FMTo__ "llo"
+#define __UINT64_FMTu__ "llu"
+#define __UINT64_FMTx__ "llx"
+#define __UINT64_MAX__ 18446744073709551615ULL
+#define __UINT64_TYPE__ long long unsigned int
+#define __UINT8_C_SUFFIX__ 
+#define __UINT8_FMTX__ "hhX"
+#define __UINT8_FMTo__ "hho"
+#define __UINT8_FMTu__ "hhu"
+#define __UINT8_FMTx__ "hhx"
+#define __UINT8_MAX__ 255
+#define __UINT8_TYPE__ unsigned char
+#define __UINTMAX_C_SUFFIX__ UL
+#define __UINTMAX_FMTX__ "lX"
+#define __UINTMAX_FMTo__ "lo"
+#define __UINTMAX_FMTu__ "lu"
+#define __UINTMAX_FMTx__ "lx"
+#define __UINTMAX_MAX__ 18446744073709551615UL
+#define __UINTMAX_TYPE__ long unsigned int
+#define __UINTMAX_WIDTH__ 64
+#define __UINTPTR_FMTX__ "lX"
+#define __UINTPTR_FMTo__ "lo"
+#define __UINTPTR_FMTu__ "lu"
+#define __UINTPTR_FMTx__ "lx"
+#define __UINTPTR_MAX__ 18446744073709551615UL
+#define __UINTPTR_TYPE__ long unsigned int
+#define __UINTPTR_WIDTH__ 64
+#define __UINT_FAST16_FMTX__ "hX"
+#define __UINT_FAST16_FMTo__ "ho"
+#define __UINT_FAST16_FMTu__ "hu"
+#define __UINT_FAST16_FMTx__ "hx"
+#define __UINT_FAST16_MAX__ 65535
+#define __UINT_FAST16_TYPE__ unsigned short
+#define __UINT_FAST32_FMTX__ "X"
+#define __UINT_FAST32_FMTo__ "o"
+#define __UINT_FAST32_FMTu__ "u"
+#define __UINT_FAST32_FMTx__ "x"
+#define __UINT_FAST32_MAX__ 4294967295U
+#define __UINT_FAST32_TYPE__ unsigned int
+#define __UINT_FAST64_FMTX__ "lX"
+#define __UINT_FAST64_FMTo__ "lo"
+#define __UINT_FAST64_FMTu__ "lu"
+#define __UINT_FAST64_FMTx__ "lx"
+#define __UINT_FAST64_MAX__ 18446744073709551615UL
+#define __UINT_FAST64_TYPE__ long unsigned int
+#define __UINT_FAST8_FMTX__ "hhX"
+#define __UINT_FAST8_FMTo__ "hho"
+#define __UINT_FAST8_FMTu__ "hhu"
+#define __UINT_FAST8_FMTx__ "hhx"
+#define __UINT_FAST8_MAX__ 255
+#define __UINT_FAST8_TYPE__ unsigned char
+#define __UINT_LEAST16_FMTX__ "hX"
+#define __UINT_LEAST16_FMTo__ "ho"
+#define __UINT_LEAST16_FMTu__ "hu"
+#define __UINT_LEAST16_FMTx__ "hx"
+#define __UINT_LEAST16_MAX__ 65535
+#define __UINT_LEAST16_TYPE__ unsigned short
+#define __UINT_LEAST32_FMTX__ "X"
+#define __UINT_LEAST32_FMTo__ "o"
+#define __UINT_LEAST32_FMTu__ "u"
+#define __UINT_LEAST32_FMTx__ "x"
+#define __UINT_LEAST32_MAX__ 4294967295U
+#define __UINT_LEAST32_TYPE__ unsigned int
+#define __UINT_LEAST64_FMTX__ "lX"
+#define __UINT_LEAST64_FMTo__ "lo"
+#define __UINT_LEAST64_FMTu__ "lu"
+#define __UINT_LEAST64_FMTx__ "lx"
+#define __UINT_LEAST64_MAX__ 18446744073709551615UL
+#define __UINT_LEAST64_TYPE__ long unsigned int
+#define __UINT_LEAST8_FMTX__ "hhX"
+#define __UINT_LEAST8_FMTo__ "hho"
+#define __UINT_LEAST8_FMTu__ "hhu"
+#define __UINT_LEAST8_FMTx__ "hhx"
+#define __UINT_LEAST8_MAX__ 255
+#define __UINT_LEAST8_TYPE__ unsigned char
+#define __USER_LABEL_PREFIX__ _
+#define __VERSION__ "4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)"
+#define __WCHAR_MAX__ 2147483647
+#define __WCHAR_TYPE__ int
+#define __WCHAR_WIDTH__ 32
+#define __WINT_TYPE__ int
+#define __WINT_WIDTH__ 32
+#define __amd64 1
+#define __amd64__ 1
+#define __apple_build_version__ 8020042
+#define __block __attribute__((__blocks__(byref)))
+#define __clang__ 1
+#define __clang_major__ 8
+#define __clang_minor__ 1
+#define __clang_patchlevel__ 0
+#define __clang_version__ "8.1.0 (clang-802.0.42)"
+#define __core2 1
+#define __core2__ 1
+#define __cplusplus 201103L
+#define __cpp_alias_templates 200704
+#define __cpp_attributes 200809
+#define __cpp_constexpr 200704
+#define __cpp_decltype 200707
+#define __cpp_delegating_constructors 200604
+#define __cpp_exceptions 199711
+#define __cpp_inheriting_constructors 200802
+#define __cpp_initializer_lists 200806
+#define __cpp_lambdas 200907
+#define __cpp_nsdmi 200809
+#define __cpp_range_based_for 200907
+#define __cpp_raw_strings 200710
+#define __cpp_ref_qualifiers 200710
+#define __cpp_rtti 199711
+#define __cpp_rvalue_references 200610
+#define __cpp_static_assert 200410
+#define __cpp_unicode_characters 200704
+#define __cpp_unicode_literals 200710
+#define __cpp_user_defined_literals 200809
+#define __cpp_variadic_templates 200704
+#define __llvm__ 1
+#define __nonnull _Nonnull
+#define __null_unspecified _Null_unspecified
+#define __nullable _Nullable
+#define __pic__ 2
+#define __private_extern__ extern
+#define __strong 
+#define __tune_core2__ 1
+#define __unsafe_unretained 
+#define __weak __attribute__((objc_gc(weak)))
+#define __x86_64 1
+#define __x86_64__ 1

--- a/src/plugins/python/moc_predefs.h
+++ b/src/plugins/python/moc_predefs.h
@@ -1,0 +1,357 @@
+#define OBJC_NEW_PROPERTIES 1
+#define _LP64 1
+#define __APPLE_CC__ 6000
+#define __APPLE__ 1
+#define __ATOMIC_ACQUIRE 2
+#define __ATOMIC_ACQ_REL 4
+#define __ATOMIC_CONSUME 1
+#define __ATOMIC_RELAXED 0
+#define __ATOMIC_RELEASE 3
+#define __ATOMIC_SEQ_CST 5
+#define __BIGGEST_ALIGNMENT__ 16
+#define __BLOCKS__ 1
+#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __CHAR16_TYPE__ unsigned short
+#define __CHAR32_TYPE__ unsigned int
+#define __CHAR_BIT__ 8
+#define __CONSTANT_CFSTRINGS__ 1
+#define __DBL_DECIMAL_DIG__ 17
+#define __DBL_DENORM_MIN__ 4.9406564584124654e-324
+#define __DBL_DIG__ 15
+#define __DBL_EPSILON__ 2.2204460492503131e-16
+#define __DBL_HAS_DENORM__ 1
+#define __DBL_HAS_INFINITY__ 1
+#define __DBL_HAS_QUIET_NAN__ 1
+#define __DBL_MANT_DIG__ 53
+#define __DBL_MAX_10_EXP__ 308
+#define __DBL_MAX_EXP__ 1024
+#define __DBL_MAX__ 1.7976931348623157e+308
+#define __DBL_MIN_10_EXP__ (-307)
+#define __DBL_MIN_EXP__ (-1021)
+#define __DBL_MIN__ 2.2250738585072014e-308
+#define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
+#define __DEPRECATED 1
+#define __DYNAMIC__ 1
+#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101000
+#define __EXCEPTIONS 1
+#define __FINITE_MATH_ONLY__ 0
+#define __FLT_DECIMAL_DIG__ 9
+#define __FLT_DENORM_MIN__ 1.40129846e-45F
+#define __FLT_DIG__ 6
+#define __FLT_EPSILON__ 1.19209290e-7F
+#define __FLT_EVAL_METHOD__ 0
+#define __FLT_HAS_DENORM__ 1
+#define __FLT_HAS_INFINITY__ 1
+#define __FLT_HAS_QUIET_NAN__ 1
+#define __FLT_MANT_DIG__ 24
+#define __FLT_MAX_10_EXP__ 38
+#define __FLT_MAX_EXP__ 128
+#define __FLT_MAX__ 3.40282347e+38F
+#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT_MIN_EXP__ (-125)
+#define __FLT_MIN__ 1.17549435e-38F
+#define __FLT_RADIX__ 2
+#define __FXSR__ 1
+#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+#define __GCC_ATOMIC_INT_LOCK_FREE 2
+#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
+#define __GLIBCXX_BITSIZE_INT_N_0 128
+#define __GLIBCXX_TYPE_INT_N_0 __int128
+#define __GNUC_GNU_INLINE__ 1
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 1
+#define __GNUC__ 4
+#define __GNUG__ 4
+#define __GXX_ABI_VERSION 1002
+#define __GXX_EXPERIMENTAL_CXX0X__ 1
+#define __GXX_RTTI 1
+#define __GXX_WEAK__ 1
+#define __INT16_C_SUFFIX__ 
+#define __INT16_FMTd__ "hd"
+#define __INT16_FMTi__ "hi"
+#define __INT16_MAX__ 32767
+#define __INT16_TYPE__ short
+#define __INT32_C_SUFFIX__ 
+#define __INT32_FMTd__ "d"
+#define __INT32_FMTi__ "i"
+#define __INT32_MAX__ 2147483647
+#define __INT32_TYPE__ int
+#define __INT64_C_SUFFIX__ LL
+#define __INT64_FMTd__ "lld"
+#define __INT64_FMTi__ "lli"
+#define __INT64_MAX__ 9223372036854775807LL
+#define __INT64_TYPE__ long long int
+#define __INT8_C_SUFFIX__ 
+#define __INT8_FMTd__ "hhd"
+#define __INT8_FMTi__ "hhi"
+#define __INT8_MAX__ 127
+#define __INT8_TYPE__ signed char
+#define __INTMAX_C_SUFFIX__ L
+#define __INTMAX_FMTd__ "ld"
+#define __INTMAX_FMTi__ "li"
+#define __INTMAX_MAX__ 9223372036854775807L
+#define __INTMAX_TYPE__ long int
+#define __INTMAX_WIDTH__ 64
+#define __INTPTR_FMTd__ "ld"
+#define __INTPTR_FMTi__ "li"
+#define __INTPTR_MAX__ 9223372036854775807L
+#define __INTPTR_TYPE__ long int
+#define __INTPTR_WIDTH__ 64
+#define __INT_FAST16_FMTd__ "hd"
+#define __INT_FAST16_FMTi__ "hi"
+#define __INT_FAST16_MAX__ 32767
+#define __INT_FAST16_TYPE__ short
+#define __INT_FAST32_FMTd__ "d"
+#define __INT_FAST32_FMTi__ "i"
+#define __INT_FAST32_MAX__ 2147483647
+#define __INT_FAST32_TYPE__ int
+#define __INT_FAST64_FMTd__ "ld"
+#define __INT_FAST64_FMTi__ "li"
+#define __INT_FAST64_MAX__ 9223372036854775807L
+#define __INT_FAST64_TYPE__ long int
+#define __INT_FAST8_FMTd__ "hhd"
+#define __INT_FAST8_FMTi__ "hhi"
+#define __INT_FAST8_MAX__ 127
+#define __INT_FAST8_TYPE__ signed char
+#define __INT_LEAST16_FMTd__ "hd"
+#define __INT_LEAST16_FMTi__ "hi"
+#define __INT_LEAST16_MAX__ 32767
+#define __INT_LEAST16_TYPE__ short
+#define __INT_LEAST32_FMTd__ "d"
+#define __INT_LEAST32_FMTi__ "i"
+#define __INT_LEAST32_MAX__ 2147483647
+#define __INT_LEAST32_TYPE__ int
+#define __INT_LEAST64_FMTd__ "ld"
+#define __INT_LEAST64_FMTi__ "li"
+#define __INT_LEAST64_MAX__ 9223372036854775807L
+#define __INT_LEAST64_TYPE__ long int
+#define __INT_LEAST8_FMTd__ "hhd"
+#define __INT_LEAST8_FMTi__ "hhi"
+#define __INT_LEAST8_MAX__ 127
+#define __INT_LEAST8_TYPE__ signed char
+#define __INT_MAX__ 2147483647
+#define __LDBL_DECIMAL_DIG__ 21
+#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+#define __LDBL_DIG__ 18
+#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
+#define __LDBL_HAS_DENORM__ 1
+#define __LDBL_HAS_INFINITY__ 1
+#define __LDBL_HAS_QUIET_NAN__ 1
+#define __LDBL_MANT_DIG__ 64
+#define __LDBL_MAX_10_EXP__ 4932
+#define __LDBL_MAX_EXP__ 16384
+#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+#define __LDBL_MIN_10_EXP__ (-4931)
+#define __LDBL_MIN_EXP__ (-16381)
+#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+#define __LITTLE_ENDIAN__ 1
+#define __LONG_LONG_MAX__ 9223372036854775807LL
+#define __LONG_MAX__ 9223372036854775807L
+#define __LP64__ 1
+#define __MACH__ 1
+#define __MMX__ 1
+#define __NO_MATH_INLINES 1
+#define __OBJC_BOOL_IS_BOOL 0
+#define __OPTIMIZE__ 1
+#define __ORDER_BIG_ENDIAN__ 4321
+#define __ORDER_LITTLE_ENDIAN__ 1234
+#define __ORDER_PDP_ENDIAN__ 3412
+#define __PIC__ 2
+#define __POINTER_WIDTH__ 64
+#define __PRAGMA_REDEFINE_EXTNAME 1
+#define __PTRDIFF_FMTd__ "ld"
+#define __PTRDIFF_FMTi__ "li"
+#define __PTRDIFF_MAX__ 9223372036854775807L
+#define __PTRDIFF_TYPE__ long int
+#define __PTRDIFF_WIDTH__ 64
+#define __REGISTER_PREFIX__ 
+#define __SCHAR_MAX__ 127
+#define __SHRT_MAX__ 32767
+#define __SIG_ATOMIC_MAX__ 2147483647
+#define __SIG_ATOMIC_WIDTH__ 32
+#define __SIZEOF_DOUBLE__ 8
+#define __SIZEOF_FLOAT__ 4
+#define __SIZEOF_INT128__ 16
+#define __SIZEOF_INT__ 4
+#define __SIZEOF_LONG_DOUBLE__ 16
+#define __SIZEOF_LONG_LONG__ 8
+#define __SIZEOF_LONG__ 8
+#define __SIZEOF_POINTER__ 8
+#define __SIZEOF_PTRDIFF_T__ 8
+#define __SIZEOF_SHORT__ 2
+#define __SIZEOF_SIZE_T__ 8
+#define __SIZEOF_WCHAR_T__ 4
+#define __SIZEOF_WINT_T__ 4
+#define __SIZE_FMTX__ "lX"
+#define __SIZE_FMTo__ "lo"
+#define __SIZE_FMTu__ "lu"
+#define __SIZE_FMTx__ "lx"
+#define __SIZE_MAX__ 18446744073709551615UL
+#define __SIZE_TYPE__ long unsigned int
+#define __SIZE_WIDTH__ 64
+#define __SSE2_MATH__ 1
+#define __SSE2__ 1
+#define __SSE3__ 1
+#define __SSE_MATH__ 1
+#define __SSE__ 1
+#define __SSP__ 1
+#define __SSSE3__ 1
+#define __STDC_HOSTED__ 1
+#define __STDC_UTF_16__ 1
+#define __STDC_UTF_32__ 1
+#define __STDC__ 1
+#define __UINT16_C_SUFFIX__ 
+#define __UINT16_FMTX__ "hX"
+#define __UINT16_FMTo__ "ho"
+#define __UINT16_FMTu__ "hu"
+#define __UINT16_FMTx__ "hx"
+#define __UINT16_MAX__ 65535
+#define __UINT16_TYPE__ unsigned short
+#define __UINT32_C_SUFFIX__ U
+#define __UINT32_FMTX__ "X"
+#define __UINT32_FMTo__ "o"
+#define __UINT32_FMTu__ "u"
+#define __UINT32_FMTx__ "x"
+#define __UINT32_MAX__ 4294967295U
+#define __UINT32_TYPE__ unsigned int
+#define __UINT64_C_SUFFIX__ ULL
+#define __UINT64_FMTX__ "llX"
+#define __UINT64_FMTo__ "llo"
+#define __UINT64_FMTu__ "llu"
+#define __UINT64_FMTx__ "llx"
+#define __UINT64_MAX__ 18446744073709551615ULL
+#define __UINT64_TYPE__ long long unsigned int
+#define __UINT8_C_SUFFIX__ 
+#define __UINT8_FMTX__ "hhX"
+#define __UINT8_FMTo__ "hho"
+#define __UINT8_FMTu__ "hhu"
+#define __UINT8_FMTx__ "hhx"
+#define __UINT8_MAX__ 255
+#define __UINT8_TYPE__ unsigned char
+#define __UINTMAX_C_SUFFIX__ UL
+#define __UINTMAX_FMTX__ "lX"
+#define __UINTMAX_FMTo__ "lo"
+#define __UINTMAX_FMTu__ "lu"
+#define __UINTMAX_FMTx__ "lx"
+#define __UINTMAX_MAX__ 18446744073709551615UL
+#define __UINTMAX_TYPE__ long unsigned int
+#define __UINTMAX_WIDTH__ 64
+#define __UINTPTR_FMTX__ "lX"
+#define __UINTPTR_FMTo__ "lo"
+#define __UINTPTR_FMTu__ "lu"
+#define __UINTPTR_FMTx__ "lx"
+#define __UINTPTR_MAX__ 18446744073709551615UL
+#define __UINTPTR_TYPE__ long unsigned int
+#define __UINTPTR_WIDTH__ 64
+#define __UINT_FAST16_FMTX__ "hX"
+#define __UINT_FAST16_FMTo__ "ho"
+#define __UINT_FAST16_FMTu__ "hu"
+#define __UINT_FAST16_FMTx__ "hx"
+#define __UINT_FAST16_MAX__ 65535
+#define __UINT_FAST16_TYPE__ unsigned short
+#define __UINT_FAST32_FMTX__ "X"
+#define __UINT_FAST32_FMTo__ "o"
+#define __UINT_FAST32_FMTu__ "u"
+#define __UINT_FAST32_FMTx__ "x"
+#define __UINT_FAST32_MAX__ 4294967295U
+#define __UINT_FAST32_TYPE__ unsigned int
+#define __UINT_FAST64_FMTX__ "lX"
+#define __UINT_FAST64_FMTo__ "lo"
+#define __UINT_FAST64_FMTu__ "lu"
+#define __UINT_FAST64_FMTx__ "lx"
+#define __UINT_FAST64_MAX__ 18446744073709551615UL
+#define __UINT_FAST64_TYPE__ long unsigned int
+#define __UINT_FAST8_FMTX__ "hhX"
+#define __UINT_FAST8_FMTo__ "hho"
+#define __UINT_FAST8_FMTu__ "hhu"
+#define __UINT_FAST8_FMTx__ "hhx"
+#define __UINT_FAST8_MAX__ 255
+#define __UINT_FAST8_TYPE__ unsigned char
+#define __UINT_LEAST16_FMTX__ "hX"
+#define __UINT_LEAST16_FMTo__ "ho"
+#define __UINT_LEAST16_FMTu__ "hu"
+#define __UINT_LEAST16_FMTx__ "hx"
+#define __UINT_LEAST16_MAX__ 65535
+#define __UINT_LEAST16_TYPE__ unsigned short
+#define __UINT_LEAST32_FMTX__ "X"
+#define __UINT_LEAST32_FMTo__ "o"
+#define __UINT_LEAST32_FMTu__ "u"
+#define __UINT_LEAST32_FMTx__ "x"
+#define __UINT_LEAST32_MAX__ 4294967295U
+#define __UINT_LEAST32_TYPE__ unsigned int
+#define __UINT_LEAST64_FMTX__ "lX"
+#define __UINT_LEAST64_FMTo__ "lo"
+#define __UINT_LEAST64_FMTu__ "lu"
+#define __UINT_LEAST64_FMTx__ "lx"
+#define __UINT_LEAST64_MAX__ 18446744073709551615UL
+#define __UINT_LEAST64_TYPE__ long unsigned int
+#define __UINT_LEAST8_FMTX__ "hhX"
+#define __UINT_LEAST8_FMTo__ "hho"
+#define __UINT_LEAST8_FMTu__ "hhu"
+#define __UINT_LEAST8_FMTx__ "hhx"
+#define __UINT_LEAST8_MAX__ 255
+#define __UINT_LEAST8_TYPE__ unsigned char
+#define __USER_LABEL_PREFIX__ _
+#define __VERSION__ "4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)"
+#define __WCHAR_MAX__ 2147483647
+#define __WCHAR_TYPE__ int
+#define __WCHAR_WIDTH__ 32
+#define __WINT_TYPE__ int
+#define __WINT_WIDTH__ 32
+#define __amd64 1
+#define __amd64__ 1
+#define __apple_build_version__ 8020042
+#define __block __attribute__((__blocks__(byref)))
+#define __clang__ 1
+#define __clang_major__ 8
+#define __clang_minor__ 1
+#define __clang_patchlevel__ 0
+#define __clang_version__ "8.1.0 (clang-802.0.42)"
+#define __core2 1
+#define __core2__ 1
+#define __cplusplus 201103L
+#define __cpp_alias_templates 200704
+#define __cpp_attributes 200809
+#define __cpp_constexpr 200704
+#define __cpp_decltype 200707
+#define __cpp_delegating_constructors 200604
+#define __cpp_exceptions 199711
+#define __cpp_inheriting_constructors 200802
+#define __cpp_initializer_lists 200806
+#define __cpp_lambdas 200907
+#define __cpp_nsdmi 200809
+#define __cpp_range_based_for 200907
+#define __cpp_raw_strings 200710
+#define __cpp_ref_qualifiers 200710
+#define __cpp_rtti 199711
+#define __cpp_rvalue_references 200610
+#define __cpp_static_assert 200410
+#define __cpp_unicode_characters 200704
+#define __cpp_unicode_literals 200710
+#define __cpp_user_defined_literals 200809
+#define __cpp_variadic_templates 200704
+#define __llvm__ 1
+#define __nonnull _Nonnull
+#define __null_unspecified _Null_unspecified
+#define __nullable _Nullable
+#define __pic__ 2
+#define __private_extern__ extern
+#define __strong 
+#define __tune_core2__ 1
+#define __unsafe_unretained 
+#define __weak __attribute__((objc_gc(weak)))
+#define __x86_64 1
+#define __x86_64__ 1

--- a/src/plugins/python/pythonbind.cpp
+++ b/src/plugins/python/pythonbind.cpp
@@ -4750,12 +4750,14 @@ _wrap_PyTiledTileLayer__tp_init(PyTiledTileLayer *self, PyObject *args, PyObject
     int y;
     int w;
     int h;
-    const char *keywords[] = {"name", "x", "y", "w", "h", NULL};
+	int tw;
+	int th;
+    const char *keywords[] = {"name", "x", "y", "w", "h", "tw", "th", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "s#iiii", (char **) keywords, &name, &name_len, &x, &y, &w, &h)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "s#iiii", (char **) keywords, &name, &name_len, &x, &y, &w, &h, &tw, &th)) {
         return -1;
     }
-    self->obj = new Tiled::TileLayer(QString::fromUtf8(name), x, y, w, h);
+    self->obj = new Tiled::TileLayer(QString::fromUtf8(name), x, y, w, h, tw, th);
     self->flags = PYBINDGEN_WRAPPER_FLAG_NONE;
     return 0;
 }

--- a/src/plugins/replicaisland/moc_predefs.h
+++ b/src/plugins/replicaisland/moc_predefs.h
@@ -1,0 +1,357 @@
+#define OBJC_NEW_PROPERTIES 1
+#define _LP64 1
+#define __APPLE_CC__ 6000
+#define __APPLE__ 1
+#define __ATOMIC_ACQUIRE 2
+#define __ATOMIC_ACQ_REL 4
+#define __ATOMIC_CONSUME 1
+#define __ATOMIC_RELAXED 0
+#define __ATOMIC_RELEASE 3
+#define __ATOMIC_SEQ_CST 5
+#define __BIGGEST_ALIGNMENT__ 16
+#define __BLOCKS__ 1
+#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __CHAR16_TYPE__ unsigned short
+#define __CHAR32_TYPE__ unsigned int
+#define __CHAR_BIT__ 8
+#define __CONSTANT_CFSTRINGS__ 1
+#define __DBL_DECIMAL_DIG__ 17
+#define __DBL_DENORM_MIN__ 4.9406564584124654e-324
+#define __DBL_DIG__ 15
+#define __DBL_EPSILON__ 2.2204460492503131e-16
+#define __DBL_HAS_DENORM__ 1
+#define __DBL_HAS_INFINITY__ 1
+#define __DBL_HAS_QUIET_NAN__ 1
+#define __DBL_MANT_DIG__ 53
+#define __DBL_MAX_10_EXP__ 308
+#define __DBL_MAX_EXP__ 1024
+#define __DBL_MAX__ 1.7976931348623157e+308
+#define __DBL_MIN_10_EXP__ (-307)
+#define __DBL_MIN_EXP__ (-1021)
+#define __DBL_MIN__ 2.2250738585072014e-308
+#define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
+#define __DEPRECATED 1
+#define __DYNAMIC__ 1
+#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101000
+#define __EXCEPTIONS 1
+#define __FINITE_MATH_ONLY__ 0
+#define __FLT_DECIMAL_DIG__ 9
+#define __FLT_DENORM_MIN__ 1.40129846e-45F
+#define __FLT_DIG__ 6
+#define __FLT_EPSILON__ 1.19209290e-7F
+#define __FLT_EVAL_METHOD__ 0
+#define __FLT_HAS_DENORM__ 1
+#define __FLT_HAS_INFINITY__ 1
+#define __FLT_HAS_QUIET_NAN__ 1
+#define __FLT_MANT_DIG__ 24
+#define __FLT_MAX_10_EXP__ 38
+#define __FLT_MAX_EXP__ 128
+#define __FLT_MAX__ 3.40282347e+38F
+#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT_MIN_EXP__ (-125)
+#define __FLT_MIN__ 1.17549435e-38F
+#define __FLT_RADIX__ 2
+#define __FXSR__ 1
+#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+#define __GCC_ATOMIC_INT_LOCK_FREE 2
+#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
+#define __GLIBCXX_BITSIZE_INT_N_0 128
+#define __GLIBCXX_TYPE_INT_N_0 __int128
+#define __GNUC_GNU_INLINE__ 1
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 1
+#define __GNUC__ 4
+#define __GNUG__ 4
+#define __GXX_ABI_VERSION 1002
+#define __GXX_EXPERIMENTAL_CXX0X__ 1
+#define __GXX_RTTI 1
+#define __GXX_WEAK__ 1
+#define __INT16_C_SUFFIX__ 
+#define __INT16_FMTd__ "hd"
+#define __INT16_FMTi__ "hi"
+#define __INT16_MAX__ 32767
+#define __INT16_TYPE__ short
+#define __INT32_C_SUFFIX__ 
+#define __INT32_FMTd__ "d"
+#define __INT32_FMTi__ "i"
+#define __INT32_MAX__ 2147483647
+#define __INT32_TYPE__ int
+#define __INT64_C_SUFFIX__ LL
+#define __INT64_FMTd__ "lld"
+#define __INT64_FMTi__ "lli"
+#define __INT64_MAX__ 9223372036854775807LL
+#define __INT64_TYPE__ long long int
+#define __INT8_C_SUFFIX__ 
+#define __INT8_FMTd__ "hhd"
+#define __INT8_FMTi__ "hhi"
+#define __INT8_MAX__ 127
+#define __INT8_TYPE__ signed char
+#define __INTMAX_C_SUFFIX__ L
+#define __INTMAX_FMTd__ "ld"
+#define __INTMAX_FMTi__ "li"
+#define __INTMAX_MAX__ 9223372036854775807L
+#define __INTMAX_TYPE__ long int
+#define __INTMAX_WIDTH__ 64
+#define __INTPTR_FMTd__ "ld"
+#define __INTPTR_FMTi__ "li"
+#define __INTPTR_MAX__ 9223372036854775807L
+#define __INTPTR_TYPE__ long int
+#define __INTPTR_WIDTH__ 64
+#define __INT_FAST16_FMTd__ "hd"
+#define __INT_FAST16_FMTi__ "hi"
+#define __INT_FAST16_MAX__ 32767
+#define __INT_FAST16_TYPE__ short
+#define __INT_FAST32_FMTd__ "d"
+#define __INT_FAST32_FMTi__ "i"
+#define __INT_FAST32_MAX__ 2147483647
+#define __INT_FAST32_TYPE__ int
+#define __INT_FAST64_FMTd__ "ld"
+#define __INT_FAST64_FMTi__ "li"
+#define __INT_FAST64_MAX__ 9223372036854775807L
+#define __INT_FAST64_TYPE__ long int
+#define __INT_FAST8_FMTd__ "hhd"
+#define __INT_FAST8_FMTi__ "hhi"
+#define __INT_FAST8_MAX__ 127
+#define __INT_FAST8_TYPE__ signed char
+#define __INT_LEAST16_FMTd__ "hd"
+#define __INT_LEAST16_FMTi__ "hi"
+#define __INT_LEAST16_MAX__ 32767
+#define __INT_LEAST16_TYPE__ short
+#define __INT_LEAST32_FMTd__ "d"
+#define __INT_LEAST32_FMTi__ "i"
+#define __INT_LEAST32_MAX__ 2147483647
+#define __INT_LEAST32_TYPE__ int
+#define __INT_LEAST64_FMTd__ "ld"
+#define __INT_LEAST64_FMTi__ "li"
+#define __INT_LEAST64_MAX__ 9223372036854775807L
+#define __INT_LEAST64_TYPE__ long int
+#define __INT_LEAST8_FMTd__ "hhd"
+#define __INT_LEAST8_FMTi__ "hhi"
+#define __INT_LEAST8_MAX__ 127
+#define __INT_LEAST8_TYPE__ signed char
+#define __INT_MAX__ 2147483647
+#define __LDBL_DECIMAL_DIG__ 21
+#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+#define __LDBL_DIG__ 18
+#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
+#define __LDBL_HAS_DENORM__ 1
+#define __LDBL_HAS_INFINITY__ 1
+#define __LDBL_HAS_QUIET_NAN__ 1
+#define __LDBL_MANT_DIG__ 64
+#define __LDBL_MAX_10_EXP__ 4932
+#define __LDBL_MAX_EXP__ 16384
+#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+#define __LDBL_MIN_10_EXP__ (-4931)
+#define __LDBL_MIN_EXP__ (-16381)
+#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+#define __LITTLE_ENDIAN__ 1
+#define __LONG_LONG_MAX__ 9223372036854775807LL
+#define __LONG_MAX__ 9223372036854775807L
+#define __LP64__ 1
+#define __MACH__ 1
+#define __MMX__ 1
+#define __NO_MATH_INLINES 1
+#define __OBJC_BOOL_IS_BOOL 0
+#define __OPTIMIZE__ 1
+#define __ORDER_BIG_ENDIAN__ 4321
+#define __ORDER_LITTLE_ENDIAN__ 1234
+#define __ORDER_PDP_ENDIAN__ 3412
+#define __PIC__ 2
+#define __POINTER_WIDTH__ 64
+#define __PRAGMA_REDEFINE_EXTNAME 1
+#define __PTRDIFF_FMTd__ "ld"
+#define __PTRDIFF_FMTi__ "li"
+#define __PTRDIFF_MAX__ 9223372036854775807L
+#define __PTRDIFF_TYPE__ long int
+#define __PTRDIFF_WIDTH__ 64
+#define __REGISTER_PREFIX__ 
+#define __SCHAR_MAX__ 127
+#define __SHRT_MAX__ 32767
+#define __SIG_ATOMIC_MAX__ 2147483647
+#define __SIG_ATOMIC_WIDTH__ 32
+#define __SIZEOF_DOUBLE__ 8
+#define __SIZEOF_FLOAT__ 4
+#define __SIZEOF_INT128__ 16
+#define __SIZEOF_INT__ 4
+#define __SIZEOF_LONG_DOUBLE__ 16
+#define __SIZEOF_LONG_LONG__ 8
+#define __SIZEOF_LONG__ 8
+#define __SIZEOF_POINTER__ 8
+#define __SIZEOF_PTRDIFF_T__ 8
+#define __SIZEOF_SHORT__ 2
+#define __SIZEOF_SIZE_T__ 8
+#define __SIZEOF_WCHAR_T__ 4
+#define __SIZEOF_WINT_T__ 4
+#define __SIZE_FMTX__ "lX"
+#define __SIZE_FMTo__ "lo"
+#define __SIZE_FMTu__ "lu"
+#define __SIZE_FMTx__ "lx"
+#define __SIZE_MAX__ 18446744073709551615UL
+#define __SIZE_TYPE__ long unsigned int
+#define __SIZE_WIDTH__ 64
+#define __SSE2_MATH__ 1
+#define __SSE2__ 1
+#define __SSE3__ 1
+#define __SSE_MATH__ 1
+#define __SSE__ 1
+#define __SSP__ 1
+#define __SSSE3__ 1
+#define __STDC_HOSTED__ 1
+#define __STDC_UTF_16__ 1
+#define __STDC_UTF_32__ 1
+#define __STDC__ 1
+#define __UINT16_C_SUFFIX__ 
+#define __UINT16_FMTX__ "hX"
+#define __UINT16_FMTo__ "ho"
+#define __UINT16_FMTu__ "hu"
+#define __UINT16_FMTx__ "hx"
+#define __UINT16_MAX__ 65535
+#define __UINT16_TYPE__ unsigned short
+#define __UINT32_C_SUFFIX__ U
+#define __UINT32_FMTX__ "X"
+#define __UINT32_FMTo__ "o"
+#define __UINT32_FMTu__ "u"
+#define __UINT32_FMTx__ "x"
+#define __UINT32_MAX__ 4294967295U
+#define __UINT32_TYPE__ unsigned int
+#define __UINT64_C_SUFFIX__ ULL
+#define __UINT64_FMTX__ "llX"
+#define __UINT64_FMTo__ "llo"
+#define __UINT64_FMTu__ "llu"
+#define __UINT64_FMTx__ "llx"
+#define __UINT64_MAX__ 18446744073709551615ULL
+#define __UINT64_TYPE__ long long unsigned int
+#define __UINT8_C_SUFFIX__ 
+#define __UINT8_FMTX__ "hhX"
+#define __UINT8_FMTo__ "hho"
+#define __UINT8_FMTu__ "hhu"
+#define __UINT8_FMTx__ "hhx"
+#define __UINT8_MAX__ 255
+#define __UINT8_TYPE__ unsigned char
+#define __UINTMAX_C_SUFFIX__ UL
+#define __UINTMAX_FMTX__ "lX"
+#define __UINTMAX_FMTo__ "lo"
+#define __UINTMAX_FMTu__ "lu"
+#define __UINTMAX_FMTx__ "lx"
+#define __UINTMAX_MAX__ 18446744073709551615UL
+#define __UINTMAX_TYPE__ long unsigned int
+#define __UINTMAX_WIDTH__ 64
+#define __UINTPTR_FMTX__ "lX"
+#define __UINTPTR_FMTo__ "lo"
+#define __UINTPTR_FMTu__ "lu"
+#define __UINTPTR_FMTx__ "lx"
+#define __UINTPTR_MAX__ 18446744073709551615UL
+#define __UINTPTR_TYPE__ long unsigned int
+#define __UINTPTR_WIDTH__ 64
+#define __UINT_FAST16_FMTX__ "hX"
+#define __UINT_FAST16_FMTo__ "ho"
+#define __UINT_FAST16_FMTu__ "hu"
+#define __UINT_FAST16_FMTx__ "hx"
+#define __UINT_FAST16_MAX__ 65535
+#define __UINT_FAST16_TYPE__ unsigned short
+#define __UINT_FAST32_FMTX__ "X"
+#define __UINT_FAST32_FMTo__ "o"
+#define __UINT_FAST32_FMTu__ "u"
+#define __UINT_FAST32_FMTx__ "x"
+#define __UINT_FAST32_MAX__ 4294967295U
+#define __UINT_FAST32_TYPE__ unsigned int
+#define __UINT_FAST64_FMTX__ "lX"
+#define __UINT_FAST64_FMTo__ "lo"
+#define __UINT_FAST64_FMTu__ "lu"
+#define __UINT_FAST64_FMTx__ "lx"
+#define __UINT_FAST64_MAX__ 18446744073709551615UL
+#define __UINT_FAST64_TYPE__ long unsigned int
+#define __UINT_FAST8_FMTX__ "hhX"
+#define __UINT_FAST8_FMTo__ "hho"
+#define __UINT_FAST8_FMTu__ "hhu"
+#define __UINT_FAST8_FMTx__ "hhx"
+#define __UINT_FAST8_MAX__ 255
+#define __UINT_FAST8_TYPE__ unsigned char
+#define __UINT_LEAST16_FMTX__ "hX"
+#define __UINT_LEAST16_FMTo__ "ho"
+#define __UINT_LEAST16_FMTu__ "hu"
+#define __UINT_LEAST16_FMTx__ "hx"
+#define __UINT_LEAST16_MAX__ 65535
+#define __UINT_LEAST16_TYPE__ unsigned short
+#define __UINT_LEAST32_FMTX__ "X"
+#define __UINT_LEAST32_FMTo__ "o"
+#define __UINT_LEAST32_FMTu__ "u"
+#define __UINT_LEAST32_FMTx__ "x"
+#define __UINT_LEAST32_MAX__ 4294967295U
+#define __UINT_LEAST32_TYPE__ unsigned int
+#define __UINT_LEAST64_FMTX__ "lX"
+#define __UINT_LEAST64_FMTo__ "lo"
+#define __UINT_LEAST64_FMTu__ "lu"
+#define __UINT_LEAST64_FMTx__ "lx"
+#define __UINT_LEAST64_MAX__ 18446744073709551615UL
+#define __UINT_LEAST64_TYPE__ long unsigned int
+#define __UINT_LEAST8_FMTX__ "hhX"
+#define __UINT_LEAST8_FMTo__ "hho"
+#define __UINT_LEAST8_FMTu__ "hhu"
+#define __UINT_LEAST8_FMTx__ "hhx"
+#define __UINT_LEAST8_MAX__ 255
+#define __UINT_LEAST8_TYPE__ unsigned char
+#define __USER_LABEL_PREFIX__ _
+#define __VERSION__ "4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)"
+#define __WCHAR_MAX__ 2147483647
+#define __WCHAR_TYPE__ int
+#define __WCHAR_WIDTH__ 32
+#define __WINT_TYPE__ int
+#define __WINT_WIDTH__ 32
+#define __amd64 1
+#define __amd64__ 1
+#define __apple_build_version__ 8020042
+#define __block __attribute__((__blocks__(byref)))
+#define __clang__ 1
+#define __clang_major__ 8
+#define __clang_minor__ 1
+#define __clang_patchlevel__ 0
+#define __clang_version__ "8.1.0 (clang-802.0.42)"
+#define __core2 1
+#define __core2__ 1
+#define __cplusplus 201103L
+#define __cpp_alias_templates 200704
+#define __cpp_attributes 200809
+#define __cpp_constexpr 200704
+#define __cpp_decltype 200707
+#define __cpp_delegating_constructors 200604
+#define __cpp_exceptions 199711
+#define __cpp_inheriting_constructors 200802
+#define __cpp_initializer_lists 200806
+#define __cpp_lambdas 200907
+#define __cpp_nsdmi 200809
+#define __cpp_range_based_for 200907
+#define __cpp_raw_strings 200710
+#define __cpp_ref_qualifiers 200710
+#define __cpp_rtti 199711
+#define __cpp_rvalue_references 200610
+#define __cpp_static_assert 200410
+#define __cpp_unicode_characters 200704
+#define __cpp_unicode_literals 200710
+#define __cpp_user_defined_literals 200809
+#define __cpp_variadic_templates 200704
+#define __llvm__ 1
+#define __nonnull _Nonnull
+#define __null_unspecified _Null_unspecified
+#define __nullable _Nullable
+#define __pic__ 2
+#define __private_extern__ extern
+#define __strong 
+#define __tune_core2__ 1
+#define __unsafe_unretained 
+#define __weak __attribute__((objc_gc(weak)))
+#define __x86_64 1
+#define __x86_64__ 1

--- a/src/plugins/replicaisland/replicaislandplugin.cpp
+++ b/src/plugins/replicaisland/replicaislandplugin.cpp
@@ -103,9 +103,10 @@ Tiled::Map *ReplicaIslandPlugin::read(const QString &fileName)
             return 0;
         }
 
+		// LUCA TODO: I don't know where the tile sizes come from
         // Create a layer object.
         TileLayer *layer =
-            new TileLayer(layerTypeToName(type), 0, 0, width, height);
+            new TileLayer(layerTypeToName(type), 0, 0, width, height, 0, 0);
         layer->setProperty("type", QString::number(type));
         layer->setProperty("tile_index", QString::number(tileIndex));
         layer->setProperty("scroll_speed", QString::number(scrollSpeed, 'f'));

--- a/src/plugins/tbin/moc_predefs.h
+++ b/src/plugins/tbin/moc_predefs.h
@@ -1,0 +1,357 @@
+#define OBJC_NEW_PROPERTIES 1
+#define _LP64 1
+#define __APPLE_CC__ 6000
+#define __APPLE__ 1
+#define __ATOMIC_ACQUIRE 2
+#define __ATOMIC_ACQ_REL 4
+#define __ATOMIC_CONSUME 1
+#define __ATOMIC_RELAXED 0
+#define __ATOMIC_RELEASE 3
+#define __ATOMIC_SEQ_CST 5
+#define __BIGGEST_ALIGNMENT__ 16
+#define __BLOCKS__ 1
+#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __CHAR16_TYPE__ unsigned short
+#define __CHAR32_TYPE__ unsigned int
+#define __CHAR_BIT__ 8
+#define __CONSTANT_CFSTRINGS__ 1
+#define __DBL_DECIMAL_DIG__ 17
+#define __DBL_DENORM_MIN__ 4.9406564584124654e-324
+#define __DBL_DIG__ 15
+#define __DBL_EPSILON__ 2.2204460492503131e-16
+#define __DBL_HAS_DENORM__ 1
+#define __DBL_HAS_INFINITY__ 1
+#define __DBL_HAS_QUIET_NAN__ 1
+#define __DBL_MANT_DIG__ 53
+#define __DBL_MAX_10_EXP__ 308
+#define __DBL_MAX_EXP__ 1024
+#define __DBL_MAX__ 1.7976931348623157e+308
+#define __DBL_MIN_10_EXP__ (-307)
+#define __DBL_MIN_EXP__ (-1021)
+#define __DBL_MIN__ 2.2250738585072014e-308
+#define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
+#define __DEPRECATED 1
+#define __DYNAMIC__ 1
+#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101000
+#define __EXCEPTIONS 1
+#define __FINITE_MATH_ONLY__ 0
+#define __FLT_DECIMAL_DIG__ 9
+#define __FLT_DENORM_MIN__ 1.40129846e-45F
+#define __FLT_DIG__ 6
+#define __FLT_EPSILON__ 1.19209290e-7F
+#define __FLT_EVAL_METHOD__ 0
+#define __FLT_HAS_DENORM__ 1
+#define __FLT_HAS_INFINITY__ 1
+#define __FLT_HAS_QUIET_NAN__ 1
+#define __FLT_MANT_DIG__ 24
+#define __FLT_MAX_10_EXP__ 38
+#define __FLT_MAX_EXP__ 128
+#define __FLT_MAX__ 3.40282347e+38F
+#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT_MIN_EXP__ (-125)
+#define __FLT_MIN__ 1.17549435e-38F
+#define __FLT_RADIX__ 2
+#define __FXSR__ 1
+#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+#define __GCC_ATOMIC_INT_LOCK_FREE 2
+#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
+#define __GLIBCXX_BITSIZE_INT_N_0 128
+#define __GLIBCXX_TYPE_INT_N_0 __int128
+#define __GNUC_GNU_INLINE__ 1
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 1
+#define __GNUC__ 4
+#define __GNUG__ 4
+#define __GXX_ABI_VERSION 1002
+#define __GXX_EXPERIMENTAL_CXX0X__ 1
+#define __GXX_RTTI 1
+#define __GXX_WEAK__ 1
+#define __INT16_C_SUFFIX__ 
+#define __INT16_FMTd__ "hd"
+#define __INT16_FMTi__ "hi"
+#define __INT16_MAX__ 32767
+#define __INT16_TYPE__ short
+#define __INT32_C_SUFFIX__ 
+#define __INT32_FMTd__ "d"
+#define __INT32_FMTi__ "i"
+#define __INT32_MAX__ 2147483647
+#define __INT32_TYPE__ int
+#define __INT64_C_SUFFIX__ LL
+#define __INT64_FMTd__ "lld"
+#define __INT64_FMTi__ "lli"
+#define __INT64_MAX__ 9223372036854775807LL
+#define __INT64_TYPE__ long long int
+#define __INT8_C_SUFFIX__ 
+#define __INT8_FMTd__ "hhd"
+#define __INT8_FMTi__ "hhi"
+#define __INT8_MAX__ 127
+#define __INT8_TYPE__ signed char
+#define __INTMAX_C_SUFFIX__ L
+#define __INTMAX_FMTd__ "ld"
+#define __INTMAX_FMTi__ "li"
+#define __INTMAX_MAX__ 9223372036854775807L
+#define __INTMAX_TYPE__ long int
+#define __INTMAX_WIDTH__ 64
+#define __INTPTR_FMTd__ "ld"
+#define __INTPTR_FMTi__ "li"
+#define __INTPTR_MAX__ 9223372036854775807L
+#define __INTPTR_TYPE__ long int
+#define __INTPTR_WIDTH__ 64
+#define __INT_FAST16_FMTd__ "hd"
+#define __INT_FAST16_FMTi__ "hi"
+#define __INT_FAST16_MAX__ 32767
+#define __INT_FAST16_TYPE__ short
+#define __INT_FAST32_FMTd__ "d"
+#define __INT_FAST32_FMTi__ "i"
+#define __INT_FAST32_MAX__ 2147483647
+#define __INT_FAST32_TYPE__ int
+#define __INT_FAST64_FMTd__ "ld"
+#define __INT_FAST64_FMTi__ "li"
+#define __INT_FAST64_MAX__ 9223372036854775807L
+#define __INT_FAST64_TYPE__ long int
+#define __INT_FAST8_FMTd__ "hhd"
+#define __INT_FAST8_FMTi__ "hhi"
+#define __INT_FAST8_MAX__ 127
+#define __INT_FAST8_TYPE__ signed char
+#define __INT_LEAST16_FMTd__ "hd"
+#define __INT_LEAST16_FMTi__ "hi"
+#define __INT_LEAST16_MAX__ 32767
+#define __INT_LEAST16_TYPE__ short
+#define __INT_LEAST32_FMTd__ "d"
+#define __INT_LEAST32_FMTi__ "i"
+#define __INT_LEAST32_MAX__ 2147483647
+#define __INT_LEAST32_TYPE__ int
+#define __INT_LEAST64_FMTd__ "ld"
+#define __INT_LEAST64_FMTi__ "li"
+#define __INT_LEAST64_MAX__ 9223372036854775807L
+#define __INT_LEAST64_TYPE__ long int
+#define __INT_LEAST8_FMTd__ "hhd"
+#define __INT_LEAST8_FMTi__ "hhi"
+#define __INT_LEAST8_MAX__ 127
+#define __INT_LEAST8_TYPE__ signed char
+#define __INT_MAX__ 2147483647
+#define __LDBL_DECIMAL_DIG__ 21
+#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+#define __LDBL_DIG__ 18
+#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
+#define __LDBL_HAS_DENORM__ 1
+#define __LDBL_HAS_INFINITY__ 1
+#define __LDBL_HAS_QUIET_NAN__ 1
+#define __LDBL_MANT_DIG__ 64
+#define __LDBL_MAX_10_EXP__ 4932
+#define __LDBL_MAX_EXP__ 16384
+#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+#define __LDBL_MIN_10_EXP__ (-4931)
+#define __LDBL_MIN_EXP__ (-16381)
+#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+#define __LITTLE_ENDIAN__ 1
+#define __LONG_LONG_MAX__ 9223372036854775807LL
+#define __LONG_MAX__ 9223372036854775807L
+#define __LP64__ 1
+#define __MACH__ 1
+#define __MMX__ 1
+#define __NO_MATH_INLINES 1
+#define __OBJC_BOOL_IS_BOOL 0
+#define __OPTIMIZE__ 1
+#define __ORDER_BIG_ENDIAN__ 4321
+#define __ORDER_LITTLE_ENDIAN__ 1234
+#define __ORDER_PDP_ENDIAN__ 3412
+#define __PIC__ 2
+#define __POINTER_WIDTH__ 64
+#define __PRAGMA_REDEFINE_EXTNAME 1
+#define __PTRDIFF_FMTd__ "ld"
+#define __PTRDIFF_FMTi__ "li"
+#define __PTRDIFF_MAX__ 9223372036854775807L
+#define __PTRDIFF_TYPE__ long int
+#define __PTRDIFF_WIDTH__ 64
+#define __REGISTER_PREFIX__ 
+#define __SCHAR_MAX__ 127
+#define __SHRT_MAX__ 32767
+#define __SIG_ATOMIC_MAX__ 2147483647
+#define __SIG_ATOMIC_WIDTH__ 32
+#define __SIZEOF_DOUBLE__ 8
+#define __SIZEOF_FLOAT__ 4
+#define __SIZEOF_INT128__ 16
+#define __SIZEOF_INT__ 4
+#define __SIZEOF_LONG_DOUBLE__ 16
+#define __SIZEOF_LONG_LONG__ 8
+#define __SIZEOF_LONG__ 8
+#define __SIZEOF_POINTER__ 8
+#define __SIZEOF_PTRDIFF_T__ 8
+#define __SIZEOF_SHORT__ 2
+#define __SIZEOF_SIZE_T__ 8
+#define __SIZEOF_WCHAR_T__ 4
+#define __SIZEOF_WINT_T__ 4
+#define __SIZE_FMTX__ "lX"
+#define __SIZE_FMTo__ "lo"
+#define __SIZE_FMTu__ "lu"
+#define __SIZE_FMTx__ "lx"
+#define __SIZE_MAX__ 18446744073709551615UL
+#define __SIZE_TYPE__ long unsigned int
+#define __SIZE_WIDTH__ 64
+#define __SSE2_MATH__ 1
+#define __SSE2__ 1
+#define __SSE3__ 1
+#define __SSE_MATH__ 1
+#define __SSE__ 1
+#define __SSP__ 1
+#define __SSSE3__ 1
+#define __STDC_HOSTED__ 1
+#define __STDC_UTF_16__ 1
+#define __STDC_UTF_32__ 1
+#define __STDC__ 1
+#define __UINT16_C_SUFFIX__ 
+#define __UINT16_FMTX__ "hX"
+#define __UINT16_FMTo__ "ho"
+#define __UINT16_FMTu__ "hu"
+#define __UINT16_FMTx__ "hx"
+#define __UINT16_MAX__ 65535
+#define __UINT16_TYPE__ unsigned short
+#define __UINT32_C_SUFFIX__ U
+#define __UINT32_FMTX__ "X"
+#define __UINT32_FMTo__ "o"
+#define __UINT32_FMTu__ "u"
+#define __UINT32_FMTx__ "x"
+#define __UINT32_MAX__ 4294967295U
+#define __UINT32_TYPE__ unsigned int
+#define __UINT64_C_SUFFIX__ ULL
+#define __UINT64_FMTX__ "llX"
+#define __UINT64_FMTo__ "llo"
+#define __UINT64_FMTu__ "llu"
+#define __UINT64_FMTx__ "llx"
+#define __UINT64_MAX__ 18446744073709551615ULL
+#define __UINT64_TYPE__ long long unsigned int
+#define __UINT8_C_SUFFIX__ 
+#define __UINT8_FMTX__ "hhX"
+#define __UINT8_FMTo__ "hho"
+#define __UINT8_FMTu__ "hhu"
+#define __UINT8_FMTx__ "hhx"
+#define __UINT8_MAX__ 255
+#define __UINT8_TYPE__ unsigned char
+#define __UINTMAX_C_SUFFIX__ UL
+#define __UINTMAX_FMTX__ "lX"
+#define __UINTMAX_FMTo__ "lo"
+#define __UINTMAX_FMTu__ "lu"
+#define __UINTMAX_FMTx__ "lx"
+#define __UINTMAX_MAX__ 18446744073709551615UL
+#define __UINTMAX_TYPE__ long unsigned int
+#define __UINTMAX_WIDTH__ 64
+#define __UINTPTR_FMTX__ "lX"
+#define __UINTPTR_FMTo__ "lo"
+#define __UINTPTR_FMTu__ "lu"
+#define __UINTPTR_FMTx__ "lx"
+#define __UINTPTR_MAX__ 18446744073709551615UL
+#define __UINTPTR_TYPE__ long unsigned int
+#define __UINTPTR_WIDTH__ 64
+#define __UINT_FAST16_FMTX__ "hX"
+#define __UINT_FAST16_FMTo__ "ho"
+#define __UINT_FAST16_FMTu__ "hu"
+#define __UINT_FAST16_FMTx__ "hx"
+#define __UINT_FAST16_MAX__ 65535
+#define __UINT_FAST16_TYPE__ unsigned short
+#define __UINT_FAST32_FMTX__ "X"
+#define __UINT_FAST32_FMTo__ "o"
+#define __UINT_FAST32_FMTu__ "u"
+#define __UINT_FAST32_FMTx__ "x"
+#define __UINT_FAST32_MAX__ 4294967295U
+#define __UINT_FAST32_TYPE__ unsigned int
+#define __UINT_FAST64_FMTX__ "lX"
+#define __UINT_FAST64_FMTo__ "lo"
+#define __UINT_FAST64_FMTu__ "lu"
+#define __UINT_FAST64_FMTx__ "lx"
+#define __UINT_FAST64_MAX__ 18446744073709551615UL
+#define __UINT_FAST64_TYPE__ long unsigned int
+#define __UINT_FAST8_FMTX__ "hhX"
+#define __UINT_FAST8_FMTo__ "hho"
+#define __UINT_FAST8_FMTu__ "hhu"
+#define __UINT_FAST8_FMTx__ "hhx"
+#define __UINT_FAST8_MAX__ 255
+#define __UINT_FAST8_TYPE__ unsigned char
+#define __UINT_LEAST16_FMTX__ "hX"
+#define __UINT_LEAST16_FMTo__ "ho"
+#define __UINT_LEAST16_FMTu__ "hu"
+#define __UINT_LEAST16_FMTx__ "hx"
+#define __UINT_LEAST16_MAX__ 65535
+#define __UINT_LEAST16_TYPE__ unsigned short
+#define __UINT_LEAST32_FMTX__ "X"
+#define __UINT_LEAST32_FMTo__ "o"
+#define __UINT_LEAST32_FMTu__ "u"
+#define __UINT_LEAST32_FMTx__ "x"
+#define __UINT_LEAST32_MAX__ 4294967295U
+#define __UINT_LEAST32_TYPE__ unsigned int
+#define __UINT_LEAST64_FMTX__ "lX"
+#define __UINT_LEAST64_FMTo__ "lo"
+#define __UINT_LEAST64_FMTu__ "lu"
+#define __UINT_LEAST64_FMTx__ "lx"
+#define __UINT_LEAST64_MAX__ 18446744073709551615UL
+#define __UINT_LEAST64_TYPE__ long unsigned int
+#define __UINT_LEAST8_FMTX__ "hhX"
+#define __UINT_LEAST8_FMTo__ "hho"
+#define __UINT_LEAST8_FMTu__ "hhu"
+#define __UINT_LEAST8_FMTx__ "hhx"
+#define __UINT_LEAST8_MAX__ 255
+#define __UINT_LEAST8_TYPE__ unsigned char
+#define __USER_LABEL_PREFIX__ _
+#define __VERSION__ "4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)"
+#define __WCHAR_MAX__ 2147483647
+#define __WCHAR_TYPE__ int
+#define __WCHAR_WIDTH__ 32
+#define __WINT_TYPE__ int
+#define __WINT_WIDTH__ 32
+#define __amd64 1
+#define __amd64__ 1
+#define __apple_build_version__ 8020042
+#define __block __attribute__((__blocks__(byref)))
+#define __clang__ 1
+#define __clang_major__ 8
+#define __clang_minor__ 1
+#define __clang_patchlevel__ 0
+#define __clang_version__ "8.1.0 (clang-802.0.42)"
+#define __core2 1
+#define __core2__ 1
+#define __cplusplus 201103L
+#define __cpp_alias_templates 200704
+#define __cpp_attributes 200809
+#define __cpp_constexpr 200704
+#define __cpp_decltype 200707
+#define __cpp_delegating_constructors 200604
+#define __cpp_exceptions 199711
+#define __cpp_inheriting_constructors 200802
+#define __cpp_initializer_lists 200806
+#define __cpp_lambdas 200907
+#define __cpp_nsdmi 200809
+#define __cpp_range_based_for 200907
+#define __cpp_raw_strings 200710
+#define __cpp_ref_qualifiers 200710
+#define __cpp_rtti 199711
+#define __cpp_rvalue_references 200610
+#define __cpp_static_assert 200410
+#define __cpp_unicode_characters 200704
+#define __cpp_unicode_literals 200710
+#define __cpp_user_defined_literals 200809
+#define __cpp_variadic_templates 200704
+#define __llvm__ 1
+#define __nonnull _Nonnull
+#define __null_unspecified _Null_unspecified
+#define __nullable _Nullable
+#define __pic__ 2
+#define __private_extern__ extern
+#define __strong 
+#define __tune_core2__ 1
+#define __unsafe_unretained 
+#define __weak __attribute__((objc_gc(weak)))
+#define __x86_64 1
+#define __x86_64__ 1

--- a/src/plugins/tbin/tbinplugin.cpp
+++ b/src/plugins/tbin/tbinplugin.cpp
@@ -164,7 +164,8 @@ Tiled::Map *TbinMapFormat::read(const QString &fileName)
             if (tlayer.tileSize.x != tmap.layers[0].tileSize.x || tlayer.tileSize.y != tmap.layers[0].tileSize.y)
                 throw std::invalid_argument(QT_TR_NOOP("Different tile sizes per layer are not supported."));
 
-            Tiled::TileLayer* layer = new Tiled::TileLayer(tlayer.id.c_str(), 0, 0, tlayer.layerSize.x, tlayer.layerSize.y);
+			// LUCA TODO: Do this properly, ask Bjorn
+            Tiled::TileLayer* layer = new Tiled::TileLayer(tlayer.id.c_str(), 0, 0, tlayer.layerSize.x, tlayer.layerSize.y, 0, 0);
             tbinToTiledProperties(tlayer.props, layer);
             Tiled::ObjectGroup* objects = new Tiled::ObjectGroup(tlayer.id.c_str(), 0, 0);
             for (std::size_t i = 0; i < tlayer.tiles.size(); ++i) {

--- a/src/plugins/tengine/moc_predefs.h
+++ b/src/plugins/tengine/moc_predefs.h
@@ -1,0 +1,357 @@
+#define OBJC_NEW_PROPERTIES 1
+#define _LP64 1
+#define __APPLE_CC__ 6000
+#define __APPLE__ 1
+#define __ATOMIC_ACQUIRE 2
+#define __ATOMIC_ACQ_REL 4
+#define __ATOMIC_CONSUME 1
+#define __ATOMIC_RELAXED 0
+#define __ATOMIC_RELEASE 3
+#define __ATOMIC_SEQ_CST 5
+#define __BIGGEST_ALIGNMENT__ 16
+#define __BLOCKS__ 1
+#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __CHAR16_TYPE__ unsigned short
+#define __CHAR32_TYPE__ unsigned int
+#define __CHAR_BIT__ 8
+#define __CONSTANT_CFSTRINGS__ 1
+#define __DBL_DECIMAL_DIG__ 17
+#define __DBL_DENORM_MIN__ 4.9406564584124654e-324
+#define __DBL_DIG__ 15
+#define __DBL_EPSILON__ 2.2204460492503131e-16
+#define __DBL_HAS_DENORM__ 1
+#define __DBL_HAS_INFINITY__ 1
+#define __DBL_HAS_QUIET_NAN__ 1
+#define __DBL_MANT_DIG__ 53
+#define __DBL_MAX_10_EXP__ 308
+#define __DBL_MAX_EXP__ 1024
+#define __DBL_MAX__ 1.7976931348623157e+308
+#define __DBL_MIN_10_EXP__ (-307)
+#define __DBL_MIN_EXP__ (-1021)
+#define __DBL_MIN__ 2.2250738585072014e-308
+#define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
+#define __DEPRECATED 1
+#define __DYNAMIC__ 1
+#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101000
+#define __EXCEPTIONS 1
+#define __FINITE_MATH_ONLY__ 0
+#define __FLT_DECIMAL_DIG__ 9
+#define __FLT_DENORM_MIN__ 1.40129846e-45F
+#define __FLT_DIG__ 6
+#define __FLT_EPSILON__ 1.19209290e-7F
+#define __FLT_EVAL_METHOD__ 0
+#define __FLT_HAS_DENORM__ 1
+#define __FLT_HAS_INFINITY__ 1
+#define __FLT_HAS_QUIET_NAN__ 1
+#define __FLT_MANT_DIG__ 24
+#define __FLT_MAX_10_EXP__ 38
+#define __FLT_MAX_EXP__ 128
+#define __FLT_MAX__ 3.40282347e+38F
+#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT_MIN_EXP__ (-125)
+#define __FLT_MIN__ 1.17549435e-38F
+#define __FLT_RADIX__ 2
+#define __FXSR__ 1
+#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+#define __GCC_ATOMIC_INT_LOCK_FREE 2
+#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
+#define __GLIBCXX_BITSIZE_INT_N_0 128
+#define __GLIBCXX_TYPE_INT_N_0 __int128
+#define __GNUC_GNU_INLINE__ 1
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 1
+#define __GNUC__ 4
+#define __GNUG__ 4
+#define __GXX_ABI_VERSION 1002
+#define __GXX_EXPERIMENTAL_CXX0X__ 1
+#define __GXX_RTTI 1
+#define __GXX_WEAK__ 1
+#define __INT16_C_SUFFIX__ 
+#define __INT16_FMTd__ "hd"
+#define __INT16_FMTi__ "hi"
+#define __INT16_MAX__ 32767
+#define __INT16_TYPE__ short
+#define __INT32_C_SUFFIX__ 
+#define __INT32_FMTd__ "d"
+#define __INT32_FMTi__ "i"
+#define __INT32_MAX__ 2147483647
+#define __INT32_TYPE__ int
+#define __INT64_C_SUFFIX__ LL
+#define __INT64_FMTd__ "lld"
+#define __INT64_FMTi__ "lli"
+#define __INT64_MAX__ 9223372036854775807LL
+#define __INT64_TYPE__ long long int
+#define __INT8_C_SUFFIX__ 
+#define __INT8_FMTd__ "hhd"
+#define __INT8_FMTi__ "hhi"
+#define __INT8_MAX__ 127
+#define __INT8_TYPE__ signed char
+#define __INTMAX_C_SUFFIX__ L
+#define __INTMAX_FMTd__ "ld"
+#define __INTMAX_FMTi__ "li"
+#define __INTMAX_MAX__ 9223372036854775807L
+#define __INTMAX_TYPE__ long int
+#define __INTMAX_WIDTH__ 64
+#define __INTPTR_FMTd__ "ld"
+#define __INTPTR_FMTi__ "li"
+#define __INTPTR_MAX__ 9223372036854775807L
+#define __INTPTR_TYPE__ long int
+#define __INTPTR_WIDTH__ 64
+#define __INT_FAST16_FMTd__ "hd"
+#define __INT_FAST16_FMTi__ "hi"
+#define __INT_FAST16_MAX__ 32767
+#define __INT_FAST16_TYPE__ short
+#define __INT_FAST32_FMTd__ "d"
+#define __INT_FAST32_FMTi__ "i"
+#define __INT_FAST32_MAX__ 2147483647
+#define __INT_FAST32_TYPE__ int
+#define __INT_FAST64_FMTd__ "ld"
+#define __INT_FAST64_FMTi__ "li"
+#define __INT_FAST64_MAX__ 9223372036854775807L
+#define __INT_FAST64_TYPE__ long int
+#define __INT_FAST8_FMTd__ "hhd"
+#define __INT_FAST8_FMTi__ "hhi"
+#define __INT_FAST8_MAX__ 127
+#define __INT_FAST8_TYPE__ signed char
+#define __INT_LEAST16_FMTd__ "hd"
+#define __INT_LEAST16_FMTi__ "hi"
+#define __INT_LEAST16_MAX__ 32767
+#define __INT_LEAST16_TYPE__ short
+#define __INT_LEAST32_FMTd__ "d"
+#define __INT_LEAST32_FMTi__ "i"
+#define __INT_LEAST32_MAX__ 2147483647
+#define __INT_LEAST32_TYPE__ int
+#define __INT_LEAST64_FMTd__ "ld"
+#define __INT_LEAST64_FMTi__ "li"
+#define __INT_LEAST64_MAX__ 9223372036854775807L
+#define __INT_LEAST64_TYPE__ long int
+#define __INT_LEAST8_FMTd__ "hhd"
+#define __INT_LEAST8_FMTi__ "hhi"
+#define __INT_LEAST8_MAX__ 127
+#define __INT_LEAST8_TYPE__ signed char
+#define __INT_MAX__ 2147483647
+#define __LDBL_DECIMAL_DIG__ 21
+#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+#define __LDBL_DIG__ 18
+#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
+#define __LDBL_HAS_DENORM__ 1
+#define __LDBL_HAS_INFINITY__ 1
+#define __LDBL_HAS_QUIET_NAN__ 1
+#define __LDBL_MANT_DIG__ 64
+#define __LDBL_MAX_10_EXP__ 4932
+#define __LDBL_MAX_EXP__ 16384
+#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+#define __LDBL_MIN_10_EXP__ (-4931)
+#define __LDBL_MIN_EXP__ (-16381)
+#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+#define __LITTLE_ENDIAN__ 1
+#define __LONG_LONG_MAX__ 9223372036854775807LL
+#define __LONG_MAX__ 9223372036854775807L
+#define __LP64__ 1
+#define __MACH__ 1
+#define __MMX__ 1
+#define __NO_MATH_INLINES 1
+#define __OBJC_BOOL_IS_BOOL 0
+#define __OPTIMIZE__ 1
+#define __ORDER_BIG_ENDIAN__ 4321
+#define __ORDER_LITTLE_ENDIAN__ 1234
+#define __ORDER_PDP_ENDIAN__ 3412
+#define __PIC__ 2
+#define __POINTER_WIDTH__ 64
+#define __PRAGMA_REDEFINE_EXTNAME 1
+#define __PTRDIFF_FMTd__ "ld"
+#define __PTRDIFF_FMTi__ "li"
+#define __PTRDIFF_MAX__ 9223372036854775807L
+#define __PTRDIFF_TYPE__ long int
+#define __PTRDIFF_WIDTH__ 64
+#define __REGISTER_PREFIX__ 
+#define __SCHAR_MAX__ 127
+#define __SHRT_MAX__ 32767
+#define __SIG_ATOMIC_MAX__ 2147483647
+#define __SIG_ATOMIC_WIDTH__ 32
+#define __SIZEOF_DOUBLE__ 8
+#define __SIZEOF_FLOAT__ 4
+#define __SIZEOF_INT128__ 16
+#define __SIZEOF_INT__ 4
+#define __SIZEOF_LONG_DOUBLE__ 16
+#define __SIZEOF_LONG_LONG__ 8
+#define __SIZEOF_LONG__ 8
+#define __SIZEOF_POINTER__ 8
+#define __SIZEOF_PTRDIFF_T__ 8
+#define __SIZEOF_SHORT__ 2
+#define __SIZEOF_SIZE_T__ 8
+#define __SIZEOF_WCHAR_T__ 4
+#define __SIZEOF_WINT_T__ 4
+#define __SIZE_FMTX__ "lX"
+#define __SIZE_FMTo__ "lo"
+#define __SIZE_FMTu__ "lu"
+#define __SIZE_FMTx__ "lx"
+#define __SIZE_MAX__ 18446744073709551615UL
+#define __SIZE_TYPE__ long unsigned int
+#define __SIZE_WIDTH__ 64
+#define __SSE2_MATH__ 1
+#define __SSE2__ 1
+#define __SSE3__ 1
+#define __SSE_MATH__ 1
+#define __SSE__ 1
+#define __SSP__ 1
+#define __SSSE3__ 1
+#define __STDC_HOSTED__ 1
+#define __STDC_UTF_16__ 1
+#define __STDC_UTF_32__ 1
+#define __STDC__ 1
+#define __UINT16_C_SUFFIX__ 
+#define __UINT16_FMTX__ "hX"
+#define __UINT16_FMTo__ "ho"
+#define __UINT16_FMTu__ "hu"
+#define __UINT16_FMTx__ "hx"
+#define __UINT16_MAX__ 65535
+#define __UINT16_TYPE__ unsigned short
+#define __UINT32_C_SUFFIX__ U
+#define __UINT32_FMTX__ "X"
+#define __UINT32_FMTo__ "o"
+#define __UINT32_FMTu__ "u"
+#define __UINT32_FMTx__ "x"
+#define __UINT32_MAX__ 4294967295U
+#define __UINT32_TYPE__ unsigned int
+#define __UINT64_C_SUFFIX__ ULL
+#define __UINT64_FMTX__ "llX"
+#define __UINT64_FMTo__ "llo"
+#define __UINT64_FMTu__ "llu"
+#define __UINT64_FMTx__ "llx"
+#define __UINT64_MAX__ 18446744073709551615ULL
+#define __UINT64_TYPE__ long long unsigned int
+#define __UINT8_C_SUFFIX__ 
+#define __UINT8_FMTX__ "hhX"
+#define __UINT8_FMTo__ "hho"
+#define __UINT8_FMTu__ "hhu"
+#define __UINT8_FMTx__ "hhx"
+#define __UINT8_MAX__ 255
+#define __UINT8_TYPE__ unsigned char
+#define __UINTMAX_C_SUFFIX__ UL
+#define __UINTMAX_FMTX__ "lX"
+#define __UINTMAX_FMTo__ "lo"
+#define __UINTMAX_FMTu__ "lu"
+#define __UINTMAX_FMTx__ "lx"
+#define __UINTMAX_MAX__ 18446744073709551615UL
+#define __UINTMAX_TYPE__ long unsigned int
+#define __UINTMAX_WIDTH__ 64
+#define __UINTPTR_FMTX__ "lX"
+#define __UINTPTR_FMTo__ "lo"
+#define __UINTPTR_FMTu__ "lu"
+#define __UINTPTR_FMTx__ "lx"
+#define __UINTPTR_MAX__ 18446744073709551615UL
+#define __UINTPTR_TYPE__ long unsigned int
+#define __UINTPTR_WIDTH__ 64
+#define __UINT_FAST16_FMTX__ "hX"
+#define __UINT_FAST16_FMTo__ "ho"
+#define __UINT_FAST16_FMTu__ "hu"
+#define __UINT_FAST16_FMTx__ "hx"
+#define __UINT_FAST16_MAX__ 65535
+#define __UINT_FAST16_TYPE__ unsigned short
+#define __UINT_FAST32_FMTX__ "X"
+#define __UINT_FAST32_FMTo__ "o"
+#define __UINT_FAST32_FMTu__ "u"
+#define __UINT_FAST32_FMTx__ "x"
+#define __UINT_FAST32_MAX__ 4294967295U
+#define __UINT_FAST32_TYPE__ unsigned int
+#define __UINT_FAST64_FMTX__ "lX"
+#define __UINT_FAST64_FMTo__ "lo"
+#define __UINT_FAST64_FMTu__ "lu"
+#define __UINT_FAST64_FMTx__ "lx"
+#define __UINT_FAST64_MAX__ 18446744073709551615UL
+#define __UINT_FAST64_TYPE__ long unsigned int
+#define __UINT_FAST8_FMTX__ "hhX"
+#define __UINT_FAST8_FMTo__ "hho"
+#define __UINT_FAST8_FMTu__ "hhu"
+#define __UINT_FAST8_FMTx__ "hhx"
+#define __UINT_FAST8_MAX__ 255
+#define __UINT_FAST8_TYPE__ unsigned char
+#define __UINT_LEAST16_FMTX__ "hX"
+#define __UINT_LEAST16_FMTo__ "ho"
+#define __UINT_LEAST16_FMTu__ "hu"
+#define __UINT_LEAST16_FMTx__ "hx"
+#define __UINT_LEAST16_MAX__ 65535
+#define __UINT_LEAST16_TYPE__ unsigned short
+#define __UINT_LEAST32_FMTX__ "X"
+#define __UINT_LEAST32_FMTo__ "o"
+#define __UINT_LEAST32_FMTu__ "u"
+#define __UINT_LEAST32_FMTx__ "x"
+#define __UINT_LEAST32_MAX__ 4294967295U
+#define __UINT_LEAST32_TYPE__ unsigned int
+#define __UINT_LEAST64_FMTX__ "lX"
+#define __UINT_LEAST64_FMTo__ "lo"
+#define __UINT_LEAST64_FMTu__ "lu"
+#define __UINT_LEAST64_FMTx__ "lx"
+#define __UINT_LEAST64_MAX__ 18446744073709551615UL
+#define __UINT_LEAST64_TYPE__ long unsigned int
+#define __UINT_LEAST8_FMTX__ "hhX"
+#define __UINT_LEAST8_FMTo__ "hho"
+#define __UINT_LEAST8_FMTu__ "hhu"
+#define __UINT_LEAST8_FMTx__ "hhx"
+#define __UINT_LEAST8_MAX__ 255
+#define __UINT_LEAST8_TYPE__ unsigned char
+#define __USER_LABEL_PREFIX__ _
+#define __VERSION__ "4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)"
+#define __WCHAR_MAX__ 2147483647
+#define __WCHAR_TYPE__ int
+#define __WCHAR_WIDTH__ 32
+#define __WINT_TYPE__ int
+#define __WINT_WIDTH__ 32
+#define __amd64 1
+#define __amd64__ 1
+#define __apple_build_version__ 8020042
+#define __block __attribute__((__blocks__(byref)))
+#define __clang__ 1
+#define __clang_major__ 8
+#define __clang_minor__ 1
+#define __clang_patchlevel__ 0
+#define __clang_version__ "8.1.0 (clang-802.0.42)"
+#define __core2 1
+#define __core2__ 1
+#define __cplusplus 201103L
+#define __cpp_alias_templates 200704
+#define __cpp_attributes 200809
+#define __cpp_constexpr 200704
+#define __cpp_decltype 200707
+#define __cpp_delegating_constructors 200604
+#define __cpp_exceptions 199711
+#define __cpp_inheriting_constructors 200802
+#define __cpp_initializer_lists 200806
+#define __cpp_lambdas 200907
+#define __cpp_nsdmi 200809
+#define __cpp_range_based_for 200907
+#define __cpp_raw_strings 200710
+#define __cpp_ref_qualifiers 200710
+#define __cpp_rtti 199711
+#define __cpp_rvalue_references 200610
+#define __cpp_static_assert 200410
+#define __cpp_unicode_characters 200704
+#define __cpp_unicode_literals 200710
+#define __cpp_user_defined_literals 200809
+#define __cpp_variadic_templates 200704
+#define __llvm__ 1
+#define __nonnull _Nonnull
+#define __null_unspecified _Null_unspecified
+#define __nullable _Nullable
+#define __pic__ 2
+#define __private_extern__ extern
+#define __strong 
+#define __tune_core2__ 1
+#define __unsafe_unretained 
+#define __weak __attribute__((objc_gc(weak)))
+#define __x86_64 1
+#define __x86_64__ 1

--- a/src/plugins/tmw/moc_predefs.h
+++ b/src/plugins/tmw/moc_predefs.h
@@ -1,0 +1,357 @@
+#define OBJC_NEW_PROPERTIES 1
+#define _LP64 1
+#define __APPLE_CC__ 6000
+#define __APPLE__ 1
+#define __ATOMIC_ACQUIRE 2
+#define __ATOMIC_ACQ_REL 4
+#define __ATOMIC_CONSUME 1
+#define __ATOMIC_RELAXED 0
+#define __ATOMIC_RELEASE 3
+#define __ATOMIC_SEQ_CST 5
+#define __BIGGEST_ALIGNMENT__ 16
+#define __BLOCKS__ 1
+#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __CHAR16_TYPE__ unsigned short
+#define __CHAR32_TYPE__ unsigned int
+#define __CHAR_BIT__ 8
+#define __CONSTANT_CFSTRINGS__ 1
+#define __DBL_DECIMAL_DIG__ 17
+#define __DBL_DENORM_MIN__ 4.9406564584124654e-324
+#define __DBL_DIG__ 15
+#define __DBL_EPSILON__ 2.2204460492503131e-16
+#define __DBL_HAS_DENORM__ 1
+#define __DBL_HAS_INFINITY__ 1
+#define __DBL_HAS_QUIET_NAN__ 1
+#define __DBL_MANT_DIG__ 53
+#define __DBL_MAX_10_EXP__ 308
+#define __DBL_MAX_EXP__ 1024
+#define __DBL_MAX__ 1.7976931348623157e+308
+#define __DBL_MIN_10_EXP__ (-307)
+#define __DBL_MIN_EXP__ (-1021)
+#define __DBL_MIN__ 2.2250738585072014e-308
+#define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
+#define __DEPRECATED 1
+#define __DYNAMIC__ 1
+#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101000
+#define __EXCEPTIONS 1
+#define __FINITE_MATH_ONLY__ 0
+#define __FLT_DECIMAL_DIG__ 9
+#define __FLT_DENORM_MIN__ 1.40129846e-45F
+#define __FLT_DIG__ 6
+#define __FLT_EPSILON__ 1.19209290e-7F
+#define __FLT_EVAL_METHOD__ 0
+#define __FLT_HAS_DENORM__ 1
+#define __FLT_HAS_INFINITY__ 1
+#define __FLT_HAS_QUIET_NAN__ 1
+#define __FLT_MANT_DIG__ 24
+#define __FLT_MAX_10_EXP__ 38
+#define __FLT_MAX_EXP__ 128
+#define __FLT_MAX__ 3.40282347e+38F
+#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT_MIN_EXP__ (-125)
+#define __FLT_MIN__ 1.17549435e-38F
+#define __FLT_RADIX__ 2
+#define __FXSR__ 1
+#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+#define __GCC_ATOMIC_INT_LOCK_FREE 2
+#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
+#define __GLIBCXX_BITSIZE_INT_N_0 128
+#define __GLIBCXX_TYPE_INT_N_0 __int128
+#define __GNUC_GNU_INLINE__ 1
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 1
+#define __GNUC__ 4
+#define __GNUG__ 4
+#define __GXX_ABI_VERSION 1002
+#define __GXX_EXPERIMENTAL_CXX0X__ 1
+#define __GXX_RTTI 1
+#define __GXX_WEAK__ 1
+#define __INT16_C_SUFFIX__ 
+#define __INT16_FMTd__ "hd"
+#define __INT16_FMTi__ "hi"
+#define __INT16_MAX__ 32767
+#define __INT16_TYPE__ short
+#define __INT32_C_SUFFIX__ 
+#define __INT32_FMTd__ "d"
+#define __INT32_FMTi__ "i"
+#define __INT32_MAX__ 2147483647
+#define __INT32_TYPE__ int
+#define __INT64_C_SUFFIX__ LL
+#define __INT64_FMTd__ "lld"
+#define __INT64_FMTi__ "lli"
+#define __INT64_MAX__ 9223372036854775807LL
+#define __INT64_TYPE__ long long int
+#define __INT8_C_SUFFIX__ 
+#define __INT8_FMTd__ "hhd"
+#define __INT8_FMTi__ "hhi"
+#define __INT8_MAX__ 127
+#define __INT8_TYPE__ signed char
+#define __INTMAX_C_SUFFIX__ L
+#define __INTMAX_FMTd__ "ld"
+#define __INTMAX_FMTi__ "li"
+#define __INTMAX_MAX__ 9223372036854775807L
+#define __INTMAX_TYPE__ long int
+#define __INTMAX_WIDTH__ 64
+#define __INTPTR_FMTd__ "ld"
+#define __INTPTR_FMTi__ "li"
+#define __INTPTR_MAX__ 9223372036854775807L
+#define __INTPTR_TYPE__ long int
+#define __INTPTR_WIDTH__ 64
+#define __INT_FAST16_FMTd__ "hd"
+#define __INT_FAST16_FMTi__ "hi"
+#define __INT_FAST16_MAX__ 32767
+#define __INT_FAST16_TYPE__ short
+#define __INT_FAST32_FMTd__ "d"
+#define __INT_FAST32_FMTi__ "i"
+#define __INT_FAST32_MAX__ 2147483647
+#define __INT_FAST32_TYPE__ int
+#define __INT_FAST64_FMTd__ "ld"
+#define __INT_FAST64_FMTi__ "li"
+#define __INT_FAST64_MAX__ 9223372036854775807L
+#define __INT_FAST64_TYPE__ long int
+#define __INT_FAST8_FMTd__ "hhd"
+#define __INT_FAST8_FMTi__ "hhi"
+#define __INT_FAST8_MAX__ 127
+#define __INT_FAST8_TYPE__ signed char
+#define __INT_LEAST16_FMTd__ "hd"
+#define __INT_LEAST16_FMTi__ "hi"
+#define __INT_LEAST16_MAX__ 32767
+#define __INT_LEAST16_TYPE__ short
+#define __INT_LEAST32_FMTd__ "d"
+#define __INT_LEAST32_FMTi__ "i"
+#define __INT_LEAST32_MAX__ 2147483647
+#define __INT_LEAST32_TYPE__ int
+#define __INT_LEAST64_FMTd__ "ld"
+#define __INT_LEAST64_FMTi__ "li"
+#define __INT_LEAST64_MAX__ 9223372036854775807L
+#define __INT_LEAST64_TYPE__ long int
+#define __INT_LEAST8_FMTd__ "hhd"
+#define __INT_LEAST8_FMTi__ "hhi"
+#define __INT_LEAST8_MAX__ 127
+#define __INT_LEAST8_TYPE__ signed char
+#define __INT_MAX__ 2147483647
+#define __LDBL_DECIMAL_DIG__ 21
+#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+#define __LDBL_DIG__ 18
+#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
+#define __LDBL_HAS_DENORM__ 1
+#define __LDBL_HAS_INFINITY__ 1
+#define __LDBL_HAS_QUIET_NAN__ 1
+#define __LDBL_MANT_DIG__ 64
+#define __LDBL_MAX_10_EXP__ 4932
+#define __LDBL_MAX_EXP__ 16384
+#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+#define __LDBL_MIN_10_EXP__ (-4931)
+#define __LDBL_MIN_EXP__ (-16381)
+#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+#define __LITTLE_ENDIAN__ 1
+#define __LONG_LONG_MAX__ 9223372036854775807LL
+#define __LONG_MAX__ 9223372036854775807L
+#define __LP64__ 1
+#define __MACH__ 1
+#define __MMX__ 1
+#define __NO_MATH_INLINES 1
+#define __OBJC_BOOL_IS_BOOL 0
+#define __OPTIMIZE__ 1
+#define __ORDER_BIG_ENDIAN__ 4321
+#define __ORDER_LITTLE_ENDIAN__ 1234
+#define __ORDER_PDP_ENDIAN__ 3412
+#define __PIC__ 2
+#define __POINTER_WIDTH__ 64
+#define __PRAGMA_REDEFINE_EXTNAME 1
+#define __PTRDIFF_FMTd__ "ld"
+#define __PTRDIFF_FMTi__ "li"
+#define __PTRDIFF_MAX__ 9223372036854775807L
+#define __PTRDIFF_TYPE__ long int
+#define __PTRDIFF_WIDTH__ 64
+#define __REGISTER_PREFIX__ 
+#define __SCHAR_MAX__ 127
+#define __SHRT_MAX__ 32767
+#define __SIG_ATOMIC_MAX__ 2147483647
+#define __SIG_ATOMIC_WIDTH__ 32
+#define __SIZEOF_DOUBLE__ 8
+#define __SIZEOF_FLOAT__ 4
+#define __SIZEOF_INT128__ 16
+#define __SIZEOF_INT__ 4
+#define __SIZEOF_LONG_DOUBLE__ 16
+#define __SIZEOF_LONG_LONG__ 8
+#define __SIZEOF_LONG__ 8
+#define __SIZEOF_POINTER__ 8
+#define __SIZEOF_PTRDIFF_T__ 8
+#define __SIZEOF_SHORT__ 2
+#define __SIZEOF_SIZE_T__ 8
+#define __SIZEOF_WCHAR_T__ 4
+#define __SIZEOF_WINT_T__ 4
+#define __SIZE_FMTX__ "lX"
+#define __SIZE_FMTo__ "lo"
+#define __SIZE_FMTu__ "lu"
+#define __SIZE_FMTx__ "lx"
+#define __SIZE_MAX__ 18446744073709551615UL
+#define __SIZE_TYPE__ long unsigned int
+#define __SIZE_WIDTH__ 64
+#define __SSE2_MATH__ 1
+#define __SSE2__ 1
+#define __SSE3__ 1
+#define __SSE_MATH__ 1
+#define __SSE__ 1
+#define __SSP__ 1
+#define __SSSE3__ 1
+#define __STDC_HOSTED__ 1
+#define __STDC_UTF_16__ 1
+#define __STDC_UTF_32__ 1
+#define __STDC__ 1
+#define __UINT16_C_SUFFIX__ 
+#define __UINT16_FMTX__ "hX"
+#define __UINT16_FMTo__ "ho"
+#define __UINT16_FMTu__ "hu"
+#define __UINT16_FMTx__ "hx"
+#define __UINT16_MAX__ 65535
+#define __UINT16_TYPE__ unsigned short
+#define __UINT32_C_SUFFIX__ U
+#define __UINT32_FMTX__ "X"
+#define __UINT32_FMTo__ "o"
+#define __UINT32_FMTu__ "u"
+#define __UINT32_FMTx__ "x"
+#define __UINT32_MAX__ 4294967295U
+#define __UINT32_TYPE__ unsigned int
+#define __UINT64_C_SUFFIX__ ULL
+#define __UINT64_FMTX__ "llX"
+#define __UINT64_FMTo__ "llo"
+#define __UINT64_FMTu__ "llu"
+#define __UINT64_FMTx__ "llx"
+#define __UINT64_MAX__ 18446744073709551615ULL
+#define __UINT64_TYPE__ long long unsigned int
+#define __UINT8_C_SUFFIX__ 
+#define __UINT8_FMTX__ "hhX"
+#define __UINT8_FMTo__ "hho"
+#define __UINT8_FMTu__ "hhu"
+#define __UINT8_FMTx__ "hhx"
+#define __UINT8_MAX__ 255
+#define __UINT8_TYPE__ unsigned char
+#define __UINTMAX_C_SUFFIX__ UL
+#define __UINTMAX_FMTX__ "lX"
+#define __UINTMAX_FMTo__ "lo"
+#define __UINTMAX_FMTu__ "lu"
+#define __UINTMAX_FMTx__ "lx"
+#define __UINTMAX_MAX__ 18446744073709551615UL
+#define __UINTMAX_TYPE__ long unsigned int
+#define __UINTMAX_WIDTH__ 64
+#define __UINTPTR_FMTX__ "lX"
+#define __UINTPTR_FMTo__ "lo"
+#define __UINTPTR_FMTu__ "lu"
+#define __UINTPTR_FMTx__ "lx"
+#define __UINTPTR_MAX__ 18446744073709551615UL
+#define __UINTPTR_TYPE__ long unsigned int
+#define __UINTPTR_WIDTH__ 64
+#define __UINT_FAST16_FMTX__ "hX"
+#define __UINT_FAST16_FMTo__ "ho"
+#define __UINT_FAST16_FMTu__ "hu"
+#define __UINT_FAST16_FMTx__ "hx"
+#define __UINT_FAST16_MAX__ 65535
+#define __UINT_FAST16_TYPE__ unsigned short
+#define __UINT_FAST32_FMTX__ "X"
+#define __UINT_FAST32_FMTo__ "o"
+#define __UINT_FAST32_FMTu__ "u"
+#define __UINT_FAST32_FMTx__ "x"
+#define __UINT_FAST32_MAX__ 4294967295U
+#define __UINT_FAST32_TYPE__ unsigned int
+#define __UINT_FAST64_FMTX__ "lX"
+#define __UINT_FAST64_FMTo__ "lo"
+#define __UINT_FAST64_FMTu__ "lu"
+#define __UINT_FAST64_FMTx__ "lx"
+#define __UINT_FAST64_MAX__ 18446744073709551615UL
+#define __UINT_FAST64_TYPE__ long unsigned int
+#define __UINT_FAST8_FMTX__ "hhX"
+#define __UINT_FAST8_FMTo__ "hho"
+#define __UINT_FAST8_FMTu__ "hhu"
+#define __UINT_FAST8_FMTx__ "hhx"
+#define __UINT_FAST8_MAX__ 255
+#define __UINT_FAST8_TYPE__ unsigned char
+#define __UINT_LEAST16_FMTX__ "hX"
+#define __UINT_LEAST16_FMTo__ "ho"
+#define __UINT_LEAST16_FMTu__ "hu"
+#define __UINT_LEAST16_FMTx__ "hx"
+#define __UINT_LEAST16_MAX__ 65535
+#define __UINT_LEAST16_TYPE__ unsigned short
+#define __UINT_LEAST32_FMTX__ "X"
+#define __UINT_LEAST32_FMTo__ "o"
+#define __UINT_LEAST32_FMTu__ "u"
+#define __UINT_LEAST32_FMTx__ "x"
+#define __UINT_LEAST32_MAX__ 4294967295U
+#define __UINT_LEAST32_TYPE__ unsigned int
+#define __UINT_LEAST64_FMTX__ "lX"
+#define __UINT_LEAST64_FMTo__ "lo"
+#define __UINT_LEAST64_FMTu__ "lu"
+#define __UINT_LEAST64_FMTx__ "lx"
+#define __UINT_LEAST64_MAX__ 18446744073709551615UL
+#define __UINT_LEAST64_TYPE__ long unsigned int
+#define __UINT_LEAST8_FMTX__ "hhX"
+#define __UINT_LEAST8_FMTo__ "hho"
+#define __UINT_LEAST8_FMTu__ "hhu"
+#define __UINT_LEAST8_FMTx__ "hhx"
+#define __UINT_LEAST8_MAX__ 255
+#define __UINT_LEAST8_TYPE__ unsigned char
+#define __USER_LABEL_PREFIX__ _
+#define __VERSION__ "4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)"
+#define __WCHAR_MAX__ 2147483647
+#define __WCHAR_TYPE__ int
+#define __WCHAR_WIDTH__ 32
+#define __WINT_TYPE__ int
+#define __WINT_WIDTH__ 32
+#define __amd64 1
+#define __amd64__ 1
+#define __apple_build_version__ 8020042
+#define __block __attribute__((__blocks__(byref)))
+#define __clang__ 1
+#define __clang_major__ 8
+#define __clang_minor__ 1
+#define __clang_patchlevel__ 0
+#define __clang_version__ "8.1.0 (clang-802.0.42)"
+#define __core2 1
+#define __core2__ 1
+#define __cplusplus 201103L
+#define __cpp_alias_templates 200704
+#define __cpp_attributes 200809
+#define __cpp_constexpr 200704
+#define __cpp_decltype 200707
+#define __cpp_delegating_constructors 200604
+#define __cpp_exceptions 199711
+#define __cpp_inheriting_constructors 200802
+#define __cpp_initializer_lists 200806
+#define __cpp_lambdas 200907
+#define __cpp_nsdmi 200809
+#define __cpp_range_based_for 200907
+#define __cpp_raw_strings 200710
+#define __cpp_ref_qualifiers 200710
+#define __cpp_rtti 199711
+#define __cpp_rvalue_references 200610
+#define __cpp_static_assert 200410
+#define __cpp_unicode_characters 200704
+#define __cpp_unicode_literals 200710
+#define __cpp_user_defined_literals 200809
+#define __cpp_variadic_templates 200704
+#define __llvm__ 1
+#define __nonnull _Nonnull
+#define __null_unspecified _Null_unspecified
+#define __nullable _Nullable
+#define __pic__ 2
+#define __private_extern__ extern
+#define __strong 
+#define __tune_core2__ 1
+#define __unsafe_unretained 
+#define __weak __attribute__((objc_gc(weak)))
+#define __x86_64 1
+#define __x86_64__ 1

--- a/src/tiled/abstractobjecttool.cpp
+++ b/src/tiled/abstractobjecttool.cpp
@@ -106,12 +106,12 @@ void AbstractObjectTool::mouseMoved(const QPointF &pos,
     if (layer)
         offsetPos -= layer->totalOffset();
 
-	QRect workSize;
-	mapDocument()->currentWorkSpace(workSize);
+	QRect workSpace;
+	mapDocument()->currentWorkSpace(workSpace);
 
     const QPoint pixelPos = offsetPos.toPoint();
 
-    const QPointF tilePosF = mapDocument()->renderer()->screenToTileCoords(offsetPos, workSize);
+    const QPointF tilePosF = mapDocument()->renderer()->screenToTileCoords(offsetPos, workSpace);
     const int x = (int) std::floor(tilePosF.x());
     const int y = (int) std::floor(tilePosF.y());
     setStatusInfo(QString(QLatin1String("%1, %2 (%3, %4)")).arg(x).arg(y).arg(pixelPos.x()).arg(pixelPos.y()));

--- a/src/tiled/abstractobjecttool.cpp
+++ b/src/tiled/abstractobjecttool.cpp
@@ -31,6 +31,7 @@
 #include "resizemapobject.h"
 #include "tile.h"
 #include "utils.h"
+#include "workspace.h"
 
 #include <QKeyEvent>
 #include <QMenu>
@@ -106,7 +107,7 @@ void AbstractObjectTool::mouseMoved(const QPointF &pos,
     if (layer)
         offsetPos -= layer->totalOffset();
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mapDocument()->currentWorkSpace(workSpace);
 
     const QPoint pixelPos = offsetPos.toPoint();

--- a/src/tiled/abstractobjecttool.cpp
+++ b/src/tiled/abstractobjecttool.cpp
@@ -102,12 +102,16 @@ void AbstractObjectTool::mouseMoved(const QPointF &pos,
 {
     // Take into account the offset of the current layer
     QPointF offsetPos = pos;
-    if (Layer *layer = currentLayer())
+    Layer *layer = currentLayer();
+    if (layer)
         offsetPos -= layer->totalOffset();
+
+	QRect workSize;
+	mapDocument()->currentWorkSpace(workSize);
 
     const QPoint pixelPos = offsetPos.toPoint();
 
-    const QPointF tilePosF = mapDocument()->renderer()->screenToTileCoords(offsetPos);
+    const QPointF tilePosF = mapDocument()->renderer()->screenToTileCoords(offsetPos, workSize);
     const int x = (int) std::floor(tilePosF.x());
     const int y = (int) std::floor(tilePosF.y());
     setStatusInfo(QString(QLatin1String("%1, %2 (%3, %4)")).arg(x).arg(y).arg(pixelPos.x()).arg(pixelPos.y()));

--- a/src/tiled/abstracttiletool.cpp
+++ b/src/tiled/abstracttiletool.cpp
@@ -75,13 +75,18 @@ void AbstractTileTool::mouseMoved(const QPointF &pos, Qt::KeyboardModifiers)
 {
     // Take into account the offset of the current layer
     QPointF offsetPos = pos;
-    if (Layer *layer = currentLayer()) {
+    Layer *layer = currentLayer();
+    if (layer) {
         offsetPos -= layer->totalOffset();
         mBrushItem->setLayerOffset(layer->totalOffset());
     }
 
     const MapRenderer *renderer = mapDocument()->renderer();
-    const QPointF tilePosF = renderer->screenToTileCoords(offsetPos);
+
+	QRect workSize;
+	mapDocument()->currentWorkSpace(workSize);
+
+    const QPointF tilePosF = renderer->screenToTileCoords(offsetPos, workSize);
     QPoint tilePos;
 
     if (mTilePositionMethod == BetweenTiles)

--- a/src/tiled/abstracttiletool.cpp
+++ b/src/tiled/abstracttiletool.cpp
@@ -83,10 +83,10 @@ void AbstractTileTool::mouseMoved(const QPointF &pos, Qt::KeyboardModifiers)
 
     const MapRenderer *renderer = mapDocument()->renderer();
 
-	QRect workSize;
-	mapDocument()->currentWorkSpace(workSize);
+	QRect workSpace;
+	mapDocument()->currentWorkSpace(workSpace);
 
-    const QPointF tilePosF = renderer->screenToTileCoords(offsetPos, workSize);
+    const QPointF tilePosF = renderer->screenToTileCoords(offsetPos, workSpace);
     QPoint tilePos;
 
     if (mTilePositionMethod == BetweenTiles)

--- a/src/tiled/abstracttiletool.cpp
+++ b/src/tiled/abstracttiletool.cpp
@@ -27,6 +27,7 @@
 #include "mapscene.h"
 #include "tile.h"
 #include "tilelayer.h"
+#include "workspace.h"
 
 #include <cmath>
 
@@ -83,7 +84,7 @@ void AbstractTileTool::mouseMoved(const QPointF &pos, Qt::KeyboardModifiers)
 
     const MapRenderer *renderer = mapDocument()->renderer();
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mapDocument()->currentWorkSpace(workSpace);
 
     const QPointF tilePosF = renderer->screenToTileCoords(offsetPos, workSpace);

--- a/src/tiled/adjusttileindexes.cpp
+++ b/src/tiled/adjusttileindexes.cpp
@@ -81,7 +81,9 @@ AdjustTileIndexes::AdjustTileIndexes(MapDocument *mapDocument,
                 const QRect boundingRect(region.boundingRect());
                 auto changedLayer = new TileLayer(QString(), 0, 0,
                                                   boundingRect.width(),
-                                                  boundingRect.height());
+                                                  boundingRect.height(),
+												  mapDocument->map()->tileWidth(),
+												  mapDocument->map()->tileHeight());
 
                 for (const QRect &rect : region.rects()) {
                     for (int x = rect.left(); x <= rect.right(); ++x) {

--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -837,13 +837,8 @@ void AutoMapper::copyObjectRegion(const ObjectGroup *srcLayer, int srcX, int src
 {
     QUndoStack *undo = mMapDocument->undoStack();
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
-
-	TileLayer* tLayer = mMapDocument->currentLayer()->layerType() == Layer::TileLayerType ? static_cast<TileLayer*>(mMapDocument->currentLayer()) : 0;
-	if (tLayer) {
-		workSpace = QRect(tLayer->width(), tLayer->height(), tLayer->tileWidth(), tLayer->tileHeight());
-	}
 
     const QRectF rect = QRectF(srcX, srcY, width, height);
     const QRectF pixelRect = mMapDocument->renderer()->tileToPixelCoords(rect, workSpace);

--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -837,19 +837,19 @@ void AutoMapper::copyObjectRegion(const ObjectGroup *srcLayer, int srcX, int src
 {
     QUndoStack *undo = mMapDocument->undoStack();
 
-	QRect workSize;
-	mMapDocument->currentWorkSpace(workSize);
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
 
 	TileLayer* tLayer = mMapDocument->currentLayer()->layerType() == Layer::TileLayerType ? static_cast<TileLayer*>(mMapDocument->currentLayer()) : 0;
 	if (tLayer) {
-		workSize = QRect(tLayer->width(), tLayer->height(), tLayer->tileWidth(), tLayer->tileHeight());
+		workSpace = QRect(tLayer->width(), tLayer->height(), tLayer->tileWidth(), tLayer->tileHeight());
 	}
 
     const QRectF rect = QRectF(srcX, srcY, width, height);
-    const QRectF pixelRect = mMapDocument->renderer()->tileToPixelCoords(rect, workSize);
+    const QRectF pixelRect = mMapDocument->renderer()->tileToPixelCoords(rect, workSpace);
     const QList<MapObject*> objects = objectsInRegion(srcLayer, pixelRect.toAlignedRect());
 
-    QPointF pixelOffset = mMapDocument->renderer()->tileToPixelCoords(dstX, dstY, workSize);
+    QPointF pixelOffset = mMapDocument->renderer()->tileToPixelCoords(dstX, dstY, workSpace);
     pixelOffset -= pixelRect.topLeft();
 
     for (MapObject *obj : objects) {

--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -353,7 +353,9 @@ bool AutoMapper::setupMissingLayers()
         const int index =  mMapWork->layerCount();
         TileLayer *tileLayer = new TileLayer(name, 0, 0,
                                              mMapWork->width(),
-                                             mMapWork->height());
+                                             mMapWork->height(),
+											 mMapWork->tileWidth(),
+											 mMapWork->tileHeight());
         undoStack->push(new AddLayer(mMapDocument, index, tileLayer, nullptr));
         mAddedLayers.append(tileLayer);
     }

--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -836,11 +836,20 @@ void AutoMapper::copyObjectRegion(const ObjectGroup *srcLayer, int srcX, int src
                                   ObjectGroup *dstLayer, int dstX, int dstY)
 {
     QUndoStack *undo = mMapDocument->undoStack();
+
+	QRect workSize;
+	mMapDocument->currentWorkSpace(workSize);
+
+	TileLayer* tLayer = mMapDocument->currentLayer()->layerType() == Layer::TileLayerType ? static_cast<TileLayer*>(mMapDocument->currentLayer()) : 0;
+	if (tLayer) {
+		workSize = QRect(tLayer->width(), tLayer->height(), tLayer->tileWidth(), tLayer->tileHeight());
+	}
+
     const QRectF rect = QRectF(srcX, srcY, width, height);
-    const QRectF pixelRect = mMapDocument->renderer()->tileToPixelCoords(rect);
+    const QRectF pixelRect = mMapDocument->renderer()->tileToPixelCoords(rect, workSize);
     const QList<MapObject*> objects = objectsInRegion(srcLayer, pixelRect.toAlignedRect());
 
-    QPointF pixelOffset = mMapDocument->renderer()->tileToPixelCoords(dstX, dstY);
+    QPointF pixelOffset = mMapDocument->renderer()->tileToPixelCoords(dstX, dstY, workSize);
     pixelOffset -= pixelRect.topLeft();
 
     for (MapObject *obj : objects) {

--- a/src/tiled/automapper.h
+++ b/src/tiled/automapper.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "tileset.h"
+#include "workspace.h"
 
 #include <QList>
 #include <QMap>

--- a/src/tiled/automappingutils.cpp
+++ b/src/tiled/automappingutils.cpp
@@ -39,8 +39,8 @@ void eraseRegionObjectGroup(MapDocument *mapDocument,
 {
     QUndoStack *undo = mapDocument->undoStack();
 
-	QRect workSize;
-	mapDocument->currentWorkSpace(workSize);
+	QRect workSpace;
+	mapDocument->currentWorkSpace(workSpace);
 
     const auto objects = layer->objects();
     for (MapObject *obj : objects) {
@@ -51,10 +51,10 @@ void eraseRegionObjectGroup(MapDocument *mapDocument,
 
         // Convert the boundary of the object into tile space
         const QRectF objBounds = obj->boundsUseTile();
-        QPointF tl = mapDocument->renderer()->pixelToTileCoords(objBounds.topLeft(), workSize);
-        QPointF tr = mapDocument->renderer()->pixelToTileCoords(objBounds.topRight(), workSize);
-        QPointF br = mapDocument->renderer()->pixelToTileCoords(objBounds.bottomRight(), workSize);
-        QPointF bl = mapDocument->renderer()->pixelToTileCoords(objBounds.bottomLeft(), workSize);
+        QPointF tl = mapDocument->renderer()->pixelToTileCoords(objBounds.topLeft(), workSpace);
+        QPointF tr = mapDocument->renderer()->pixelToTileCoords(objBounds.topRight(), workSpace);
+        QPointF br = mapDocument->renderer()->pixelToTileCoords(objBounds.bottomRight(), workSpace);
+        QPointF bl = mapDocument->renderer()->pixelToTileCoords(objBounds.bottomLeft(), workSpace);
 
         QRectF objInTileSpace;
         objInTileSpace.setTopLeft(tl);

--- a/src/tiled/automappingutils.cpp
+++ b/src/tiled/automappingutils.cpp
@@ -23,6 +23,7 @@
 
 #include "addremovemapobject.h"
 #include "mapdocument.h"
+#include "map.h"
 #include "mapobject.h"
 #include "maprenderer.h"
 #include "objectgroup.h"
@@ -38,6 +39,9 @@ void eraseRegionObjectGroup(MapDocument *mapDocument,
 {
     QUndoStack *undo = mapDocument->undoStack();
 
+	QRect workSize;
+	mapDocument->currentWorkSpace(workSize);
+
     const auto objects = layer->objects();
     for (MapObject *obj : objects) {
         // TODO: we are checking bounds, which is only correct for rectangles and
@@ -47,10 +51,10 @@ void eraseRegionObjectGroup(MapDocument *mapDocument,
 
         // Convert the boundary of the object into tile space
         const QRectF objBounds = obj->boundsUseTile();
-        QPointF tl = mapDocument->renderer()->pixelToTileCoords(objBounds.topLeft());
-        QPointF tr = mapDocument->renderer()->pixelToTileCoords(objBounds.topRight());
-        QPointF br = mapDocument->renderer()->pixelToTileCoords(objBounds.bottomRight());
-        QPointF bl = mapDocument->renderer()->pixelToTileCoords(objBounds.bottomLeft());
+        QPointF tl = mapDocument->renderer()->pixelToTileCoords(objBounds.topLeft(), workSize);
+        QPointF tr = mapDocument->renderer()->pixelToTileCoords(objBounds.topRight(), workSize);
+        QPointF br = mapDocument->renderer()->pixelToTileCoords(objBounds.bottomRight(), workSize);
+        QPointF bl = mapDocument->renderer()->pixelToTileCoords(objBounds.bottomLeft(), workSize);
 
         QRectF objInTileSpace;
         objInTileSpace.setTopLeft(tl);

--- a/src/tiled/automappingutils.cpp
+++ b/src/tiled/automappingutils.cpp
@@ -27,6 +27,7 @@
 #include "mapobject.h"
 #include "maprenderer.h"
 #include "objectgroup.h"
+#include "workspace.h"
 
 #include <QUndoStack>
 
@@ -39,7 +40,7 @@ void eraseRegionObjectGroup(MapDocument *mapDocument,
 {
     QUndoStack *undo = mapDocument->undoStack();
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mapDocument->currentWorkSpace(workSpace);
 
     const auto objects = layer->objects();

--- a/src/tiled/brushitem.cpp
+++ b/src/tiled/brushitem.cpp
@@ -135,7 +135,7 @@ void BrushItem::paint(QPainter *painter,
     insideMapHighlight.setAlpha(64);
     QColor outsideMapHighlight = QColor(255, 0, 0, 64);
     
-	TileLayer* tileLayer = mMapDocument->currentLayer()->layerType() == Layer::TileLayerType ? static_cast<TileLayer*>(mMapDocument->currentLayer()) : 0;
+	TileLayer* tileLayer = mMapDocument->currentLayer()->asTileLayer();
     int layerWidth = tileLayer ? tileLayer->width() : mMapDocument->map()->width();
     int layerHeight = tileLayer? tileLayer->height() : mMapDocument->map()->height();
 

--- a/src/tiled/brushitem.cpp
+++ b/src/tiled/brushitem.cpp
@@ -148,19 +148,19 @@ void BrushItem::paint(QPainter *painter,
 
     const MapRenderer *renderer = mMapDocument->renderer();
 
-	QRect workSize;
-	mMapDocument->currentWorkSpace(workSize);
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
     if (mTileLayer) {
         const qreal opacity = painter->opacity();
         painter->setOpacity(0.75);
-        renderer->drawTileLayer(painter, mTileLayer.data(), workSize, option->exposedRect);
+        renderer->drawTileLayer(painter, mTileLayer.data(), workSpace, option->exposedRect);
         painter->setOpacity(opacity);
     }
 
-    renderer->drawTileSelection(painter, insideMapRegion, workSize,
+    renderer->drawTileSelection(painter, insideMapRegion, workSpace,
                                 insideMapHighlight,
                                 option->exposedRect);
-    renderer->drawTileSelection(painter, outsideMapRegion, workSize,
+    renderer->drawTileSelection(painter, outsideMapRegion, workSpace,
                                 outsideMapHighlight,
                                 option->exposedRect);
 }
@@ -176,10 +176,10 @@ void BrushItem::updateBoundingRect()
 
     const QRect bounds = mRegion.boundingRect();
 
-	QRect workSize;
-	mMapDocument->currentWorkSpace(workSize);
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
 
-    mBoundingRect = mMapDocument->renderer()->boundingRect(bounds, workSize);
+    mBoundingRect = mMapDocument->renderer()->boundingRect(bounds, workSpace);
 
     // Adjust for amount of pixels tiles extend at the top and to the right
     if (mTileLayer) {

--- a/src/tiled/brushitem.cpp
+++ b/src/tiled/brushitem.cpp
@@ -26,6 +26,7 @@
 #include "painttilelayer.h"
 #include "tile.h"
 #include "tilelayer.h"
+#include "workspace.h"
 
 #include <QApplication>
 #include <QPainter>
@@ -148,7 +149,7 @@ void BrushItem::paint(QPainter *painter,
 
     const MapRenderer *renderer = mMapDocument->renderer();
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
     if (mTileLayer) {
         const qreal opacity = painter->opacity();
@@ -176,7 +177,7 @@ void BrushItem::updateBoundingRect()
 
     const QRect bounds = mRegion.boundingRect();
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
 
     mBoundingRect = mMapDocument->renderer()->boundingRect(bounds, workSpace);

--- a/src/tiled/brushitem.cpp
+++ b/src/tiled/brushitem.cpp
@@ -134,9 +134,11 @@ void BrushItem::paint(QPainter *painter,
     insideMapHighlight.setAlpha(64);
     QColor outsideMapHighlight = QColor(255, 0, 0, 64);
     
-    int mapWidth = mMapDocument->map()->width();
-    int mapHeight = mMapDocument->map()->height();
-    QRegion mapRegion = QRegion(0, 0, mapWidth, mapHeight);
+	TileLayer* tileLayer = mMapDocument->currentLayer()->layerType() == Layer::TileLayerType ? static_cast<TileLayer*>(mMapDocument->currentLayer()) : 0;
+    int layerWidth = tileLayer ? tileLayer->width() : mMapDocument->map()->width();
+    int layerHeight = tileLayer? tileLayer->height() : mMapDocument->map()->height();
+
+    QRegion mapRegion = QRegion(0, 0, layerWidth, layerHeight);
 
     if (!mMapDocument->currentLayer()->isUnlocked())
         mapRegion = QRegion();
@@ -174,7 +176,7 @@ void BrushItem::updateBoundingRect()
 
     // Adjust for amount of pixels tiles extend at the top and to the right
     if (mTileLayer) {
-        QSize tileSize = mMapDocument->map()->tileSize();
+        QSize tileSize = mTileLayer->tileSize();
 
         QMargins drawMargins = mTileLayer->drawMargins();
         drawMargins.setTop(drawMargins.top() - tileSize.height());

--- a/src/tiled/brushitem.cpp
+++ b/src/tiled/brushitem.cpp
@@ -147,17 +147,20 @@ void BrushItem::paint(QPainter *painter,
     QRegion outsideMapRegion = mRegion.subtracted(mapRegion);
 
     const MapRenderer *renderer = mMapDocument->renderer();
+
+	QRect workSize;
+	mMapDocument->currentWorkSpace(workSize);
     if (mTileLayer) {
         const qreal opacity = painter->opacity();
         painter->setOpacity(0.75);
-        renderer->drawTileLayer(painter, mTileLayer.data(), option->exposedRect);
+        renderer->drawTileLayer(painter, mTileLayer.data(), workSize, option->exposedRect);
         painter->setOpacity(opacity);
     }
 
-    renderer->drawTileSelection(painter, insideMapRegion,
+    renderer->drawTileSelection(painter, insideMapRegion, workSize,
                                 insideMapHighlight,
                                 option->exposedRect);
-    renderer->drawTileSelection(painter, outsideMapRegion,
+    renderer->drawTileSelection(painter, outsideMapRegion, workSize,
                                 outsideMapHighlight,
                                 option->exposedRect);
 }
@@ -172,7 +175,11 @@ void BrushItem::updateBoundingRect()
     }
 
     const QRect bounds = mRegion.boundingRect();
-    mBoundingRect = mMapDocument->renderer()->boundingRect(bounds);
+
+	QRect workSize;
+	mMapDocument->currentWorkSpace(workSize);
+
+    mBoundingRect = mMapDocument->renderer()->boundingRect(bounds, workSize);
 
     // Adjust for amount of pixels tiles extend at the top and to the right
     if (mTileLayer) {

--- a/src/tiled/bucketfilltool.cpp
+++ b/src/tiled/bucketfilltool.cpp
@@ -176,7 +176,9 @@ void BucketFillTool::tilePositionChanged(const QPoint &tilePos)
                                                      fillBounds.x(),
                                                      fillBounds.y(),
                                                      fillBounds.width(),
-                                                     fillBounds.height()));
+                                                     fillBounds.height(),
+													 tileLayer->tileWidth(),
+													 tileLayer->tileHeight()));
     }
 
     // Paint the new overlay

--- a/src/tiled/changelayer.cpp
+++ b/src/tiled/changelayer.cpp
@@ -123,6 +123,24 @@ void SetLayerOffset::setOffset(const QPointF &offset)
     mMapDocument->layerModel()->setLayerOffset(mLayer, offset);
 }
 
+SetLayerTileSize::SetLayerTileSize(MapDocument *mapDocument,
+                               TileLayer *layer,
+                               const QSize &tileSize,
+                               QUndoCommand *parent)
+    : QUndoCommand(parent)
+    , mMapDocument(mapDocument)
+    , mLayer(layer)
+    , mOldTileSize(layer->tileSize())
+    , mNewTileSize(tileSize)
+{
+    setText(QCoreApplication::translate("Undo Commands",
+                                        "Change Layer Tile Size"));
+}
+
+void SetLayerTileSize::setTileSize(const QSize &tileSize)
+{
+    mMapDocument->layerModel()->setLayerTileSize(mLayer, tileSize);
+}
 
 } // namespace Internal
 } // namespace Tiled

--- a/src/tiled/changelayer.h
+++ b/src/tiled/changelayer.h
@@ -23,11 +23,13 @@
 #include "undocommands.h"
 
 #include <QPointF>
+#include <QSize>
 #include <QUndoCommand>
 
 namespace Tiled {
 
 class Layer;
+class TileLayer;
 
 namespace Internal {
 
@@ -125,6 +127,31 @@ private:
     Layer *mLayer;
     QPointF mOldOffset;
     QPointF mNewOffset;
+};
+
+/**
+ * Used for changing the layer tile size.
+ */
+class SetLayerTileSize : public QUndoCommand
+{
+public:
+    SetLayerTileSize(MapDocument *mapDocument,
+                   TileLayer *layer,
+                   const QSize &tileSize,
+                   QUndoCommand *parent = nullptr);
+
+    void undo() override { setTileSize(mOldTileSize); }
+    void redo() override { setTileSize(mNewTileSize); }
+
+    int id() const override { return Cmd_ChangeLayerTileSize; }
+
+private:
+    void setTileSize(const QSize &tileSize);
+
+    MapDocument *mMapDocument;
+    TileLayer *mLayer;
+    QSize mOldTileSize;
+    QSize mNewTileSize;
 };
 
 } // namespace Internal

--- a/src/tiled/clipboardmanager.cpp
+++ b/src/tiled/clipboardmanager.cpp
@@ -206,11 +206,11 @@ void ClipboardManager::pasteObjectGroup(const ObjectGroup *objectGroup,
 
         const QPointF scenePos = view->mapToScene(viewPos);
 
-		QRect workSize;
-		mapDocument->currentWorkSpace(workSize);
+		QRect workSpace;
+		mapDocument->currentWorkSpace(workSpace);
 
-        insertPos = renderer->screenToPixelCoords(scenePos, workSize) - center;
-        SnapHelper(renderer).snap(insertPos, workSize);
+        insertPos = renderer->screenToPixelCoords(scenePos, workSpace) - center;
+        SnapHelper(renderer).snap(insertPos, workSpace);
     }
 
     QUndoStack *undoStack = mapDocument->undoStack();

--- a/src/tiled/clipboardmanager.cpp
+++ b/src/tiled/clipboardmanager.cpp
@@ -31,6 +31,7 @@
 #include "tmxmapformat.h"
 #include "tile.h"
 #include "tilelayer.h"
+#include "workspace.h"
 
 #include <QApplication>
 #include <QClipboard>
@@ -206,7 +207,7 @@ void ClipboardManager::pasteObjectGroup(const ObjectGroup *objectGroup,
 
         const QPointF scenePos = view->mapToScene(viewPos);
 
-		QRect workSpace;
+		WorkSpace workSpace;
 		mapDocument->currentWorkSpace(workSpace);
 
         insertPos = renderer->screenToPixelCoords(scenePos, workSpace) - center;

--- a/src/tiled/clipboardmanager.cpp
+++ b/src/tiled/clipboardmanager.cpp
@@ -206,8 +206,11 @@ void ClipboardManager::pasteObjectGroup(const ObjectGroup *objectGroup,
 
         const QPointF scenePos = view->mapToScene(viewPos);
 
-        insertPos = renderer->screenToPixelCoords(scenePos) - center;
-        SnapHelper(renderer).snap(insertPos);
+		QRect workSize;
+		mapDocument->currentWorkSpace(workSize);
+
+        insertPos = renderer->screenToPixelCoords(scenePos, workSize) - center;
+        SnapHelper(renderer).snap(insertPos, workSize);
     }
 
     QUndoStack *undoStack = mapDocument->undoStack();

--- a/src/tiled/createmultipointobjecttool.cpp
+++ b/src/tiled/createmultipointobjecttool.cpp
@@ -29,6 +29,7 @@
 #include "objectgroup.h"
 #include "snaphelper.h"
 #include "utils.h"
+#include "workspace.h"
 
 #include <QApplication>
 #include <QPalette>
@@ -57,7 +58,7 @@ void CreateMultipointObjectTool::mouseMovedWhileCreatingObject(const QPointF &po
 {
     const MapRenderer *renderer = mapDocument()->renderer();
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mapDocument()->currentWorkSpace(workSpace);
 
     QPointF pixelCoords = renderer->screenToPixelCoords(pos, workSpace);

--- a/src/tiled/createmultipointobjecttool.cpp
+++ b/src/tiled/createmultipointobjecttool.cpp
@@ -21,6 +21,7 @@
 #include "createmultipointobjecttool.h"
 
 #include "mapdocument.h"
+#include "map.h"
 #include "mapobject.h"
 #include "mapobjectitem.h"
 #include "maprenderer.h"
@@ -55,9 +56,13 @@ void CreateMultipointObjectTool::mouseMovedWhileCreatingObject(const QPointF &po
                                                                Qt::KeyboardModifiers modifiers)
 {
     const MapRenderer *renderer = mapDocument()->renderer();
-    QPointF pixelCoords = renderer->screenToPixelCoords(pos);
 
-    SnapHelper(renderer, modifiers).snap(pixelCoords);
+	QRect workSize;
+	mapDocument()->currentWorkSpace(workSize);
+
+    QPointF pixelCoords = renderer->screenToPixelCoords(pos, workSize);
+
+    SnapHelper(renderer, modifiers).snap(pixelCoords, workSize);
 
     pixelCoords -= mNewMapObjectItem->mapObject()->position();
 

--- a/src/tiled/createmultipointobjecttool.cpp
+++ b/src/tiled/createmultipointobjecttool.cpp
@@ -57,12 +57,12 @@ void CreateMultipointObjectTool::mouseMovedWhileCreatingObject(const QPointF &po
 {
     const MapRenderer *renderer = mapDocument()->renderer();
 
-	QRect workSize;
-	mapDocument()->currentWorkSpace(workSize);
+	QRect workSpace;
+	mapDocument()->currentWorkSpace(workSpace);
 
-    QPointF pixelCoords = renderer->screenToPixelCoords(pos, workSize);
+    QPointF pixelCoords = renderer->screenToPixelCoords(pos, workSpace);
 
-    SnapHelper(renderer, modifiers).snap(pixelCoords, workSize);
+    SnapHelper(renderer, modifiers).snap(pixelCoords, workSpace);
 
     pixelCoords -= mNewMapObjectItem->mapObject()->position();
 

--- a/src/tiled/createobjecttool.cpp
+++ b/src/tiled/createobjecttool.cpp
@@ -33,6 +33,7 @@
 #include "snaphelper.h"
 #include "tile.h"
 #include "utils.h"
+#include "workspace.h"
 
 #include <QApplication>
 #include <QKeyEvent>
@@ -131,7 +132,7 @@ void CreateObjectTool::mousePressed(QGraphicsSceneMouseEvent *event)
     const MapRenderer *renderer = mapDocument()->renderer();
     const QPointF offsetPos = event->scenePos() - objectGroup->totalOffset();
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mapDocument()->currentWorkSpace(workSpace);
 
     QPointF pixelCoords = renderer->screenToPixelCoords(offsetPos, workSpace);

--- a/src/tiled/createobjecttool.cpp
+++ b/src/tiled/createobjecttool.cpp
@@ -131,8 +131,11 @@ void CreateObjectTool::mousePressed(QGraphicsSceneMouseEvent *event)
     const MapRenderer *renderer = mapDocument()->renderer();
     const QPointF offsetPos = event->scenePos() - objectGroup->totalOffset();
 
-    QPointF pixelCoords = renderer->screenToPixelCoords(offsetPos);
-    SnapHelper(renderer, event->modifiers()).snap(pixelCoords);
+	QRect workSize;
+	mapDocument()->currentWorkSpace(workSize);
+
+    QPointF pixelCoords = renderer->screenToPixelCoords(offsetPos, workSize);
+    SnapHelper(renderer, event->modifiers()).snap(pixelCoords, workSize);
 
     if (startNewMapObject(pixelCoords, objectGroup))
         mouseMovedWhileCreatingObject(offsetPos, event->modifiers());

--- a/src/tiled/createobjecttool.cpp
+++ b/src/tiled/createobjecttool.cpp
@@ -131,11 +131,11 @@ void CreateObjectTool::mousePressed(QGraphicsSceneMouseEvent *event)
     const MapRenderer *renderer = mapDocument()->renderer();
     const QPointF offsetPos = event->scenePos() - objectGroup->totalOffset();
 
-	QRect workSize;
-	mapDocument()->currentWorkSpace(workSize);
+	QRect workSpace;
+	mapDocument()->currentWorkSpace(workSpace);
 
-    QPointF pixelCoords = renderer->screenToPixelCoords(offsetPos, workSize);
-    SnapHelper(renderer, event->modifiers()).snap(pixelCoords, workSize);
+    QPointF pixelCoords = renderer->screenToPixelCoords(offsetPos, workSpace);
+    SnapHelper(renderer, event->modifiers()).snap(pixelCoords, workSpace);
 
     if (startNewMapObject(pixelCoords, objectGroup))
         mouseMovedWhileCreatingObject(offsetPos, event->modifiers());

--- a/src/tiled/createscalableobjecttool.cpp
+++ b/src/tiled/createscalableobjecttool.cpp
@@ -51,10 +51,10 @@ void CreateScalableObjectTool::mouseMovedWhileCreatingObject(const QPointF &pos,
 {
     const MapRenderer *renderer = mapDocument()->renderer();
 
-	QRect workSize;
-	mapDocument()->currentWorkSpace(workSize);
+	QRect workSpace;
+	mapDocument()->currentWorkSpace(workSpace);
 
-    const QPointF pixelCoords = renderer->screenToPixelCoords(pos, workSize);
+    const QPointF pixelCoords = renderer->screenToPixelCoords(pos, workSpace);
 
     QRectF objectArea(mStartPos, pixelCoords);
 
@@ -67,7 +67,7 @@ void CreateScalableObjectTool::mouseMovedWhileCreatingObject(const QPointF &pos,
 
     // Update the position and size of the new map object
     QPointF snapSize(objectArea.width(), objectArea.height());
-    SnapHelper(renderer, modifiers).snap(snapSize, workSize);
+    SnapHelper(renderer, modifiers).snap(snapSize, workSpace);
     objectArea.setWidth(snapSize.x());
     objectArea.setHeight(snapSize.y());
 

--- a/src/tiled/createscalableobjecttool.cpp
+++ b/src/tiled/createscalableobjecttool.cpp
@@ -21,6 +21,7 @@
 #include "createscalableobjecttool.h"
 
 #include "mapdocument.h"
+#include "map.h"
 #include "mapobject.h"
 #include "mapobjectitem.h"
 #include "maprenderer.h"
@@ -49,7 +50,11 @@ static qreal sign(qreal value)
 void CreateScalableObjectTool::mouseMovedWhileCreatingObject(const QPointF &pos, Qt::KeyboardModifiers modifiers)
 {
     const MapRenderer *renderer = mapDocument()->renderer();
-    const QPointF pixelCoords = renderer->screenToPixelCoords(pos);
+
+	QRect workSize;
+	mapDocument()->currentWorkSpace(workSize);
+
+    const QPointF pixelCoords = renderer->screenToPixelCoords(pos, workSize);
 
     QRectF objectArea(mStartPos, pixelCoords);
 
@@ -62,7 +67,7 @@ void CreateScalableObjectTool::mouseMovedWhileCreatingObject(const QPointF &pos,
 
     // Update the position and size of the new map object
     QPointF snapSize(objectArea.width(), objectArea.height());
-    SnapHelper(renderer, modifiers).snap(snapSize);
+    SnapHelper(renderer, modifiers).snap(snapSize, workSize);
     objectArea.setWidth(snapSize.x());
     objectArea.setHeight(snapSize.y());
 

--- a/src/tiled/createscalableobjecttool.cpp
+++ b/src/tiled/createscalableobjecttool.cpp
@@ -27,6 +27,7 @@
 #include "maprenderer.h"
 #include "snaphelper.h"
 #include "utils.h"
+#include "workspace.h"
 
 using namespace Tiled;
 using namespace Tiled::Internal;
@@ -51,7 +52,7 @@ void CreateScalableObjectTool::mouseMovedWhileCreatingObject(const QPointF &pos,
 {
     const MapRenderer *renderer = mapDocument()->renderer();
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mapDocument()->currentWorkSpace(workSpace);
 
     const QPointF pixelCoords = renderer->screenToPixelCoords(pos, workSpace);

--- a/src/tiled/createtextobjecttool.cpp
+++ b/src/tiled/createtextobjecttool.cpp
@@ -48,12 +48,12 @@ void CreateTextObjectTool::mouseMovedWhileCreatingObject(const QPointF &pos, Qt:
     const MapObject *mapObject = mNewMapObjectItem->mapObject();
     const QPointF diff(-mapObject->width() / 2, -mapObject->height() / 2);
 
-	QRect workSize;
-	mapDocument()->currentWorkSpace(workSize);
+	QRect workSpace;
+	mapDocument()->currentWorkSpace(workSpace);
 
-    QPointF pixelCoords = renderer->screenToPixelCoords(pos + diff, workSize);
+    QPointF pixelCoords = renderer->screenToPixelCoords(pos + diff, workSpace);
 
-    SnapHelper(renderer, modifiers).snap(pixelCoords, workSize);
+    SnapHelper(renderer, modifiers).snap(pixelCoords, workSpace);
 
     mNewMapObjectItem->mapObject()->setPosition(pixelCoords);
     mNewMapObjectItem->syncWithMapObject();

--- a/src/tiled/createtextobjecttool.cpp
+++ b/src/tiled/createtextobjecttool.cpp
@@ -21,6 +21,7 @@
 #include "createtextobjecttool.h"
 
 #include "mapdocument.h"
+#include "map.h"
 #include "mapobject.h"
 #include "mapobjectitem.h"
 #include "maprenderer.h"
@@ -46,9 +47,13 @@ void CreateTextObjectTool::mouseMovedWhileCreatingObject(const QPointF &pos, Qt:
 
     const MapObject *mapObject = mNewMapObjectItem->mapObject();
     const QPointF diff(-mapObject->width() / 2, -mapObject->height() / 2);
-    QPointF pixelCoords = renderer->screenToPixelCoords(pos + diff);
 
-    SnapHelper(renderer, modifiers).snap(pixelCoords);
+	QRect workSize;
+	mapDocument()->currentWorkSpace(workSize);
+
+    QPointF pixelCoords = renderer->screenToPixelCoords(pos + diff, workSize);
+
+    SnapHelper(renderer, modifiers).snap(pixelCoords, workSize);
 
     mNewMapObjectItem->mapObject()->setPosition(pixelCoords);
     mNewMapObjectItem->syncWithMapObject();

--- a/src/tiled/createtextobjecttool.cpp
+++ b/src/tiled/createtextobjecttool.cpp
@@ -27,6 +27,7 @@
 #include "maprenderer.h"
 #include "snaphelper.h"
 #include "utils.h"
+#include "workspace.h"
 
 namespace Tiled {
 namespace Internal {
@@ -48,7 +49,7 @@ void CreateTextObjectTool::mouseMovedWhileCreatingObject(const QPointF &pos, Qt:
     const MapObject *mapObject = mNewMapObjectItem->mapObject();
     const QPointF diff(-mapObject->width() / 2, -mapObject->height() / 2);
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mapDocument()->currentWorkSpace(workSpace);
 
     QPointF pixelCoords = renderer->screenToPixelCoords(pos + diff, workSpace);

--- a/src/tiled/createtileobjecttool.cpp
+++ b/src/tiled/createtileobjecttool.cpp
@@ -48,11 +48,11 @@ void CreateTileObjectTool::mouseMovedWhileCreatingObject(const QPointF &pos, Qt:
     const QSize imgSize = mNewMapObjectItem->mapObject()->cell().tile()->size();
     const QPointF diff(-imgSize.width() / 2, imgSize.height() / 2);
 
-	QRect workSize;
-	mapDocument()->currentWorkSpace(workSize);
-    QPointF pixelCoords = renderer->screenToPixelCoords(pos + diff, workSize);
+	QRect workSpace;
+	mapDocument()->currentWorkSpace(workSpace);
+    QPointF pixelCoords = renderer->screenToPixelCoords(pos + diff, workSpace);
 
-    SnapHelper(renderer, modifiers).snap(pixelCoords, workSize);
+    SnapHelper(renderer, modifiers).snap(pixelCoords, workSpace);
 
     mNewMapObjectItem->mapObject()->setPosition(pixelCoords);
     mNewMapObjectItem->syncWithMapObject();

--- a/src/tiled/createtileobjecttool.cpp
+++ b/src/tiled/createtileobjecttool.cpp
@@ -27,6 +27,7 @@
 #include "snaphelper.h"
 #include "tile.h"
 #include "utils.h"
+#include "workspace.h"
 
 using namespace Tiled;
 using namespace Tiled::Internal;
@@ -48,7 +49,7 @@ void CreateTileObjectTool::mouseMovedWhileCreatingObject(const QPointF &pos, Qt:
     const QSize imgSize = mNewMapObjectItem->mapObject()->cell().tile()->size();
     const QPointF diff(-imgSize.width() / 2, imgSize.height() / 2);
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mapDocument()->currentWorkSpace(workSpace);
     QPointF pixelCoords = renderer->screenToPixelCoords(pos + diff, workSpace);
 

--- a/src/tiled/createtileobjecttool.cpp
+++ b/src/tiled/createtileobjecttool.cpp
@@ -47,9 +47,12 @@ void CreateTileObjectTool::mouseMovedWhileCreatingObject(const QPointF &pos, Qt:
 
     const QSize imgSize = mNewMapObjectItem->mapObject()->cell().tile()->size();
     const QPointF diff(-imgSize.width() / 2, imgSize.height() / 2);
-    QPointF pixelCoords = renderer->screenToPixelCoords(pos + diff);
 
-    SnapHelper(renderer, modifiers).snap(pixelCoords);
+	QRect workSize;
+	mapDocument()->currentWorkSpace(workSize);
+    QPointF pixelCoords = renderer->screenToPixelCoords(pos + diff, workSize);
+
+    SnapHelper(renderer, modifiers).snap(pixelCoords, workSize);
 
     mNewMapObjectItem->mapObject()->setPosition(pixelCoords);
     mNewMapObjectItem->syncWithMapObject();

--- a/src/tiled/documentmanager.cpp
+++ b/src/tiled/documentmanager.cpp
@@ -789,7 +789,10 @@ void DocumentManager::centerMapViewOn(qreal x, qreal y)
 {
     if (MapView *view = currentMapView()) {
         auto mapDocument = view->mapScene()->mapDocument();
-        view->centerOn(mapDocument->renderer()->pixelToScreenCoords(x, y));
+
+		QRect workSize;
+		mapDocument->currentWorkSpace(workSize);
+        view->centerOn(mapDocument->renderer()->pixelToScreenCoords(x, y, workSize));
     }
 }
 

--- a/src/tiled/documentmanager.cpp
+++ b/src/tiled/documentmanager.cpp
@@ -41,6 +41,7 @@
 #include "tilesetmanager.h"
 #include "tmxmapformat.h"
 #include "utils.h"
+#include "workspace.h"
 #include "zoomable.h"
 
 #include <QApplication>
@@ -790,7 +791,7 @@ void DocumentManager::centerMapViewOn(qreal x, qreal y)
     if (MapView *view = currentMapView()) {
         auto mapDocument = view->mapScene()->mapDocument();
 
-		QRect workSpace;
+		WorkSpace workSpace;
 		mapDocument->currentWorkSpace(workSpace);
         view->centerOn(mapDocument->renderer()->pixelToScreenCoords(x, y, workSpace));
     }

--- a/src/tiled/documentmanager.cpp
+++ b/src/tiled/documentmanager.cpp
@@ -790,9 +790,9 @@ void DocumentManager::centerMapViewOn(qreal x, qreal y)
     if (MapView *view = currentMapView()) {
         auto mapDocument = view->mapScene()->mapDocument();
 
-		QRect workSize;
-		mapDocument->currentWorkSpace(workSize);
-        view->centerOn(mapDocument->renderer()->pixelToScreenCoords(x, y, workSize));
+		QRect workSpace;
+		mapDocument->currentWorkSpace(workSpace);
+        view->centerOn(mapDocument->renderer()->pixelToScreenCoords(x, y, workSpace));
     }
 }
 

--- a/src/tiled/editpolygontool.cpp
+++ b/src/tiled/editpolygontool.cpp
@@ -35,6 +35,7 @@
 #include "selectionrectangle.h"
 #include "snaphelper.h"
 #include "utils.h"
+#include "workspace.h"
 
 #include <QApplication>
 #include <QGraphicsItem>
@@ -386,7 +387,7 @@ void EditPolygonTool::updateHandles()
     }
 
     MapRenderer *renderer = mapDocument()->renderer();
-	QRect workSpace;
+	WorkSpace workSpace;
 	mapDocument()->currentWorkSpace(workSpace);
 
     for (MapObjectItem *item : selection) {
@@ -505,7 +506,7 @@ void EditPolygonTool::startMoving()
     mMode = Moving;
 
     MapRenderer *renderer = mapDocument()->renderer();
-	QRect workSpace;
+	WorkSpace workSpace;
 	mapDocument()->currentWorkSpace(workSpace);
 
     // Remember the current object positions
@@ -536,7 +537,7 @@ void EditPolygonTool::updateMovingItems(const QPointF &pos,
 
     SnapHelper snapHelper(renderer, modifiers);
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mapDocument()->currentWorkSpace(workSpace);
 
     if (snapHelper.snaps()) {

--- a/src/tiled/editpolygontool.cpp
+++ b/src/tiled/editpolygontool.cpp
@@ -386,8 +386,8 @@ void EditPolygonTool::updateHandles()
     }
 
     MapRenderer *renderer = mapDocument()->renderer();
-	QRect workSize;
-	mapDocument()->currentWorkSpace(workSize);
+	QRect workSpace;
+	mapDocument()->currentWorkSpace(workSpace);
 
     for (MapObjectItem *item : selection) {
         const MapObject *object = item->mapObject();
@@ -417,7 +417,7 @@ void EditPolygonTool::updateHandles()
         // Update the position of all handles
         for (int i = 0; i < pointHandles.size(); ++i) {
             const QPointF &point = polygon.at(i);
-            const QPointF handlePos = renderer->pixelToScreenCoords(point, workSize);
+            const QPointF handlePos = renderer->pixelToScreenCoords(point, workSpace);
             const QPointF internalHandlePos = handlePos - item->pos();
             pointHandles.at(i)->setPos(item->mapToScene(internalHandlePos));
         }
@@ -505,17 +505,17 @@ void EditPolygonTool::startMoving()
     mMode = Moving;
 
     MapRenderer *renderer = mapDocument()->renderer();
-	QRect workSize;
-	mapDocument()->currentWorkSpace(workSize);
+	QRect workSpace;
+	mapDocument()->currentWorkSpace(workSpace);
 
     // Remember the current object positions
     mOldHandlePositions.clear();
     mOldPolygons.clear();
-    mAlignPosition = renderer->screenToPixelCoords((*mSelectedHandles.begin())->pos(), workSize);
+    mAlignPosition = renderer->screenToPixelCoords((*mSelectedHandles.begin())->pos(), workSpace);
 
     const auto &selectedHandles = mSelectedHandles;
     for (PointHandle *handle : selectedHandles) {
-        const QPointF pos = renderer->screenToPixelCoords(handle->pos(), workSize);
+        const QPointF pos = renderer->screenToPixelCoords(handle->pos(), workSpace);
         mOldHandlePositions.append(handle->pos());
         if (pos.x() < mAlignPosition.x())
             mAlignPosition.setX(pos.x());
@@ -536,17 +536,17 @@ void EditPolygonTool::updateMovingItems(const QPointF &pos,
 
     SnapHelper snapHelper(renderer, modifiers);
 
-	QRect workSize;
-	mapDocument()->currentWorkSpace(workSize);
+	QRect workSpace;
+	mapDocument()->currentWorkSpace(workSpace);
 
     if (snapHelper.snaps()) {
-        const QPointF alignScreenPos = renderer->pixelToScreenCoords(mAlignPosition, workSize);
+        const QPointF alignScreenPos = renderer->pixelToScreenCoords(mAlignPosition, workSpace);
         const QPointF newAlignScreenPos = alignScreenPos + diff;
 
-        QPointF newAlignPixelPos = renderer->screenToPixelCoords(newAlignScreenPos, workSize);
-        snapHelper.snap(newAlignPixelPos, workSize);
+        QPointF newAlignPixelPos = renderer->screenToPixelCoords(newAlignScreenPos, workSpace);
+        snapHelper.snap(newAlignPixelPos, workSpace);
 
-        diff = renderer->pixelToScreenCoords(newAlignPixelPos, workSize) - alignScreenPos;
+        diff = renderer->pixelToScreenCoords(newAlignPixelPos, workSpace) - alignScreenPos;
     }
 
     const auto &selectedHandles = mSelectedHandles;
@@ -561,7 +561,7 @@ void EditPolygonTool::updateMovingItems(const QPointF &pos,
         const MapObjectItem *item = handle->mapObjectItem();
         const QPointF newInternalPos = item->mapFromScene(newScreenPos);
         const QPointF newScenePos = item->pos() + newInternalPos;
-        const QPointF newPixelPos = renderer->screenToPixelCoords(newScenePos, workSize);
+        const QPointF newPixelPos = renderer->screenToPixelCoords(newScenePos, workSpace);
 
         // update the polygon
         MapObject *mapObject = item->mapObject();

--- a/src/tiled/exportasimagedialog.cpp
+++ b/src/tiled/exportasimagedialog.cpp
@@ -31,6 +31,7 @@
 #include "preferences.h"
 #include "tilelayer.h"
 #include "utils.h"
+#include "workspace.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -157,7 +158,7 @@ void ExportAsImageDialog::accept()
 
     renderer->setFlag(ShowTileObjectOutlines, false);
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
     QSize mapSize = renderer->workSize(workSpace);
 

--- a/src/tiled/exportasimagedialog.cpp
+++ b/src/tiled/exportasimagedialog.cpp
@@ -157,7 +157,9 @@ void ExportAsImageDialog::accept()
 
     renderer->setFlag(ShowTileObjectOutlines, false);
 
-    QSize mapSize = renderer->mapSize();
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
+    QSize mapSize = renderer->workSize(workSpace);
 
     QMargins margins = mMapDocument->map()->computeLayerOffsetMargins();
     mapSize.setWidth(mapSize.width() + margins.left() + margins.right());
@@ -218,8 +220,6 @@ void ExportAsImageDialog::accept()
     painter.translate(margins.left(), margins.top());
 
     LayerIterator iterator(mMapDocument->map());
-	QRect workSpace;
-	mMapDocument->currentWorkSpace(workSpace);
 
     while (Layer *layer = iterator.next()) {
         if (visibleLayersOnly && layer->isHidden())
@@ -279,7 +279,7 @@ void ExportAsImageDialog::accept()
 
     if (drawTileGrid) {
         Preferences *prefs = Preferences::instance();
-        renderer->drawGrid(&painter, QRectF(QPointF(), renderer->mapSize()), workSpace,
+        renderer->drawGrid(&painter, QRectF(QPointF(), renderer->workSize(workSpace)), workSpace,
                            prefs->gridColor());
     }
 

--- a/src/tiled/exportasimagedialog.cpp
+++ b/src/tiled/exportasimagedialog.cpp
@@ -218,8 +218,8 @@ void ExportAsImageDialog::accept()
     painter.translate(margins.left(), margins.top());
 
     LayerIterator iterator(mMapDocument->map());
-	QRect workSize;
-	mMapDocument->currentWorkSpace(workSize);
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
 
     while (Layer *layer = iterator.next()) {
         if (visibleLayersOnly && layer->isHidden())
@@ -233,7 +233,7 @@ void ExportAsImageDialog::accept()
         switch (layer->layerType()) {
         case Layer::TileLayerType: {
             const TileLayer *tileLayer = static_cast<const TileLayer*>(layer);
-            renderer->drawTileLayer(&painter, tileLayer, workSize);
+            renderer->drawTileLayer(&painter, tileLayer, workSpace);
             break;
         }
 
@@ -247,7 +247,7 @@ void ExportAsImageDialog::accept()
             foreach (const MapObject *object, objects) {
                 if (object->isVisible()) {
                     if (object->rotation() != qreal(0)) {
-                        QPointF origin = renderer->pixelToScreenCoords(object->position(), workSize);
+                        QPointF origin = renderer->pixelToScreenCoords(object->position(), workSpace);
                         painter.save();
                         painter.translate(origin);
                         painter.rotate(object->rotation());
@@ -255,7 +255,7 @@ void ExportAsImageDialog::accept()
                     }
 
                     const QColor color = MapObjectItem::objectColor(object);
-                    renderer->drawMapObject(&painter, workSize, object, color);
+                    renderer->drawMapObject(&painter, workSpace, object, color);
 
                     if (object->rotation() != qreal(0))
                         painter.restore();
@@ -265,7 +265,7 @@ void ExportAsImageDialog::accept()
         }
         case Layer::ImageLayerType: {
             const ImageLayer *imageLayer = static_cast<const ImageLayer*>(layer);
-            renderer->drawImageLayer(&painter, workSize, imageLayer);
+            renderer->drawImageLayer(&painter, workSpace, imageLayer);
             break;
         }
 
@@ -279,7 +279,7 @@ void ExportAsImageDialog::accept()
 
     if (drawTileGrid) {
         Preferences *prefs = Preferences::instance();
-        renderer->drawGrid(&painter, QRectF(QPointF(), renderer->mapSize()), workSize,
+        renderer->drawGrid(&painter, QRectF(QPointF(), renderer->mapSize()), workSpace,
                            prefs->gridColor());
     }
 

--- a/src/tiled/exportasimagedialog.cpp
+++ b/src/tiled/exportasimagedialog.cpp
@@ -218,6 +218,9 @@ void ExportAsImageDialog::accept()
     painter.translate(margins.left(), margins.top());
 
     LayerIterator iterator(mMapDocument->map());
+	QRect workSize;
+	mMapDocument->currentWorkSpace(workSize);
+
     while (Layer *layer = iterator.next()) {
         if (visibleLayersOnly && layer->isHidden())
             continue;
@@ -230,7 +233,7 @@ void ExportAsImageDialog::accept()
         switch (layer->layerType()) {
         case Layer::TileLayerType: {
             const TileLayer *tileLayer = static_cast<const TileLayer*>(layer);
-            renderer->drawTileLayer(&painter, tileLayer);
+            renderer->drawTileLayer(&painter, tileLayer, workSize);
             break;
         }
 
@@ -244,7 +247,7 @@ void ExportAsImageDialog::accept()
             foreach (const MapObject *object, objects) {
                 if (object->isVisible()) {
                     if (object->rotation() != qreal(0)) {
-                        QPointF origin = renderer->pixelToScreenCoords(object->position());
+                        QPointF origin = renderer->pixelToScreenCoords(object->position(), workSize);
                         painter.save();
                         painter.translate(origin);
                         painter.rotate(object->rotation());
@@ -252,7 +255,7 @@ void ExportAsImageDialog::accept()
                     }
 
                     const QColor color = MapObjectItem::objectColor(object);
-                    renderer->drawMapObject(&painter, object, color);
+                    renderer->drawMapObject(&painter, workSize, object, color);
 
                     if (object->rotation() != qreal(0))
                         painter.restore();
@@ -262,7 +265,7 @@ void ExportAsImageDialog::accept()
         }
         case Layer::ImageLayerType: {
             const ImageLayer *imageLayer = static_cast<const ImageLayer*>(layer);
-            renderer->drawImageLayer(&painter, imageLayer);
+            renderer->drawImageLayer(&painter, workSize, imageLayer);
             break;
         }
 
@@ -276,7 +279,7 @@ void ExportAsImageDialog::accept()
 
     if (drawTileGrid) {
         Preferences *prefs = Preferences::instance();
-        renderer->drawGrid(&painter, QRectF(QPointF(), renderer->mapSize()),
+        renderer->drawGrid(&painter, QRectF(QPointF(), renderer->mapSize()), workSize,
                            prefs->gridColor());
     }
 

--- a/src/tiled/imagelayeritem.cpp
+++ b/src/tiled/imagelayeritem.cpp
@@ -42,7 +42,9 @@ ImageLayerItem::ImageLayerItem(ImageLayer *layer, MapDocument *mapDocument, QGra
 void ImageLayerItem::syncWithImageLayer()
 {
     prepareGeometryChange();
-    mBoundingRect = mMapDocument->renderer()->boundingRect(imageLayer());
+	QRect workSize;
+	mMapDocument->currentWorkSpace(workSize);
+    mBoundingRect = mMapDocument->renderer()->boundingRect(imageLayer(), workSize);
 }
 
 QRectF ImageLayerItem::boundingRect() const
@@ -56,5 +58,7 @@ void ImageLayerItem::paint(QPainter *painter,
 {
     // TODO: Display a border around the layer when selected
     MapRenderer *renderer = mMapDocument->renderer();
-    renderer->drawImageLayer(painter, imageLayer(), option->exposedRect);
+	QRect workSize;
+	mMapDocument->currentWorkSpace(workSize);
+    renderer->drawImageLayer(painter, workSize, imageLayer(), option->exposedRect);
 }

--- a/src/tiled/imagelayeritem.cpp
+++ b/src/tiled/imagelayeritem.cpp
@@ -23,6 +23,7 @@
 
 #include "mapdocument.h"
 #include "maprenderer.h"
+#include "workspace.h"
 
 #include <QPainter>
 #include <QStyleOptionGraphicsItem>
@@ -42,7 +43,7 @@ ImageLayerItem::ImageLayerItem(ImageLayer *layer, MapDocument *mapDocument, QGra
 void ImageLayerItem::syncWithImageLayer()
 {
     prepareGeometryChange();
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
     mBoundingRect = mMapDocument->renderer()->boundingRect(imageLayer(), workSpace);
 }
@@ -58,7 +59,7 @@ void ImageLayerItem::paint(QPainter *painter,
 {
     // TODO: Display a border around the layer when selected
     MapRenderer *renderer = mMapDocument->renderer();
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
     renderer->drawImageLayer(painter, workSpace, imageLayer(), option->exposedRect);
 }

--- a/src/tiled/imagelayeritem.cpp
+++ b/src/tiled/imagelayeritem.cpp
@@ -42,9 +42,9 @@ ImageLayerItem::ImageLayerItem(ImageLayer *layer, MapDocument *mapDocument, QGra
 void ImageLayerItem::syncWithImageLayer()
 {
     prepareGeometryChange();
-	QRect workSize;
-	mMapDocument->currentWorkSpace(workSize);
-    mBoundingRect = mMapDocument->renderer()->boundingRect(imageLayer(), workSize);
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
+    mBoundingRect = mMapDocument->renderer()->boundingRect(imageLayer(), workSpace);
 }
 
 QRectF ImageLayerItem::boundingRect() const
@@ -58,7 +58,7 @@ void ImageLayerItem::paint(QPainter *painter,
 {
     // TODO: Display a border around the layer when selected
     MapRenderer *renderer = mMapDocument->renderer();
-	QRect workSize;
-	mMapDocument->currentWorkSpace(workSize);
-    renderer->drawImageLayer(painter, workSize, imageLayer(), option->exposedRect);
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
+    renderer->drawImageLayer(painter, workSpace, imageLayer(), option->exposedRect);
 }

--- a/src/tiled/layermodel.cpp
+++ b/src/tiled/layermodel.cpp
@@ -469,6 +469,19 @@ void LayerModel::setLayerOffset(Layer *layer, const QPointF &offset)
 }
 
 /**
+ * Sets the tile size of the layer at the given index.
+ */
+void LayerModel::setLayerTileSize(Layer *layer, const QSize &tileSize)
+{
+	TileLayer* tileLayer = layer->asTileLayer();
+    if (!tileLayer || tileLayer->tileSize() == tileSize)
+        return;
+
+    tileLayer->setTileSize(tileSize);
+    emit layerChanged(layer);
+}
+
+/**
  * Renames the layer at the given index.
  */
 void LayerModel::renameLayer(Layer *layer, const QString &name)

--- a/src/tiled/layermodel.h
+++ b/src/tiled/layermodel.h
@@ -89,6 +89,7 @@ public:
     void setLayerLocked(Layer *layer, bool locked);
     void setLayerOpacity(Layer *layer, float opacity);
     void setLayerOffset(Layer *layer, const QPointF &offset);
+	void setLayerTileSize(Layer *layer, const QSize &tileSize);
 
     void renameLayer(Layer *layer, const QString &name);
 

--- a/src/tiled/layeroffsettool.cpp
+++ b/src/tiled/layeroffsettool.cpp
@@ -73,7 +73,10 @@ void LayerOffsetTool::mouseMoved(const QPointF &pos, Qt::KeyboardModifiers modif
     if (Layer *layer = currentLayer())
         offsetPos -= layer->totalOffset();
 
-    const QPointF tilePosF = mapDocument()->renderer()->screenToTileCoords(offsetPos);
+	QRect workSize;
+	mapDocument()->currentWorkSpace(workSize);
+
+    const QPointF tilePosF = mapDocument()->renderer()->screenToTileCoords(offsetPos, workSize);
     const int x = (int) std::floor(tilePosF.x());
     const int y = (int) std::floor(tilePosF.y());
     setStatusInfo(QString(QLatin1String("%1, %2")).arg(x).arg(y));
@@ -95,7 +98,7 @@ void LayerOffsetTool::mouseMoved(const QPointF &pos, Qt::KeyboardModifiers modif
     auto currentLayer = mapDocument()->currentLayer();
     if (currentLayer && mDragging) {
         QPointF newOffset = mOldOffset + (pos - mMouseSceneStart);
-        SnapHelper(mapDocument()->renderer(), modifiers).snap(newOffset);
+        SnapHelper(mapDocument()->renderer(), modifiers).snap(newOffset, workSize);
         mApplyingChange = true;
         mapDocument()->layerModel()->setLayerOffset(currentLayer, newOffset);
         mApplyingChange = false;

--- a/src/tiled/layeroffsettool.cpp
+++ b/src/tiled/layeroffsettool.cpp
@@ -26,6 +26,7 @@
 #include "mapdocument.h"
 #include "maprenderer.h"
 #include "snaphelper.h"
+#include "workspace.h"
 
 #include <QApplication>
 #include <QUndoStack>
@@ -73,7 +74,7 @@ void LayerOffsetTool::mouseMoved(const QPointF &pos, Qt::KeyboardModifiers modif
     if (Layer *layer = currentLayer())
         offsetPos -= layer->totalOffset();
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mapDocument()->currentWorkSpace(workSpace);
 
     const QPointF tilePosF = mapDocument()->renderer()->screenToTileCoords(offsetPos, workSpace);

--- a/src/tiled/layeroffsettool.cpp
+++ b/src/tiled/layeroffsettool.cpp
@@ -73,10 +73,10 @@ void LayerOffsetTool::mouseMoved(const QPointF &pos, Qt::KeyboardModifiers modif
     if (Layer *layer = currentLayer())
         offsetPos -= layer->totalOffset();
 
-	QRect workSize;
-	mapDocument()->currentWorkSpace(workSize);
+	QRect workSpace;
+	mapDocument()->currentWorkSpace(workSpace);
 
-    const QPointF tilePosF = mapDocument()->renderer()->screenToTileCoords(offsetPos, workSize);
+    const QPointF tilePosF = mapDocument()->renderer()->screenToTileCoords(offsetPos, workSpace);
     const int x = (int) std::floor(tilePosF.x());
     const int y = (int) std::floor(tilePosF.y());
     setStatusInfo(QString(QLatin1String("%1, %2")).arg(x).arg(y));
@@ -98,7 +98,7 @@ void LayerOffsetTool::mouseMoved(const QPointF &pos, Qt::KeyboardModifiers modif
     auto currentLayer = mapDocument()->currentLayer();
     if (currentLayer && mDragging) {
         QPointF newOffset = mOldOffset + (pos - mMouseSceneStart);
-        SnapHelper(mapDocument()->renderer(), modifiers).snap(newOffset, workSize);
+        SnapHelper(mapDocument()->renderer(), modifiers).snap(newOffset, workSpace);
         mApplyingChange = true;
         mapDocument()->layerModel()->setLayerOffset(currentLayer, newOffset);
         mApplyingChange = false;

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -424,7 +424,7 @@ Layer *MapDocument::addLayer(Layer::TypeFlag layerType)
     switch (layerType) {
     case Layer::TileLayerType:
         name = tr("Tile Layer %1").arg(mMap->tileLayerCount() + 1);
-        layer = new TileLayer(name, 0, 0, mMap->width(), mMap->height());
+        layer = new TileLayer(name, 0, 0, mMap->width(), mMap->height(), mMap->tileWidth(), mMap->tileHeight());
         break;
     case Layer::ObjectGroupType:
         name = tr("Object Layer %1").arg(mMap->objectGroupCount() + 1);

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -272,13 +272,13 @@ static bool intersects(const QRectF &a, const QRectF &b)
 static bool visibleIn(const QRectF &area, MapObject *object,
                       MapRenderer *renderer, MapDocument* mapDocument)
 {
-	QRect workSize;
-	mapDocument->currentWorkSpace(workSize);
-    QRectF boundingRect = renderer->boundingRect(object, workSize);
+	QRect workSpace;
+	mapDocument->currentWorkSpace(workSpace);
+    QRectF boundingRect = renderer->boundingRect(object, workSpace);
 
     if (object->rotation() != 0) {
         // Rotate around object position
-        QPointF pos = renderer->pixelToScreenCoords(object->position(), workSize);
+        QPointF pos = renderer->pixelToScreenCoords(object->position(), workSpace);
         boundingRect.translate(-pos);
 
         QTransform transform;
@@ -293,15 +293,15 @@ static bool visibleIn(const QRectF &area, MapObject *object,
 
 void MapDocument::resizeMap(const QSize &size, const QPoint &offset, bool removeObjects)
 {
-	QRect workSize;
-	currentWorkSpace(workSize);
+	QRect workSpace;
+	currentWorkSpace(workSpace);
 
     const QRegion movedSelection = mSelectedArea.translated(offset);
     const QRect newArea = QRect(-offset, size);
-    const QRectF visibleArea = mRenderer->boundingRect(newArea, workSize);
+    const QRectF visibleArea = mRenderer->boundingRect(newArea, workSpace);
 
-    const QPointF origin = mRenderer->tileToPixelCoords(QPointF(), workSize);
-    const QPointF newOrigin = mRenderer->tileToPixelCoords(-offset, workSize);
+    const QPointF origin = mRenderer->tileToPixelCoords(QPointF(), workSpace);
+    const QPointF newOrigin = mRenderer->tileToPixelCoords(-offset, workSpace);
     const QPointF pixelOffset = origin - newOrigin;
 
     // Resize the map and each layer

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -58,6 +58,7 @@
 #include "tilesetdocument.h"
 #include "tilesetmanager.h"
 #include "tmxmapformat.h"
+#include "workspace.h"
 
 #include <QFileInfo>
 #include <QRect>
@@ -239,18 +240,18 @@ void MapDocument::setCurrentLayer(Layer *layer)
             setCurrentObject(mCurrentLayer);
 }
 
-void MapDocument::currentWorkSpace(QRect &workSpace) const {
+void MapDocument::currentWorkSpace(WorkSpace &workSpace) const {
 	if (mCurrentLayer && mCurrentLayer->asTileLayer()) {
 		TileLayer* tLayer = static_cast<TileLayer*>(mCurrentLayer);
-		workSpace.setX(tLayer->width());
-		workSpace.setY(tLayer->height());
-		workSpace.setWidth(tLayer->tileWidth());
-		workSpace.setHeight(tLayer->tileHeight());
+		workSpace.setWidth(tLayer->width());
+		workSpace.setHeight(tLayer->height());
+		workSpace.setTileWidth(tLayer->tileWidth());
+		workSpace.setTileHeight(tLayer->tileHeight());
 	} else {
-		workSpace.setX(mMap->width());
-		workSpace.setY(mMap->height());
-		workSpace.setWidth(mMap->tileWidth());
-		workSpace.setHeight(mMap->tileHeight());
+		workSpace.setWidth(mMap->width());
+		workSpace.setHeight(mMap->height());
+		workSpace.setTileWidth(mMap->tileWidth());
+		workSpace.setTileHeight(mMap->tileHeight());
 	}
 }
 
@@ -272,7 +273,7 @@ static bool intersects(const QRectF &a, const QRectF &b)
 static bool visibleIn(const QRectF &area, MapObject *object,
                       MapRenderer *renderer, MapDocument* mapDocument)
 {
-	QRect workSpace;
+	WorkSpace workSpace;
 	mapDocument->currentWorkSpace(workSpace);
     QRectF boundingRect = renderer->boundingRect(object, workSpace);
 
@@ -293,7 +294,7 @@ static bool visibleIn(const QRectF &area, MapObject *object,
 
 void MapDocument::resizeMap(const QSize &size, const QPoint &offset, bool removeObjects)
 {
-	QRect workSpace;
+	WorkSpace workSpace;
 	currentWorkSpace(workSpace);
 
     const QRegion movedSelection = mSelectedArea.translated(offset);

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -26,6 +26,7 @@
 #include "layer.h"
 #include "tiled.h"
 #include "tileset.h"
+#include "workspace.h"
 
 #include <QList>
 #include <QPointer>
@@ -116,7 +117,7 @@ public:
     /**
      * Returns the current work space
      */
-    void currentWorkSpace(QRect& workSpace) const;
+    void currentWorkSpace(WorkSpace &workSpace) const;
 
 
     /**

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -114,6 +114,12 @@ public:
     void setCurrentLayer(Layer *layer);
 
     /**
+     * Returns the current work space
+     */
+    void currentWorkSpace(QRect& workSpace) const;
+
+
+    /**
      * Resize this map to the given \a size, while at the same time shifting
      * the contents by \a offset. If \a removeObjects is true then all objects
      * which are outside the map will be removed.

--- a/src/tiled/mapdocumentactionhandler.cpp
+++ b/src/tiled/mapdocumentactionhandler.cpp
@@ -407,10 +407,10 @@ void MapDocumentActionHandler::copyPosition()
     const QPointF scenePos = view->mapToScene(viewportPos);
 
     const MapRenderer *renderer = mapDocument()->renderer();
-	QRect workSize;
-	mapDocument()->currentWorkSpace(workSize);
+	QRect workSpace;
+	mapDocument()->currentWorkSpace(workSpace);
 
-    const QPointF tilePos = renderer->screenToTileCoords(scenePos, workSize);
+    const QPointF tilePos = renderer->screenToTileCoords(scenePos, workSpace);
     const int x = qFloor(tilePos.x());
     const int y = qFloor(tilePos.y());
 

--- a/src/tiled/mapdocumentactionhandler.cpp
+++ b/src/tiled/mapdocumentactionhandler.cpp
@@ -479,7 +479,7 @@ void MapDocumentActionHandler::layerVia(MapDocumentActionHandler::LayerViaVarian
 
         auto map = mMapDocument->map();
         sourceLayer = static_cast<TileLayer*>(currentLayer);
-        auto newTileLayer = new TileLayer(name, 0, 0, map->width(), map->height());
+        auto newTileLayer = new TileLayer(name, 0, 0, map->width(), map->height(), map->tileWidth(), map->tileHeight());
         newTileLayer->setCells(0, 0, sourceLayer, selectedArea);
 
         newLayer = newTileLayer;

--- a/src/tiled/mapdocumentactionhandler.cpp
+++ b/src/tiled/mapdocumentactionhandler.cpp
@@ -479,7 +479,7 @@ void MapDocumentActionHandler::layerVia(MapDocumentActionHandler::LayerViaVarian
 
         auto map = mMapDocument->map();
         sourceLayer = static_cast<TileLayer*>(currentLayer);
-        auto newTileLayer = new TileLayer(name, 0, 0, map->width(), map->height(), map->tileWidth(), map->tileHeight());
+        auto newTileLayer = new TileLayer(name, 0, 0, sourceLayer->width(), sourceLayer->height(), sourceLayer->tileWidth(), sourceLayer->tileHeight());
         newTileLayer->setCells(0, 0, sourceLayer, selectedArea);
 
         newLayer = newTileLayer;

--- a/src/tiled/mapdocumentactionhandler.cpp
+++ b/src/tiled/mapdocumentactionhandler.cpp
@@ -37,6 +37,7 @@
 #include "objectgroup.h"
 #include "tilelayer.h"
 #include "utils.h"
+#include "workspace.h"
 
 #include <QAction>
 #include <QApplication>
@@ -407,7 +408,7 @@ void MapDocumentActionHandler::copyPosition()
     const QPointF scenePos = view->mapToScene(viewportPos);
 
     const MapRenderer *renderer = mapDocument()->renderer();
-	QRect workSpace;
+	WorkSpace workSpace;
 	mapDocument()->currentWorkSpace(workSpace);
 
     const QPointF tilePos = renderer->screenToTileCoords(scenePos, workSpace);

--- a/src/tiled/mapdocumentactionhandler.cpp
+++ b/src/tiled/mapdocumentactionhandler.cpp
@@ -407,7 +407,10 @@ void MapDocumentActionHandler::copyPosition()
     const QPointF scenePos = view->mapToScene(viewportPos);
 
     const MapRenderer *renderer = mapDocument()->renderer();
-    const QPointF tilePos = renderer->screenToTileCoords(scenePos);
+	QRect workSize;
+	mapDocument()->currentWorkSpace(workSize);
+
+    const QPointF tilePos = renderer->screenToTileCoords(scenePos, workSize);
     const int x = qFloor(tilePos.x());
     const int y = qFloor(tilePos.y());
 

--- a/src/tiled/mapobjectitem.cpp
+++ b/src/tiled/mapobjectitem.cpp
@@ -34,6 +34,7 @@
 #include "resizemapobject.h"
 #include "tile.h"
 #include "zoomable.h"
+#include "workspace.h"
 
 #include <QApplication>
 #include <QGraphicsSceneMouseEvent>
@@ -75,7 +76,7 @@ void MapObjectItem::syncWithMapObject()
     setToolTip(toolTip);
 
     MapRenderer *renderer = mMapDocument->renderer();
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
     const QPointF pixelPos = renderer->pixelToScreenCoords(mObject->position(), workSpace);
     QRectF bounds = renderer->boundingRect(mObject, workSpace);
@@ -105,7 +106,7 @@ QRectF MapObjectItem::boundingRect() const
 
 QPainterPath MapObjectItem::shape() const
 {
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
     QPainterPath path = mMapDocument->renderer()->shape(mObject, workSpace);
     path.translate(-pos());
@@ -116,7 +117,7 @@ void MapObjectItem::paint(QPainter *painter,
                           const QStyleOptionGraphicsItem *,
                           QWidget *widget)
 {
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
 
     qreal scale = static_cast<MapView*>(widget->parent())->zoomable()->scale();

--- a/src/tiled/mapobjectitem.cpp
+++ b/src/tiled/mapobjectitem.cpp
@@ -75,8 +75,10 @@ void MapObjectItem::syncWithMapObject()
     setToolTip(toolTip);
 
     MapRenderer *renderer = mMapDocument->renderer();
-    const QPointF pixelPos = renderer->pixelToScreenCoords(mObject->position());
-    QRectF bounds = renderer->boundingRect(mObject);
+	QRect workSize;
+	mMapDocument->currentWorkSpace(workSize);
+    const QPointF pixelPos = renderer->pixelToScreenCoords(mObject->position(), workSize);
+    QRectF bounds = renderer->boundingRect(mObject, workSize);
 
     bounds.translate(-pixelPos);
 
@@ -103,7 +105,9 @@ QRectF MapObjectItem::boundingRect() const
 
 QPainterPath MapObjectItem::shape() const
 {
-    QPainterPath path = mMapDocument->renderer()->shape(mObject);
+	QRect workSize;
+	mMapDocument->currentWorkSpace(workSize);
+    QPainterPath path = mMapDocument->renderer()->shape(mObject, workSize);
     path.translate(-pos());
     return path;
 }
@@ -112,10 +116,13 @@ void MapObjectItem::paint(QPainter *painter,
                           const QStyleOptionGraphicsItem *,
                           QWidget *widget)
 {
+	QRect workSize;
+	mMapDocument->currentWorkSpace(workSize);
+
     qreal scale = static_cast<MapView*>(widget->parent())->zoomable()->scale();
     painter->translate(-pos());
     mMapDocument->renderer()->setPainterScale(scale);
-    mMapDocument->renderer()->drawMapObject(painter, mObject, mColor);
+    mMapDocument->renderer()->drawMapObject(painter, workSize, mObject, mColor);
 }
 
 void MapObjectItem::resizeObject(const QRectF &bounds)

--- a/src/tiled/mapobjectitem.cpp
+++ b/src/tiled/mapobjectitem.cpp
@@ -75,10 +75,10 @@ void MapObjectItem::syncWithMapObject()
     setToolTip(toolTip);
 
     MapRenderer *renderer = mMapDocument->renderer();
-	QRect workSize;
-	mMapDocument->currentWorkSpace(workSize);
-    const QPointF pixelPos = renderer->pixelToScreenCoords(mObject->position(), workSize);
-    QRectF bounds = renderer->boundingRect(mObject, workSize);
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
+    const QPointF pixelPos = renderer->pixelToScreenCoords(mObject->position(), workSpace);
+    QRectF bounds = renderer->boundingRect(mObject, workSpace);
 
     bounds.translate(-pixelPos);
 
@@ -105,9 +105,9 @@ QRectF MapObjectItem::boundingRect() const
 
 QPainterPath MapObjectItem::shape() const
 {
-	QRect workSize;
-	mMapDocument->currentWorkSpace(workSize);
-    QPainterPath path = mMapDocument->renderer()->shape(mObject, workSize);
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
+    QPainterPath path = mMapDocument->renderer()->shape(mObject, workSpace);
     path.translate(-pos());
     return path;
 }
@@ -116,13 +116,13 @@ void MapObjectItem::paint(QPainter *painter,
                           const QStyleOptionGraphicsItem *,
                           QWidget *widget)
 {
-	QRect workSize;
-	mMapDocument->currentWorkSpace(workSize);
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
 
     qreal scale = static_cast<MapView*>(widget->parent())->zoomable()->scale();
     painter->translate(-pos());
     mMapDocument->renderer()->setPainterScale(scale);
-    mMapDocument->renderer()->drawMapObject(painter, workSize, mObject, mColor);
+    mMapDocument->renderer()->drawMapObject(painter, workSpace, mObject, mColor);
 }
 
 void MapObjectItem::resizeObject(const QRectF &bounds)

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -295,7 +295,9 @@ void MapScene::updateDefaultBackgroundColor()
 
 void MapScene::updateSceneRect()
 {
-    const QSize mapSize = mMapDocument->renderer()->mapSize();
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
+    const QSize mapSize = mMapDocument->renderer()->workSize(workSpace);
     QRectF sceneRect(0, 0, mapSize.width(), mapSize.height());
 
     QMargins margins = mMapDocument->map()->computeLayerOffsetMargins();

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -356,11 +356,11 @@ void MapScene::repaintRegion(const QRegion &region, Layer *layer)
     const MapRenderer *renderer = mMapDocument->renderer();
     const QMargins margins = mMapDocument->map()->drawMargins();
 
-	QRect workSize;
-	mMapDocument->currentWorkSpace(workSize);
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
 
     for (const QRect &r : region.rects()) {
-        QRectF boundingRect = renderer->boundingRect(r, workSize);
+        QRectF boundingRect = renderer->boundingRect(r, workSpace);
 
         boundingRect.adjust(-margins.left(),
                             -margins.top(),
@@ -757,10 +757,10 @@ void MapScene::drawForeground(QPainter *painter, const QRectF &rect)
 
     Preferences *prefs = Preferences::instance();
 
-	QRect workSize;
-	mMapDocument->currentWorkSpace(workSize);
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
     mMapDocument->renderer()->drawGrid(painter,
-                                       rect.translated(-offset), workSize,
+                                       rect.translated(-offset), workSpace,
                                        prefs->gridColor());
 }
 

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -45,6 +45,7 @@
 #include "stylehelper.h"
 #include "toolmanager.h"
 #include "tilesetmanager.h"
+#include "workspace.h"
 
 #include <QApplication>
 #include <QGraphicsSceneMouseEvent>
@@ -295,7 +296,7 @@ void MapScene::updateDefaultBackgroundColor()
 
 void MapScene::updateSceneRect()
 {
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
     const QSize mapSize = mMapDocument->renderer()->workSize(workSpace);
     QRectF sceneRect(0, 0, mapSize.width(), mapSize.height());
@@ -358,7 +359,7 @@ void MapScene::repaintRegion(const QRegion &region, Layer *layer)
     const MapRenderer *renderer = mMapDocument->renderer();
     const QMargins margins = mMapDocument->map()->drawMargins();
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
 
     for (const QRect &r : region.rects()) {
@@ -759,7 +760,7 @@ void MapScene::drawForeground(QPainter *painter, const QRectF &rect)
 
     Preferences *prefs = Preferences::instance();
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
     mMapDocument->renderer()->drawGrid(painter,
                                        rect.translated(-offset), workSpace,

--- a/src/tiled/mapscene.cpp
+++ b/src/tiled/mapscene.cpp
@@ -356,8 +356,11 @@ void MapScene::repaintRegion(const QRegion &region, Layer *layer)
     const MapRenderer *renderer = mMapDocument->renderer();
     const QMargins margins = mMapDocument->map()->drawMargins();
 
+	QRect workSize;
+	mMapDocument->currentWorkSpace(workSize);
+
     for (const QRect &r : region.rects()) {
-        QRectF boundingRect = renderer->boundingRect(r);
+        QRectF boundingRect = renderer->boundingRect(r, workSize);
 
         boundingRect.adjust(-margins.left(),
                             -margins.top(),
@@ -753,8 +756,11 @@ void MapScene::drawForeground(QPainter *painter, const QRectF &rect)
     }
 
     Preferences *prefs = Preferences::instance();
+
+	QRect workSize;
+	mMapDocument->currentWorkSpace(workSize);
     mMapDocument->renderer()->drawGrid(painter,
-                                       rect.translated(-offset),
+                                       rect.translated(-offset), workSize,
                                        prefs->gridColor());
 }
 

--- a/src/tiled/minimap.cpp
+++ b/src/tiled/minimap.cpp
@@ -28,6 +28,7 @@
 #include "mapview.h"
 #include "utils.h"
 #include "zoomable.h"
+#include "workspace.h"
 
 #include <QCursor>
 #include <QResizeEvent>
@@ -173,7 +174,7 @@ void MiniMap::renderMapToImage()
 #else
     const QSize viewSize = contentsRect().size() * devicePixelRatio();
 #endif
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
     QSize mapSize = renderer->workSize(workSpace);
 

--- a/src/tiled/minimap.cpp
+++ b/src/tiled/minimap.cpp
@@ -173,7 +173,9 @@ void MiniMap::renderMapToImage()
 #else
     const QSize viewSize = contentsRect().size() * devicePixelRatio();
 #endif
-    QSize mapSize = renderer->mapSize();
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
+    QSize mapSize = renderer->workSize(workSpace);
 
     if (mapSize.isEmpty()) {
         mMapImage = QImage();

--- a/src/tiled/minimaprenderer.cpp
+++ b/src/tiled/minimaprenderer.cpp
@@ -30,6 +30,7 @@
 #include "objectgroup.h"
 #include "preferences.h"
 #include "tilelayer.h"
+#include "workspace.h"
 
 #include <QPainter>
 
@@ -63,7 +64,7 @@ void MiniMapRenderer::renderToImage(QImage& image, RenderFlags renderFlags) cons
     const Tiled::RenderFlags rendererFlags = renderer->flags();
     renderer->setFlag(ShowTileObjectOutlines, false);
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
     QSize mapSize = renderer->workSize(workSpace);
 

--- a/src/tiled/minimaprenderer.cpp
+++ b/src/tiled/minimaprenderer.cpp
@@ -63,7 +63,10 @@ void MiniMapRenderer::renderToImage(QImage& image, RenderFlags renderFlags) cons
     const Tiled::RenderFlags rendererFlags = renderer->flags();
     renderer->setFlag(ShowTileObjectOutlines, false);
 
-    QSize mapSize = renderer->mapSize();
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
+    QSize mapSize = renderer->workSize(workSpace);
+
     QMargins margins = mMapDocument->map()->computeLayerOffsetMargins();
     mapSize.setWidth(mapSize.width() + margins.left() + margins.right());
     mapSize.setHeight(mapSize.height() + margins.top() + margins.bottom());
@@ -81,8 +84,6 @@ void MiniMapRenderer::renderToImage(QImage& image, RenderFlags renderFlags) cons
 
     LayerIterator iterator(mMapDocument->map());
 
-	QRect workSpace;
-	mMapDocument->currentWorkSpace(workSpace);
     while (const Layer *layer = iterator.next()) {
         if (visibleLayersOnly && layer->isHidden())
             continue;
@@ -130,7 +131,7 @@ void MiniMapRenderer::renderToImage(QImage& image, RenderFlags renderFlags) cons
 
     if (drawTileGrid) {
         Preferences *prefs = Preferences::instance();
-        renderer->drawGrid(&painter, QRectF(QPointF(), renderer->mapSize()), workSpace,
+        renderer->drawGrid(&painter, QRectF(QPointF(), renderer->workSize(workSpace)), workSpace,
                            prefs->gridColor());
     }
 

--- a/src/tiled/minimaprenderer.cpp
+++ b/src/tiled/minimaprenderer.cpp
@@ -81,8 +81,8 @@ void MiniMapRenderer::renderToImage(QImage& image, RenderFlags renderFlags) cons
 
     LayerIterator iterator(mMapDocument->map());
 
-	QRect workSize;
-	mMapDocument->currentWorkSpace(workSize);
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
     while (const Layer *layer = iterator.next()) {
         if (visibleLayersOnly && layer->isHidden())
             continue;
@@ -97,7 +97,7 @@ void MiniMapRenderer::renderToImage(QImage& image, RenderFlags renderFlags) cons
         const ImageLayer *imageLayer = dynamic_cast<const ImageLayer*>(layer);
 
         if (tileLayer && drawTiles) {
-            renderer->drawTileLayer(&painter, tileLayer, workSize);
+            renderer->drawTileLayer(&painter, tileLayer, workSpace);
         } else if (objGroup && drawObjects) {
             QList<MapObject*> objects = objGroup->objects();
 
@@ -107,7 +107,7 @@ void MiniMapRenderer::renderToImage(QImage& image, RenderFlags renderFlags) cons
             foreach (const MapObject *object, objects) {
                 if (object->isVisible()) {
                     if (object->rotation() != qreal(0)) {
-                        QPointF origin = renderer->pixelToScreenCoords(object->position(), workSize);
+                        QPointF origin = renderer->pixelToScreenCoords(object->position(), workSpace);
                         painter.save();
                         painter.translate(origin);
                         painter.rotate(object->rotation());
@@ -115,14 +115,14 @@ void MiniMapRenderer::renderToImage(QImage& image, RenderFlags renderFlags) cons
                     }
 
                     const QColor color = MapObjectItem::objectColor(object);
-                    renderer->drawMapObject(&painter, workSize, object, color);
+                    renderer->drawMapObject(&painter, workSpace, object, color);
 
                     if (object->rotation() != qreal(0))
                         painter.restore();
                 }
             }
         } else if (imageLayer && drawImages) {
-            renderer->drawImageLayer(&painter, workSize, imageLayer);
+            renderer->drawImageLayer(&painter, workSpace, imageLayer);
         }
 
         painter.translate(-offset);
@@ -130,7 +130,7 @@ void MiniMapRenderer::renderToImage(QImage& image, RenderFlags renderFlags) cons
 
     if (drawTileGrid) {
         Preferences *prefs = Preferences::instance();
-        renderer->drawGrid(&painter, QRectF(QPointF(), renderer->mapSize()), workSize,
+        renderer->drawGrid(&painter, QRectF(QPointF(), renderer->mapSize()), workSpace,
                            prefs->gridColor());
     }
 

--- a/src/tiled/moc_predefs.h
+++ b/src/tiled/moc_predefs.h
@@ -1,0 +1,357 @@
+#define OBJC_NEW_PROPERTIES 1
+#define _LP64 1
+#define __APPLE_CC__ 6000
+#define __APPLE__ 1
+#define __ATOMIC_ACQUIRE 2
+#define __ATOMIC_ACQ_REL 4
+#define __ATOMIC_CONSUME 1
+#define __ATOMIC_RELAXED 0
+#define __ATOMIC_RELEASE 3
+#define __ATOMIC_SEQ_CST 5
+#define __BIGGEST_ALIGNMENT__ 16
+#define __BLOCKS__ 1
+#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __CHAR16_TYPE__ unsigned short
+#define __CHAR32_TYPE__ unsigned int
+#define __CHAR_BIT__ 8
+#define __CONSTANT_CFSTRINGS__ 1
+#define __DBL_DECIMAL_DIG__ 17
+#define __DBL_DENORM_MIN__ 4.9406564584124654e-324
+#define __DBL_DIG__ 15
+#define __DBL_EPSILON__ 2.2204460492503131e-16
+#define __DBL_HAS_DENORM__ 1
+#define __DBL_HAS_INFINITY__ 1
+#define __DBL_HAS_QUIET_NAN__ 1
+#define __DBL_MANT_DIG__ 53
+#define __DBL_MAX_10_EXP__ 308
+#define __DBL_MAX_EXP__ 1024
+#define __DBL_MAX__ 1.7976931348623157e+308
+#define __DBL_MIN_10_EXP__ (-307)
+#define __DBL_MIN_EXP__ (-1021)
+#define __DBL_MIN__ 2.2250738585072014e-308
+#define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
+#define __DEPRECATED 1
+#define __DYNAMIC__ 1
+#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101000
+#define __EXCEPTIONS 1
+#define __FINITE_MATH_ONLY__ 0
+#define __FLT_DECIMAL_DIG__ 9
+#define __FLT_DENORM_MIN__ 1.40129846e-45F
+#define __FLT_DIG__ 6
+#define __FLT_EPSILON__ 1.19209290e-7F
+#define __FLT_EVAL_METHOD__ 0
+#define __FLT_HAS_DENORM__ 1
+#define __FLT_HAS_INFINITY__ 1
+#define __FLT_HAS_QUIET_NAN__ 1
+#define __FLT_MANT_DIG__ 24
+#define __FLT_MAX_10_EXP__ 38
+#define __FLT_MAX_EXP__ 128
+#define __FLT_MAX__ 3.40282347e+38F
+#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT_MIN_EXP__ (-125)
+#define __FLT_MIN__ 1.17549435e-38F
+#define __FLT_RADIX__ 2
+#define __FXSR__ 1
+#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+#define __GCC_ATOMIC_INT_LOCK_FREE 2
+#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
+#define __GLIBCXX_BITSIZE_INT_N_0 128
+#define __GLIBCXX_TYPE_INT_N_0 __int128
+#define __GNUC_GNU_INLINE__ 1
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 1
+#define __GNUC__ 4
+#define __GNUG__ 4
+#define __GXX_ABI_VERSION 1002
+#define __GXX_EXPERIMENTAL_CXX0X__ 1
+#define __GXX_RTTI 1
+#define __GXX_WEAK__ 1
+#define __INT16_C_SUFFIX__ 
+#define __INT16_FMTd__ "hd"
+#define __INT16_FMTi__ "hi"
+#define __INT16_MAX__ 32767
+#define __INT16_TYPE__ short
+#define __INT32_C_SUFFIX__ 
+#define __INT32_FMTd__ "d"
+#define __INT32_FMTi__ "i"
+#define __INT32_MAX__ 2147483647
+#define __INT32_TYPE__ int
+#define __INT64_C_SUFFIX__ LL
+#define __INT64_FMTd__ "lld"
+#define __INT64_FMTi__ "lli"
+#define __INT64_MAX__ 9223372036854775807LL
+#define __INT64_TYPE__ long long int
+#define __INT8_C_SUFFIX__ 
+#define __INT8_FMTd__ "hhd"
+#define __INT8_FMTi__ "hhi"
+#define __INT8_MAX__ 127
+#define __INT8_TYPE__ signed char
+#define __INTMAX_C_SUFFIX__ L
+#define __INTMAX_FMTd__ "ld"
+#define __INTMAX_FMTi__ "li"
+#define __INTMAX_MAX__ 9223372036854775807L
+#define __INTMAX_TYPE__ long int
+#define __INTMAX_WIDTH__ 64
+#define __INTPTR_FMTd__ "ld"
+#define __INTPTR_FMTi__ "li"
+#define __INTPTR_MAX__ 9223372036854775807L
+#define __INTPTR_TYPE__ long int
+#define __INTPTR_WIDTH__ 64
+#define __INT_FAST16_FMTd__ "hd"
+#define __INT_FAST16_FMTi__ "hi"
+#define __INT_FAST16_MAX__ 32767
+#define __INT_FAST16_TYPE__ short
+#define __INT_FAST32_FMTd__ "d"
+#define __INT_FAST32_FMTi__ "i"
+#define __INT_FAST32_MAX__ 2147483647
+#define __INT_FAST32_TYPE__ int
+#define __INT_FAST64_FMTd__ "ld"
+#define __INT_FAST64_FMTi__ "li"
+#define __INT_FAST64_MAX__ 9223372036854775807L
+#define __INT_FAST64_TYPE__ long int
+#define __INT_FAST8_FMTd__ "hhd"
+#define __INT_FAST8_FMTi__ "hhi"
+#define __INT_FAST8_MAX__ 127
+#define __INT_FAST8_TYPE__ signed char
+#define __INT_LEAST16_FMTd__ "hd"
+#define __INT_LEAST16_FMTi__ "hi"
+#define __INT_LEAST16_MAX__ 32767
+#define __INT_LEAST16_TYPE__ short
+#define __INT_LEAST32_FMTd__ "d"
+#define __INT_LEAST32_FMTi__ "i"
+#define __INT_LEAST32_MAX__ 2147483647
+#define __INT_LEAST32_TYPE__ int
+#define __INT_LEAST64_FMTd__ "ld"
+#define __INT_LEAST64_FMTi__ "li"
+#define __INT_LEAST64_MAX__ 9223372036854775807L
+#define __INT_LEAST64_TYPE__ long int
+#define __INT_LEAST8_FMTd__ "hhd"
+#define __INT_LEAST8_FMTi__ "hhi"
+#define __INT_LEAST8_MAX__ 127
+#define __INT_LEAST8_TYPE__ signed char
+#define __INT_MAX__ 2147483647
+#define __LDBL_DECIMAL_DIG__ 21
+#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+#define __LDBL_DIG__ 18
+#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
+#define __LDBL_HAS_DENORM__ 1
+#define __LDBL_HAS_INFINITY__ 1
+#define __LDBL_HAS_QUIET_NAN__ 1
+#define __LDBL_MANT_DIG__ 64
+#define __LDBL_MAX_10_EXP__ 4932
+#define __LDBL_MAX_EXP__ 16384
+#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+#define __LDBL_MIN_10_EXP__ (-4931)
+#define __LDBL_MIN_EXP__ (-16381)
+#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+#define __LITTLE_ENDIAN__ 1
+#define __LONG_LONG_MAX__ 9223372036854775807LL
+#define __LONG_MAX__ 9223372036854775807L
+#define __LP64__ 1
+#define __MACH__ 1
+#define __MMX__ 1
+#define __NO_MATH_INLINES 1
+#define __OBJC_BOOL_IS_BOOL 0
+#define __OPTIMIZE__ 1
+#define __ORDER_BIG_ENDIAN__ 4321
+#define __ORDER_LITTLE_ENDIAN__ 1234
+#define __ORDER_PDP_ENDIAN__ 3412
+#define __PIC__ 2
+#define __POINTER_WIDTH__ 64
+#define __PRAGMA_REDEFINE_EXTNAME 1
+#define __PTRDIFF_FMTd__ "ld"
+#define __PTRDIFF_FMTi__ "li"
+#define __PTRDIFF_MAX__ 9223372036854775807L
+#define __PTRDIFF_TYPE__ long int
+#define __PTRDIFF_WIDTH__ 64
+#define __REGISTER_PREFIX__ 
+#define __SCHAR_MAX__ 127
+#define __SHRT_MAX__ 32767
+#define __SIG_ATOMIC_MAX__ 2147483647
+#define __SIG_ATOMIC_WIDTH__ 32
+#define __SIZEOF_DOUBLE__ 8
+#define __SIZEOF_FLOAT__ 4
+#define __SIZEOF_INT128__ 16
+#define __SIZEOF_INT__ 4
+#define __SIZEOF_LONG_DOUBLE__ 16
+#define __SIZEOF_LONG_LONG__ 8
+#define __SIZEOF_LONG__ 8
+#define __SIZEOF_POINTER__ 8
+#define __SIZEOF_PTRDIFF_T__ 8
+#define __SIZEOF_SHORT__ 2
+#define __SIZEOF_SIZE_T__ 8
+#define __SIZEOF_WCHAR_T__ 4
+#define __SIZEOF_WINT_T__ 4
+#define __SIZE_FMTX__ "lX"
+#define __SIZE_FMTo__ "lo"
+#define __SIZE_FMTu__ "lu"
+#define __SIZE_FMTx__ "lx"
+#define __SIZE_MAX__ 18446744073709551615UL
+#define __SIZE_TYPE__ long unsigned int
+#define __SIZE_WIDTH__ 64
+#define __SSE2_MATH__ 1
+#define __SSE2__ 1
+#define __SSE3__ 1
+#define __SSE_MATH__ 1
+#define __SSE__ 1
+#define __SSP__ 1
+#define __SSSE3__ 1
+#define __STDC_HOSTED__ 1
+#define __STDC_UTF_16__ 1
+#define __STDC_UTF_32__ 1
+#define __STDC__ 1
+#define __UINT16_C_SUFFIX__ 
+#define __UINT16_FMTX__ "hX"
+#define __UINT16_FMTo__ "ho"
+#define __UINT16_FMTu__ "hu"
+#define __UINT16_FMTx__ "hx"
+#define __UINT16_MAX__ 65535
+#define __UINT16_TYPE__ unsigned short
+#define __UINT32_C_SUFFIX__ U
+#define __UINT32_FMTX__ "X"
+#define __UINT32_FMTo__ "o"
+#define __UINT32_FMTu__ "u"
+#define __UINT32_FMTx__ "x"
+#define __UINT32_MAX__ 4294967295U
+#define __UINT32_TYPE__ unsigned int
+#define __UINT64_C_SUFFIX__ ULL
+#define __UINT64_FMTX__ "llX"
+#define __UINT64_FMTo__ "llo"
+#define __UINT64_FMTu__ "llu"
+#define __UINT64_FMTx__ "llx"
+#define __UINT64_MAX__ 18446744073709551615ULL
+#define __UINT64_TYPE__ long long unsigned int
+#define __UINT8_C_SUFFIX__ 
+#define __UINT8_FMTX__ "hhX"
+#define __UINT8_FMTo__ "hho"
+#define __UINT8_FMTu__ "hhu"
+#define __UINT8_FMTx__ "hhx"
+#define __UINT8_MAX__ 255
+#define __UINT8_TYPE__ unsigned char
+#define __UINTMAX_C_SUFFIX__ UL
+#define __UINTMAX_FMTX__ "lX"
+#define __UINTMAX_FMTo__ "lo"
+#define __UINTMAX_FMTu__ "lu"
+#define __UINTMAX_FMTx__ "lx"
+#define __UINTMAX_MAX__ 18446744073709551615UL
+#define __UINTMAX_TYPE__ long unsigned int
+#define __UINTMAX_WIDTH__ 64
+#define __UINTPTR_FMTX__ "lX"
+#define __UINTPTR_FMTo__ "lo"
+#define __UINTPTR_FMTu__ "lu"
+#define __UINTPTR_FMTx__ "lx"
+#define __UINTPTR_MAX__ 18446744073709551615UL
+#define __UINTPTR_TYPE__ long unsigned int
+#define __UINTPTR_WIDTH__ 64
+#define __UINT_FAST16_FMTX__ "hX"
+#define __UINT_FAST16_FMTo__ "ho"
+#define __UINT_FAST16_FMTu__ "hu"
+#define __UINT_FAST16_FMTx__ "hx"
+#define __UINT_FAST16_MAX__ 65535
+#define __UINT_FAST16_TYPE__ unsigned short
+#define __UINT_FAST32_FMTX__ "X"
+#define __UINT_FAST32_FMTo__ "o"
+#define __UINT_FAST32_FMTu__ "u"
+#define __UINT_FAST32_FMTx__ "x"
+#define __UINT_FAST32_MAX__ 4294967295U
+#define __UINT_FAST32_TYPE__ unsigned int
+#define __UINT_FAST64_FMTX__ "lX"
+#define __UINT_FAST64_FMTo__ "lo"
+#define __UINT_FAST64_FMTu__ "lu"
+#define __UINT_FAST64_FMTx__ "lx"
+#define __UINT_FAST64_MAX__ 18446744073709551615UL
+#define __UINT_FAST64_TYPE__ long unsigned int
+#define __UINT_FAST8_FMTX__ "hhX"
+#define __UINT_FAST8_FMTo__ "hho"
+#define __UINT_FAST8_FMTu__ "hhu"
+#define __UINT_FAST8_FMTx__ "hhx"
+#define __UINT_FAST8_MAX__ 255
+#define __UINT_FAST8_TYPE__ unsigned char
+#define __UINT_LEAST16_FMTX__ "hX"
+#define __UINT_LEAST16_FMTo__ "ho"
+#define __UINT_LEAST16_FMTu__ "hu"
+#define __UINT_LEAST16_FMTx__ "hx"
+#define __UINT_LEAST16_MAX__ 65535
+#define __UINT_LEAST16_TYPE__ unsigned short
+#define __UINT_LEAST32_FMTX__ "X"
+#define __UINT_LEAST32_FMTo__ "o"
+#define __UINT_LEAST32_FMTu__ "u"
+#define __UINT_LEAST32_FMTx__ "x"
+#define __UINT_LEAST32_MAX__ 4294967295U
+#define __UINT_LEAST32_TYPE__ unsigned int
+#define __UINT_LEAST64_FMTX__ "lX"
+#define __UINT_LEAST64_FMTo__ "lo"
+#define __UINT_LEAST64_FMTu__ "lu"
+#define __UINT_LEAST64_FMTx__ "lx"
+#define __UINT_LEAST64_MAX__ 18446744073709551615UL
+#define __UINT_LEAST64_TYPE__ long unsigned int
+#define __UINT_LEAST8_FMTX__ "hhX"
+#define __UINT_LEAST8_FMTo__ "hho"
+#define __UINT_LEAST8_FMTu__ "hhu"
+#define __UINT_LEAST8_FMTx__ "hhx"
+#define __UINT_LEAST8_MAX__ 255
+#define __UINT_LEAST8_TYPE__ unsigned char
+#define __USER_LABEL_PREFIX__ _
+#define __VERSION__ "4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)"
+#define __WCHAR_MAX__ 2147483647
+#define __WCHAR_TYPE__ int
+#define __WCHAR_WIDTH__ 32
+#define __WINT_TYPE__ int
+#define __WINT_WIDTH__ 32
+#define __amd64 1
+#define __amd64__ 1
+#define __apple_build_version__ 8020042
+#define __block __attribute__((__blocks__(byref)))
+#define __clang__ 1
+#define __clang_major__ 8
+#define __clang_minor__ 1
+#define __clang_patchlevel__ 0
+#define __clang_version__ "8.1.0 (clang-802.0.42)"
+#define __core2 1
+#define __core2__ 1
+#define __cplusplus 201103L
+#define __cpp_alias_templates 200704
+#define __cpp_attributes 200809
+#define __cpp_constexpr 200704
+#define __cpp_decltype 200707
+#define __cpp_delegating_constructors 200604
+#define __cpp_exceptions 199711
+#define __cpp_inheriting_constructors 200802
+#define __cpp_initializer_lists 200806
+#define __cpp_lambdas 200907
+#define __cpp_nsdmi 200809
+#define __cpp_range_based_for 200907
+#define __cpp_raw_strings 200710
+#define __cpp_ref_qualifiers 200710
+#define __cpp_rtti 199711
+#define __cpp_rvalue_references 200610
+#define __cpp_static_assert 200410
+#define __cpp_unicode_characters 200704
+#define __cpp_unicode_literals 200710
+#define __cpp_user_defined_literals 200809
+#define __cpp_variadic_templates 200704
+#define __llvm__ 1
+#define __nonnull _Nonnull
+#define __null_unspecified _Null_unspecified
+#define __nullable _Nullable
+#define __pic__ 2
+#define __private_extern__ extern
+#define __strong 
+#define __tune_core2__ 1
+#define __unsafe_unretained 
+#define __weak __attribute__((objc_gc(weak)))
+#define __x86_64 1
+#define __x86_64__ 1

--- a/src/tiled/newmapdialog.cpp
+++ b/src/tiled/newmapdialog.cpp
@@ -151,7 +151,7 @@ MapDocument *NewMapDialog::createMap()
     // Add a tile layer to new maps of reasonable size
     if (memory < gigabyte) {
         map->addLayer(new TileLayer(tr("Tile Layer 1"), 0, 0,
-                                    mapWidth, mapHeight));
+                                    mapWidth, mapHeight, tileWidth, tileHeight));
     } else {
         const double gigabytes = (double) memory / gigabyte;
         QMessageBox::warning(this, tr("Memory Usage Warning"),

--- a/src/tiled/newmapdialog.cpp
+++ b/src/tiled/newmapdialog.cpp
@@ -184,18 +184,20 @@ void NewMapDialog::refreshPixelSize()
 
     QSize size;
 
+	const QRect workSpace(map.width(), map.height(), map.tileWidth(), map.tileHeight());
+
     switch (map.orientation()) {
     case Map::Isometric:
-        size = IsometricRenderer(&map).mapSize();
+        size = IsometricRenderer(&map).workSize(workSpace);
         break;
     case Map::Staggered:
-        size = StaggeredRenderer(&map).mapSize();
+        size = StaggeredRenderer(&map).workSize(workSpace);
         break;
     case Map::Hexagonal:
-        size = HexagonalRenderer(&map).mapSize();
+        size = HexagonalRenderer(&map).workSize(workSpace);
         break;
     default:
-        size = OrthogonalRenderer(&map).mapSize();
+        size = OrthogonalRenderer(&map).workSize(workSpace);
         break;
     }
 

--- a/src/tiled/newmapdialog.cpp
+++ b/src/tiled/newmapdialog.cpp
@@ -29,6 +29,7 @@
 #include "preferences.h"
 #include "staggeredrenderer.h"
 #include "tilelayer.h"
+#include "workspace.h"
 
 #include <QMessageBox>
 #include <QPushButton>
@@ -184,7 +185,7 @@ void NewMapDialog::refreshPixelSize()
 
     QSize size;
 
-	const QRect workSpace(map.width(), map.height(), map.tileWidth(), map.tileHeight());
+	const WorkSpace workSpace(map.width(), map.height(), map.tileWidth(), map.tileHeight());
 
     switch (map.orientation()) {
     case Map::Isometric:

--- a/src/tiled/objectselectionitem.cpp
+++ b/src/tiled/objectselectionitem.cpp
@@ -30,6 +30,7 @@
 #include "preferences.h"
 #include "tile.h"
 #include "utils.h"
+#include "workspace.h"
 
 #include <QGuiApplication>
 #include <QTimerEvent>
@@ -72,7 +73,7 @@ static void align(QRectF &r, Alignment alignment)
  * returns.
  */
 static QRectF objectBounds(const MapObject *object,
-                           const MapRenderer *renderer, const QRect &workSpace)
+                           const MapRenderer *renderer, const WorkSpace &workSpace)
 {
 	// LUCA TODO: Check if this is entire file is okay (there's no document)
     if (!object->cell().isEmpty()) {
@@ -142,7 +143,7 @@ public:
         setZValue(1); // makes sure outlines are above labels
     }
 
-    void syncWithMapObject(MapRenderer *renderer, const QRect &workSpace);
+    void syncWithMapObject(MapRenderer *renderer, const WorkSpace &workSpace);
 
     QRectF boundingRect() const override;
     void paint(QPainter *painter,
@@ -161,7 +162,7 @@ private:
     int mOffset = 0;
 };
 
-void MapObjectOutline::syncWithMapObject(MapRenderer *renderer, const QRect &workSpace)
+void MapObjectOutline::syncWithMapObject(MapRenderer *renderer, const WorkSpace &workSpace)
 {
     const QPointF pixelPos = renderer->pixelToScreenCoords(mObject->position(), workSpace);
     QRectF bounds = objectBounds(mObject, renderer, workSpace);
@@ -241,7 +242,7 @@ public:
     }
 
     MapObject *mapObject() const { return mObject; }
-    void syncWithMapObject(MapRenderer *renderer, const QRect &workSpace);
+    void syncWithMapObject(MapRenderer *renderer, const WorkSpace &workSpace);
     void updateColor();
 
     QRectF boundingRect() const override;
@@ -255,7 +256,7 @@ private:
     QColor mColor;
 };
 
-void MapObjectLabel::syncWithMapObject(MapRenderer *renderer, const QRect &workSpace)
+void MapObjectLabel::syncWithMapObject(MapRenderer *renderer, const WorkSpace &workSpace)
 {
     const bool nameVisible = mObject->isVisible() && !mObject->name().isEmpty();
     setVisible(nameVisible);
@@ -394,7 +395,7 @@ void ObjectSelectionItem::layerAdded(Layer *layer)
     if (objectLabelVisibility() == Preferences::AllObjectLabels) {
         MapRenderer *renderer = mMapDocument->renderer();
 
-		QRect workSpace;
+		WorkSpace workSpace;
 		mMapDocument->currentWorkSpace(workSpace);
 
         for (MapObject *object : *objectGroup) {
@@ -463,7 +464,7 @@ void ObjectSelectionItem::syncOverlayItems(const QList<MapObject*> &objects)
 {
     MapRenderer *renderer = mMapDocument->renderer();
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
 
     for (MapObject *object : objects) {
@@ -485,7 +486,7 @@ void ObjectSelectionItem::objectsAdded(const QList<MapObject *> &objects)
     if (objectLabelVisibility() == Preferences::AllObjectLabels) {
         MapRenderer *renderer = mMapDocument->renderer();
 
-		QRect workSpace;
+		WorkSpace workSpace;
 		mMapDocument->currentWorkSpace(workSpace);
 
         for (MapObject *object : objects) {
@@ -535,7 +536,7 @@ void ObjectSelectionItem::addRemoveObjectLabels()
         if (!labelItem) {
             labelItem = new MapObjectLabel(object, this);
             
-			QRect workSpace;
+			WorkSpace workSpace;
 			mMapDocument->currentWorkSpace(workSpace);
 
             labelItem->syncWithMapObject(renderer, workSpace);
@@ -576,7 +577,7 @@ void ObjectSelectionItem::addRemoveObjectOutlines()
     QHash<MapObject*, MapObjectOutline*> outlineItems;
     MapRenderer *renderer = mMapDocument->renderer();
 
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
 
     for (MapObject *mapObject : mMapDocument->selectedObjects()) {

--- a/src/tiled/objectselectiontool.cpp
+++ b/src/tiled/objectselectiontool.cpp
@@ -33,6 +33,7 @@
 #include "objectgroup.h"
 #include "preferences.h"
 #include "raiselowerhelper.h"
+#include "workspace.h"
 #include "resizemapobject.h"
 #include "rotatemapobject.h"
 #include "selectionrectangle.h"
@@ -40,6 +41,7 @@
 #include "tile.h"
 #include "tileset.h"
 #include "utils.h"
+#include "workspace.h"
 
 #include <QApplication>
 #include <QGraphicsItem>
@@ -774,7 +776,7 @@ static bool canResizeAbsolute(const MapObject *object)
  */
 static QRectF objectBounds(const MapObject *object,
                            const MapRenderer *renderer,
-						   const QRect &workSpace,
+						   const WorkSpace &workSpace,
                            const QTransform &transform)
 {
     if (!object->cell().isEmpty()) {
@@ -838,7 +840,7 @@ static QTransform rotateAt(const QPointF &position, qreal rotation)
     return transform;
 }
 
-static QTransform objectTransform(MapObject *object, MapRenderer *renderer, const QRect &workSpace)
+static QTransform objectTransform(MapObject *object, MapRenderer *renderer, const WorkSpace &workSpace)
 {
     QTransform transform;
 
@@ -864,7 +866,7 @@ void ObjectSelectionTool::updateHandles(bool resetOriginIndicator)
 
     if (showHandles) {
         MapRenderer *renderer = mapDocument()->renderer();
-		QRect workSpace;
+		WorkSpace workSpace;
 		mapDocument()->currentWorkSpace(workSpace);
 
         QRectF boundingRect = objectBounds(objects.first(), renderer, workSpace,
@@ -1092,7 +1094,7 @@ void ObjectSelectionTool::updateMovingItems(const QPointF &pos,
                                             Qt::KeyboardModifiers modifiers)
 {
     const MapRenderer *renderer = mapDocument()->renderer();
-    QRect workSpace;
+    WorkSpace workSpace;
 	mapDocument()->currentWorkSpace(workSpace);
 
     const QPointF diff = snapToGrid(pos - mStart, modifiers);
@@ -1164,7 +1166,7 @@ void ObjectSelectionTool::updateRotatingItems(const QPointF &pos,
                                               Qt::KeyboardModifiers modifiers)
 {
     MapRenderer *renderer = mapDocument()->renderer();
-	QRect workSpace;
+	WorkSpace workSpace;
 	mapDocument()->currentWorkSpace(workSpace);
 
     const QPointF startDiff = mOrigin - mStart;
@@ -1239,7 +1241,7 @@ void ObjectSelectionTool::updateResizingItems(const QPointF &pos,
                                               Qt::KeyboardModifiers modifiers)
 {
     MapRenderer *renderer = mapDocument()->renderer();
-	QRect workSpace;
+	WorkSpace workSpace;
 	mapDocument()->currentWorkSpace(workSpace);
 
     QPointF resizingOrigin = mClickedResizeHandle->resizingOrigin();
@@ -1332,7 +1334,7 @@ void ObjectSelectionTool::updateResizingSingleItem(const QPointF &resizingOrigin
                                                    Qt::KeyboardModifiers modifiers)
 {
     const MapRenderer *renderer = mapDocument()->renderer();
-	QRect workSpace;
+	WorkSpace workSpace;
 	mapDocument()->currentWorkSpace(workSpace);
 
     const MovingObject &object = mMovingObjects.first();
@@ -1550,7 +1552,7 @@ QPointF ObjectSelectionTool::snapToGrid(const QPointF &diff,
                                         Qt::KeyboardModifiers modifiers)
 {
     MapRenderer *renderer = mapDocument()->renderer();
-	QRect workSpace;
+	WorkSpace workSpace;
 	mapDocument()->currentWorkSpace(workSpace);
 
     SnapHelper snapHelper(renderer, modifiers);

--- a/src/tiled/objectselectiontool.cpp
+++ b/src/tiled/objectselectiontool.cpp
@@ -418,9 +418,10 @@ void ObjectSelectionTool::keyPressed(QKeyEvent *event)
     const bool snapToFineGrid = Preferences::instance()->snapToFineGrid();
 
     if (moveFast) {
+		TileLayer* tileLayer = mapDocument()->currentLayer()->layerType() == Layer::TileLayerType ? static_cast<TileLayer*>(mapDocument()->currentLayer()) : 0;
         // TODO: This only makes sense for orthogonal maps
-        moveBy.rx() *= mapDocument()->map()->tileWidth();
-        moveBy.ry() *= mapDocument()->map()->tileHeight();
+        moveBy.rx() *= tileLayer ? tileLayer->tileWidth() : mapDocument()->map()->tileWidth();
+        moveBy.ry() *= tileLayer ? tileLayer->tileWidth() : mapDocument()->map()->tileHeight();
         if (snapToFineGrid)
             moveBy /= Preferences::instance()->gridFine();
     }

--- a/src/tiled/offsetlayer.cpp
+++ b/src/tiled/offsetlayer.cpp
@@ -28,6 +28,7 @@
 #include "maprenderer.h"
 #include "objectgroup.h"
 #include "tilelayer.h"
+#include "workspace.h"
 
 #include <QCoreApplication>
 
@@ -59,7 +60,7 @@ OffsetLayer::OffsetLayer(MapDocument *mapDocument,
     case Layer::GroupLayerType: {
         // These layers need offset and bounds converted to pixel units
         MapRenderer *renderer = mapDocument->renderer();
-		QRect workSpace;
+		WorkSpace workSpace;
 		mapDocument->currentWorkSpace(workSpace);
         const QPointF origin = renderer->tileToPixelCoords(QPointF(), workSpace);
         const QPointF pixelOffset = renderer->tileToPixelCoords(offset, workSpace) - origin;

--- a/src/tiled/offsetlayer.cpp
+++ b/src/tiled/offsetlayer.cpp
@@ -59,11 +59,11 @@ OffsetLayer::OffsetLayer(MapDocument *mapDocument,
     case Layer::GroupLayerType: {
         // These layers need offset and bounds converted to pixel units
         MapRenderer *renderer = mapDocument->renderer();
-		QRect workSize;
-		mapDocument->currentWorkSpace(workSize);
-        const QPointF origin = renderer->tileToPixelCoords(QPointF(), workSize);
-        const QPointF pixelOffset = renderer->tileToPixelCoords(offset, workSize) - origin;
-        const QRectF pixelBounds = renderer->tileToPixelCoords(bounds, workSize);
+		QRect workSpace;
+		mapDocument->currentWorkSpace(workSpace);
+        const QPointF origin = renderer->tileToPixelCoords(QPointF(), workSpace);
+        const QPointF pixelOffset = renderer->tileToPixelCoords(offset, workSpace) - origin;
+        const QRectF pixelBounds = renderer->tileToPixelCoords(bounds, workSpace);
 
         if (mOriginalLayer->layerType() == Layer::ObjectGroupType) {
             static_cast<ObjectGroup*>(mOffsetLayer)->offsetObjects(pixelOffset, pixelBounds, wrapX, wrapY);

--- a/src/tiled/offsetlayer.cpp
+++ b/src/tiled/offsetlayer.cpp
@@ -59,9 +59,11 @@ OffsetLayer::OffsetLayer(MapDocument *mapDocument,
     case Layer::GroupLayerType: {
         // These layers need offset and bounds converted to pixel units
         MapRenderer *renderer = mapDocument->renderer();
-        const QPointF origin = renderer->tileToPixelCoords(QPointF());
-        const QPointF pixelOffset = renderer->tileToPixelCoords(offset) - origin;
-        const QRectF pixelBounds = renderer->tileToPixelCoords(bounds);
+		QRect workSize;
+		mapDocument->currentWorkSpace(workSize);
+        const QPointF origin = renderer->tileToPixelCoords(QPointF(), workSize);
+        const QPointF pixelOffset = renderer->tileToPixelCoords(offset, workSize) - origin;
+        const QRectF pixelBounds = renderer->tileToPixelCoords(bounds, workSize);
 
         if (mOriginalLayer->layerType() == Layer::ObjectGroupType) {
             static_cast<ObjectGroup*>(mOffsetLayer)->offsetObjects(pixelOffset, pixelBounds, wrapX, wrapY);

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -675,6 +675,13 @@ void PropertyBrowser::addLayerProperties(QtProperty *parent)
 void PropertyBrowser::addTileLayerProperties()
 {
     QtProperty *groupProperty = mGroupManager->addProperty(tr("Tile Layer"));
+
+	addProperty(WidthProperty, QVariant::Int, tr("Width"), groupProperty)->setEnabled(false);
+	addProperty(HeightProperty, QVariant::Int, tr("Height"), groupProperty)->setEnabled(false);
+	addProperty(TileWidthProperty, QVariant::Int, tr("Tile Width"), groupProperty)->setAttribute(QLatin1String("minimum"), 1);
+	addProperty(TileHeightProperty, QVariant::Int, tr("Tile Height"), groupProperty)->setAttribute(QLatin1String("minimum"), 1);
+
+
     addLayerProperties(groupProperty);
     addProperty(groupProperty);
 }
@@ -1030,8 +1037,24 @@ void PropertyBrowser::applyLayerValue(PropertyId id, const QVariant &val)
 
 void PropertyBrowser::applyTileLayerValue(PropertyId id, const QVariant &val)
 {
-    Q_UNUSED(id)
-    Q_UNUSED(val)
+	TileLayer* tileLayer = static_cast<TileLayer*>(mObject);
+	switch(id) {
+		case TileWidthProperty:
+		case TileHeightProperty: {
+			QSize tileSize = tileLayer->tileSize();
+
+			if (id == TileWidthProperty) {
+				tileSize.setWidth(val.toInt());
+			} else {
+				tileSize.setHeight(val.toInt());
+			}
+
+			tileLayer->setTileSize(tileSize);
+			break;
+		}
+		default:
+			break;
+	}
 }
 
 void PropertyBrowser::applyObjectGroupValue(PropertyId id, const QVariant &val)
@@ -1441,8 +1464,14 @@ void PropertyBrowser::updateProperties()
         mIdToProperty[OffsetYProperty]->setValue(layer->offset().y());
 
         switch (layer->layerType()) {
-        case Layer::TileLayerType:
+        case Layer::TileLayerType: {
+			const TileLayer* tileLayer = static_cast<const TileLayer*>(layer);
+			mIdToProperty[WidthProperty]->setValue(tileLayer->width());
+			mIdToProperty[HeightProperty]->setValue(tileLayer->height());
+			mIdToProperty[TileWidthProperty]->setValue(tileLayer->tileWidth());
+			mIdToProperty[TileHeightProperty]->setValue(tileLayer->tileHeight());
             break;
+	    }
         case Layer::ObjectGroupType: {
             const ObjectGroup *objectGroup = static_cast<const ObjectGroup*>(layer);
             const QColor color = objectGroup->color();

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -1037,6 +1037,7 @@ void PropertyBrowser::applyLayerValue(PropertyId id, const QVariant &val)
 
 void PropertyBrowser::applyTileLayerValue(PropertyId id, const QVariant &val)
 {
+    QUndoCommand *command = nullptr;
 	TileLayer* tileLayer = static_cast<TileLayer*>(mObject);
 	switch(id) {
 		case TileWidthProperty:
@@ -1049,12 +1050,15 @@ void PropertyBrowser::applyTileLayerValue(PropertyId id, const QVariant &val)
 				tileSize.setHeight(val.toInt());
 			}
 
-			tileLayer->setTileSize(tileSize);
+			command = new SetLayerTileSize(mMapDocument, tileLayer, tileSize);
 			break;
 		}
 		default:
 			break;
 	}
+
+	if (command)
+		mDocument->undoStack()->push(command);
 }
 
 void PropertyBrowser::applyObjectGroupValue(PropertyId id, const QVariant &val)

--- a/src/tiled/snaphelper.cpp
+++ b/src/tiled/snaphelper.cpp
@@ -45,7 +45,7 @@ void SnapHelper::toggleSnap()
     mSnapToFineGrid = false;
 }
 
-void SnapHelper::snap(QPointF &pixelPos, const QRect &workSpace) const
+void SnapHelper::snap(QPointF &pixelPos, const WorkSpace &workSpace) const
 {
     if (mSnapToFineGrid || mSnapToGrid) {
         QPointF tileCoords = mRenderer->pixelToTileCoords(pixelPos, workSpace);

--- a/src/tiled/snaphelper.cpp
+++ b/src/tiled/snaphelper.cpp
@@ -45,10 +45,10 @@ void SnapHelper::toggleSnap()
     mSnapToFineGrid = false;
 }
 
-void SnapHelper::snap(QPointF &pixelPos) const
+void SnapHelper::snap(QPointF &pixelPos, const QRect &workSize) const
 {
     if (mSnapToFineGrid || mSnapToGrid) {
-        QPointF tileCoords = mRenderer->pixelToTileCoords(pixelPos);
+        QPointF tileCoords = mRenderer->pixelToTileCoords(pixelPos, workSize);
         if (mSnapToFineGrid) {
             int gridFine = Preferences::instance()->gridFine();
             tileCoords = (tileCoords * gridFine).toPoint();
@@ -56,10 +56,10 @@ void SnapHelper::snap(QPointF &pixelPos) const
         } else {
             tileCoords = tileCoords.toPoint();
         }
-        pixelPos = mRenderer->tileToPixelCoords(tileCoords);
+        pixelPos = mRenderer->tileToPixelCoords(tileCoords, workSize);
     } else if (mSnapToPixels) {
-        QPointF screenPos = mRenderer->pixelToScreenCoords(pixelPos);
-        pixelPos = mRenderer->screenToPixelCoords(screenPos.toPoint());
+        QPointF screenPos = mRenderer->pixelToScreenCoords(pixelPos, workSize);
+        pixelPos = mRenderer->screenToPixelCoords(screenPos.toPoint(), workSize);
     }
 }
 

--- a/src/tiled/snaphelper.cpp
+++ b/src/tiled/snaphelper.cpp
@@ -45,10 +45,10 @@ void SnapHelper::toggleSnap()
     mSnapToFineGrid = false;
 }
 
-void SnapHelper::snap(QPointF &pixelPos, const QRect &workSize) const
+void SnapHelper::snap(QPointF &pixelPos, const QRect &workSpace) const
 {
     if (mSnapToFineGrid || mSnapToGrid) {
-        QPointF tileCoords = mRenderer->pixelToTileCoords(pixelPos, workSize);
+        QPointF tileCoords = mRenderer->pixelToTileCoords(pixelPos, workSpace);
         if (mSnapToFineGrid) {
             int gridFine = Preferences::instance()->gridFine();
             tileCoords = (tileCoords * gridFine).toPoint();
@@ -56,10 +56,10 @@ void SnapHelper::snap(QPointF &pixelPos, const QRect &workSize) const
         } else {
             tileCoords = tileCoords.toPoint();
         }
-        pixelPos = mRenderer->tileToPixelCoords(tileCoords, workSize);
+        pixelPos = mRenderer->tileToPixelCoords(tileCoords, workSpace);
     } else if (mSnapToPixels) {
-        QPointF screenPos = mRenderer->pixelToScreenCoords(pixelPos, workSize);
-        pixelPos = mRenderer->screenToPixelCoords(screenPos.toPoint(), workSize);
+        QPointF screenPos = mRenderer->pixelToScreenCoords(pixelPos, workSpace);
+        pixelPos = mRenderer->screenToPixelCoords(screenPos.toPoint(), workSpace);
     }
 }
 

--- a/src/tiled/snaphelper.h
+++ b/src/tiled/snaphelper.h
@@ -35,7 +35,7 @@ public:
 
     bool snaps() const { return mSnapToGrid || mSnapToFineGrid || mSnapToPixels; }
 
-    void snap(QPointF &pixelPos, const QRect &workSize) const;
+    void snap(QPointF &pixelPos, const QRect &workSpace) const;
 
 private:
     const MapRenderer *mRenderer;

--- a/src/tiled/snaphelper.h
+++ b/src/tiled/snaphelper.h
@@ -35,7 +35,7 @@ public:
 
     bool snaps() const { return mSnapToGrid || mSnapToFineGrid || mSnapToPixels; }
 
-    void snap(QPointF &pixelPos) const;
+    void snap(QPointF &pixelPos, const QRect &workSize) const;
 
 private:
     const MapRenderer *mRenderer;

--- a/src/tiled/snaphelper.h
+++ b/src/tiled/snaphelper.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "maprenderer.h"
+#include "workspace.h"
 
 namespace Tiled {
 namespace Internal {
@@ -35,7 +36,7 @@ public:
 
     bool snaps() const { return mSnapToGrid || mSnapToFineGrid || mSnapToPixels; }
 
-    void snap(QPointF &pixelPos, const QRect &workSpace) const;
+    void snap(QPointF &pixelPos, const WorkSpace &workSpace) const;
 
 private:
     const MapRenderer *mRenderer;

--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -281,8 +281,8 @@ void StampBrush::endCapture()
         Map *stamp = new Map(map->orientation(),
                              capture->width(),
                              capture->height(),
-                             map->tileWidth(),
-                             map->tileHeight());
+                             capture->tileWidth(),
+                             capture->tileHeight());
 
         //gets if the relative stagger should be the same as the base layer
         int staggerIndexOffSet;
@@ -388,6 +388,8 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &list)
         return;
 
 	Map* map = mapDocument()->map();
+	TileLayer* tileLayer = currentTileLayer();
+
 
     if (mIsRandom) {
         if (mRandomCellPicker.isEmpty())
@@ -398,10 +400,12 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &list)
             paintedRegion += QRect(p, QSize(1, 1));
 
         QRect bounds = paintedRegion.boundingRect();
-		// LUCA TODO: I need to use the current layer's tile size, not the maps
+
         SharedTileLayer preview(new TileLayer(QString(),
                                               bounds.x(), bounds.y(),
-                                              bounds.width(), bounds.height(), map->tileWidth(), map->tileHeight()));
+                                              bounds.width(), bounds.height(),
+											  (tileLayer ? tileLayer->tileWidth() : map->tileWidth()),
+											  (tileLayer ? tileLayer->tileHeight() : map->tileHeight())));
 
         for (const QPoint &p : list) {
             const Cell &cell = mRandomCellPicker.pick();
@@ -497,11 +501,11 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &list)
 
         QRect bounds = paintedRegion.boundingRect();
 
-		// LUCA TODO: These should be the current layer's tile sizes, not the maps
         SharedTileLayer preview(new TileLayer(QString(),
                                               bounds.x(), bounds.y(),
                                               bounds.width(), bounds.height(),
-											  map->tileWidth(), map->tileHeight()));
+											  (tileLayer ? tileLayer->tileWidth() : map->tileWidth()),
+											  (tileLayer ? tileLayer->tileHeight() : map->tileHeight())));
 
         for (const PaintOperation &op : operations)
             preview->merge(op.pos - bounds.topLeft(), op.stamp);

--- a/src/tiled/stampbrush.cpp
+++ b/src/tiled/stampbrush.cpp
@@ -387,6 +387,8 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &list)
     if (mStamp.isEmpty())
         return;
 
+	Map* map = mapDocument()->map();
+
     if (mIsRandom) {
         if (mRandomCellPicker.isEmpty())
             return;
@@ -396,9 +398,10 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &list)
             paintedRegion += QRect(p, QSize(1, 1));
 
         QRect bounds = paintedRegion.boundingRect();
+		// LUCA TODO: I need to use the current layer's tile size, not the maps
         SharedTileLayer preview(new TileLayer(QString(),
                                               bounds.x(), bounds.y(),
-                                              bounds.width(), bounds.height()));
+                                              bounds.width(), bounds.height(), map->tileWidth(), map->tileHeight()));
 
         for (const QPoint &p : list) {
             const Cell &cell = mRandomCellPicker.pick();
@@ -493,9 +496,12 @@ void StampBrush::drawPreviewLayer(const QVector<QPoint> &list)
         }
 
         QRect bounds = paintedRegion.boundingRect();
+
+		// LUCA TODO: These should be the current layer's tile sizes, not the maps
         SharedTileLayer preview(new TileLayer(QString(),
                                               bounds.x(), bounds.y(),
-                                              bounds.width(), bounds.height()));
+                                              bounds.width(), bounds.height(),
+											  map->tileWidth(), map->tileHeight()));
 
         for (const PaintOperation &op : operations)
             preview->merge(op.pos - bounds.topLeft(), op.stamp);

--- a/src/tiled/terrainbrush.cpp
+++ b/src/tiled/terrainbrush.cpp
@@ -386,7 +386,7 @@ void TerrainBrush::updateBrush(QPoint cursorPos, const QVector<QPoint> *list)
     }
 
     // create the tile stamp
-    SharedTileLayer stamp = SharedTileLayer(new TileLayer(QString(), 0, 0, currentLayer->width(), currentLayer->height()));
+    SharedTileLayer stamp = SharedTileLayer(new TileLayer(QString(), 0, 0, currentLayer->width(), currentLayer->height(), currentLayer->tileWidth(), currentLayer->tileHeight()));
 
     // create a consideration list, and push the start points
     QVector<ConsiderationPoint> transitionList;

--- a/src/tiled/thumbnailrenderer.cpp
+++ b/src/tiled/thumbnailrenderer.cpp
@@ -73,7 +73,7 @@ static bool smoothTransform(qreal scale)
 }
 
 static QRectF cellRect(const MapRenderer &renderer,
-                       const QRect &workSpace,
+                       const WorkSpace &workSpace,
                        const Cell &cell,
                        const QPointF &tileCoords)
 {
@@ -99,7 +99,7 @@ static QRectF cellRect(const MapRenderer &renderer,
 static QRect computeMapRect(const MapRenderer &renderer)
 {
 	const Map* map = renderer.map();
-	const QRect mapWorkSpace(map->width(), map->height(), map->tileWidth(), map->tileHeight());
+	const WorkSpace mapWorkSpace(map->width(), map->height(), map->tileWidth(), map->tileHeight());
     // Start with the basic map size
     QRectF rect(QPointF(0, 0), renderer.workSize(mapWorkSpace));
 
@@ -109,7 +109,7 @@ static QRect computeMapRect(const MapRenderer &renderer)
             continue;
 
         const TileLayer *tileLayer = static_cast<const TileLayer*>(layer);
-		const QRect workSpace(tileLayer->width(), tileLayer->height(), tileLayer->tileWidth(), tileLayer->tileHeight());
+		const WorkSpace workSpace(tileLayer->width(), tileLayer->height(), tileLayer->tileWidth(), tileLayer->tileHeight());
         const QPointF offset = tileLayer->totalOffset();
 
         for (int y = 0; y < tileLayer->height(); ++y) {
@@ -128,7 +128,7 @@ static QRect computeMapRect(const MapRenderer &renderer)
     return rect.toAlignedRect();
 }
 
-QImage ThumbnailRenderer::render(const QSize &size, const QRect &workSpace) const
+QImage ThumbnailRenderer::render(const QSize &size, const WorkSpace &workSpace) const
 {
     QImage image(size, QImage::Format_ARGB32_Premultiplied);
 

--- a/src/tiled/thumbnailrenderer.cpp
+++ b/src/tiled/thumbnailrenderer.cpp
@@ -98,8 +98,10 @@ static QRectF cellRect(const MapRenderer &renderer,
 
 static QRect computeMapRect(const MapRenderer &renderer)
 {
+	const Map* map = renderer.map();
+	const QRect mapWorkSpace(map->width(), map->height(), map->tileWidth(), map->tileHeight());
     // Start with the basic map size
-    QRectF rect(QPointF(0, 0), renderer.mapSize());
+    QRectF rect(QPointF(0, 0), renderer.workSize(mapWorkSpace));
 
     // Take into account large tiles extending beyond their cell
     for (const Layer *layer : renderer.map()->layers()) {

--- a/src/tiled/thumbnailrenderer.cpp
+++ b/src/tiled/thumbnailrenderer.cpp
@@ -73,7 +73,7 @@ static bool smoothTransform(qreal scale)
 }
 
 static QRectF cellRect(const MapRenderer &renderer,
-                       const QRect &workSize,
+                       const QRect &workSpace,
                        const Cell &cell,
                        const QPointF &tileCoords)
 {
@@ -81,7 +81,7 @@ static QRectF cellRect(const MapRenderer &renderer,
     if (!tile)
         return QRectF();
 
-    QPointF pixelCoords = renderer.tileToScreenCoords(tileCoords, workSize);
+    QPointF pixelCoords = renderer.tileToScreenCoords(tileCoords, workSpace);
     QPointF offset = tile->offset();
     QSize size = tile->size();
 
@@ -107,7 +107,7 @@ static QRect computeMapRect(const MapRenderer &renderer)
             continue;
 
         const TileLayer *tileLayer = static_cast<const TileLayer*>(layer);
-		const QRect workSize(tileLayer->width(), tileLayer->height(), tileLayer->tileWidth(), tileLayer->tileHeight());
+		const QRect workSpace(tileLayer->width(), tileLayer->height(), tileLayer->tileWidth(), tileLayer->tileHeight());
         const QPointF offset = tileLayer->totalOffset();
 
         for (int y = 0; y < tileLayer->height(); ++y) {
@@ -115,7 +115,7 @@ static QRect computeMapRect(const MapRenderer &renderer)
                 const Cell &cell = tileLayer->cellAt(x, y);
 
                 if (!cell.isEmpty()) {
-                    QRectF r = cellRect(renderer, workSize, cell, QPointF(x, y));
+                    QRectF r = cellRect(renderer, workSpace, cell, QPointF(x, y));
                     r.translate(offset);
                     rect |= r;
                 }
@@ -126,7 +126,7 @@ static QRect computeMapRect(const MapRenderer &renderer)
     return rect.toAlignedRect();
 }
 
-QImage ThumbnailRenderer::render(const QSize &size, const QRect &workSize) const
+QImage ThumbnailRenderer::render(const QSize &size, const QRect &workSpace) const
 {
     QImage image(size, QImage::Format_ARGB32_Premultiplied);
 
@@ -175,7 +175,7 @@ QImage ThumbnailRenderer::render(const QSize &size, const QRect &workSize) const
         switch (layer->layerType()) {
         case Layer::TileLayerType: {
             const TileLayer *tileLayer = static_cast<const TileLayer*>(layer);
-            mRenderer->drawTileLayer(&painter, tileLayer, workSize);
+            mRenderer->drawTileLayer(&painter, tileLayer, workSpace);
             break;
         }
 
@@ -189,7 +189,7 @@ QImage ThumbnailRenderer::render(const QSize &size, const QRect &workSize) const
             foreach (const MapObject *object, objects) {
                 if (object->isVisible()) {
                     if (object->rotation() != qreal(0)) {
-                        QPointF origin = mRenderer->pixelToScreenCoords(object->position(), workSize);
+                        QPointF origin = mRenderer->pixelToScreenCoords(object->position(), workSpace);
                         painter.save();
                         painter.translate(origin);
                         painter.rotate(object->rotation());
@@ -197,7 +197,7 @@ QImage ThumbnailRenderer::render(const QSize &size, const QRect &workSize) const
                     }
 
                     const QColor color = MapObjectItem::objectColor(object);
-                    mRenderer->drawMapObject(&painter, workSize, object, color);
+                    mRenderer->drawMapObject(&painter, workSpace, object, color);
 
                     if (object->rotation() != qreal(0))
                         painter.restore();
@@ -207,7 +207,7 @@ QImage ThumbnailRenderer::render(const QSize &size, const QRect &workSize) const
         }
         case Layer::ImageLayerType: {
             const ImageLayer *imageLayer = static_cast<const ImageLayer*>(layer);
-            mRenderer->drawImageLayer(&painter, workSize, imageLayer);
+            mRenderer->drawImageLayer(&painter, workSpace, imageLayer);
             break;
         }
         case Layer::GroupLayerType: {

--- a/src/tiled/thumbnailrenderer.h
+++ b/src/tiled/thumbnailrenderer.h
@@ -37,7 +37,7 @@ public:
     ThumbnailRenderer(Map *map);
     ~ThumbnailRenderer();
 
-    QImage render(const QSize &size, const QRect &workSize) const;
+    QImage render(const QSize &size, const QRect &workSpace) const;
 
     bool visibleLayersOnly() const;
     void setVisibleLayersOnly(bool visibleLayersOnly);

--- a/src/tiled/thumbnailrenderer.h
+++ b/src/tiled/thumbnailrenderer.h
@@ -37,7 +37,7 @@ public:
     ThumbnailRenderer(Map *map);
     ~ThumbnailRenderer();
 
-    QImage render(const QSize &size) const;
+    QImage render(const QSize &size, const QRect &workSize) const;
 
     bool visibleLayersOnly() const;
     void setVisibleLayersOnly(bool visibleLayersOnly);

--- a/src/tiled/thumbnailrenderer.h
+++ b/src/tiled/thumbnailrenderer.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <QImage>
+#include "workspace.h"
 
 namespace Tiled {
 
@@ -37,7 +38,7 @@ public:
     ThumbnailRenderer(Map *map);
     ~ThumbnailRenderer();
 
-    QImage render(const QSize &size, const QRect &workSpace) const;
+    QImage render(const QSize &size, const WorkSpace &workSpace) const;
 
     bool visibleLayersOnly() const;
     void setVisibleLayersOnly(bool visibleLayersOnly);

--- a/src/tiled/tilecollisiondock.cpp
+++ b/src/tiled/tilecollisiondock.cpp
@@ -162,7 +162,7 @@ void TileCollisionDock::setTile(Tile *tile)
         Map *map = new Map(orientation, 1, 1, tileSize.width(), tileSize.height());
         map->addTileset(tile->sharedTileset());
 
-        TileLayer *tileLayer = new TileLayer(QString(), 0, 0, 1, 1);
+        TileLayer *tileLayer = new TileLayer(QString(), 0, 0, 1, 1, tileSize.width(), tileSize.height());
         tileLayer->setCell(0, 0, Cell(tile));
         map->addLayer(tileLayer);
 

--- a/src/tiled/tilelayeritem.cpp
+++ b/src/tiled/tilelayeritem.cpp
@@ -45,9 +45,9 @@ void TileLayerItem::syncWithTileLayer()
     prepareGeometryChange();
 
     MapRenderer *renderer = mMapDocument->renderer();
-	QRect workSize;
-	mMapDocument->currentWorkSpace(workSize);
-    QRectF boundingRect = renderer->boundingRect(tileLayer()->bounds(), workSize);
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
+    QRectF boundingRect = renderer->boundingRect(tileLayer()->bounds(), workSpace);
 
     QMargins margins = tileLayer()->drawMargins();
     if (const Map *map = tileLayer()->map()) {
@@ -71,9 +71,9 @@ void TileLayerItem::paint(QPainter *painter,
                           QWidget *)
 {
     MapRenderer *renderer = mMapDocument->renderer();
-    QRect workSize;
-	mMapDocument->currentWorkSpace(workSize);
+    QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
 
     // TODO: Display a border around the layer when selected
-    renderer->drawTileLayer(painter, tileLayer(), workSize, option->exposedRect);
+    renderer->drawTileLayer(painter, tileLayer(), workSpace, option->exposedRect);
 }

--- a/src/tiled/tilelayeritem.cpp
+++ b/src/tiled/tilelayeritem.cpp
@@ -24,6 +24,7 @@
 #include "map.h"
 #include "mapdocument.h"
 #include "maprenderer.h"
+#include "workspace.h"
 
 #include <QPainter>
 #include <QStyleOptionGraphicsItem>
@@ -45,7 +46,7 @@ void TileLayerItem::syncWithTileLayer()
     prepareGeometryChange();
 
     MapRenderer *renderer = mMapDocument->renderer();
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
     QRectF boundingRect = renderer->boundingRect(tileLayer()->bounds(), workSpace);
 
@@ -71,7 +72,7 @@ void TileLayerItem::paint(QPainter *painter,
                           QWidget *)
 {
     MapRenderer *renderer = mMapDocument->renderer();
-    QRect workSpace;
+    WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
 
     // TODO: Display a border around the layer when selected

--- a/src/tiled/tilelayeritem.cpp
+++ b/src/tiled/tilelayeritem.cpp
@@ -49,8 +49,8 @@ void TileLayerItem::syncWithTileLayer()
 
     QMargins margins = tileLayer()->drawMargins();
     if (const Map *map = tileLayer()->map()) {
-        margins.setTop(margins.top() - map->tileHeight());
-        margins.setRight(margins.right() - map->tileWidth());
+        margins.setTop(margins.top() - tileLayer()->tileHeight());
+        margins.setRight(margins.right() - tileLayer()->tileWidth());
     }
 
     mBoundingRect = boundingRect.adjusted(-margins.left(),

--- a/src/tiled/tilelayeritem.cpp
+++ b/src/tiled/tilelayeritem.cpp
@@ -45,7 +45,9 @@ void TileLayerItem::syncWithTileLayer()
     prepareGeometryChange();
 
     MapRenderer *renderer = mMapDocument->renderer();
-    QRectF boundingRect = renderer->boundingRect(tileLayer()->bounds());
+	QRect workSize;
+	mMapDocument->currentWorkSpace(workSize);
+    QRectF boundingRect = renderer->boundingRect(tileLayer()->bounds(), workSize);
 
     QMargins margins = tileLayer()->drawMargins();
     if (const Map *map = tileLayer()->map()) {
@@ -69,6 +71,9 @@ void TileLayerItem::paint(QPainter *painter,
                           QWidget *)
 {
     MapRenderer *renderer = mMapDocument->renderer();
+    QRect workSize;
+	mMapDocument->currentWorkSpace(workSize);
+
     // TODO: Display a border around the layer when selected
-    renderer->drawTileLayer(painter, tileLayer(), option->exposedRect);
+    renderer->drawTileLayer(painter, tileLayer(), workSize, option->exposedRect);
 }

--- a/src/tiled/tileselectionitem.cpp
+++ b/src/tiled/tileselectionitem.cpp
@@ -62,9 +62,9 @@ void TileSelectionItem::paint(QPainter *painter,
     highlight.setAlpha(128);
 
     MapRenderer *renderer = mMapDocument->renderer();
-	QRect workSize;
-	mMapDocument->currentWorkSpace(workSize);
-    renderer->drawTileSelection(painter, selection, workSize, highlight,
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
+    renderer->drawTileSelection(painter, selection, workSpace, highlight,
                                 option->exposedRect);
 }
 
@@ -77,10 +77,10 @@ void TileSelectionItem::selectionChanged(const QRegion &newSelection,
     // Make sure changes within the bounding rect are updated
     const QRect changedArea = newSelection.xored(oldSelection).boundingRect();
 
-    QRect workSize;
-	mMapDocument->currentWorkSpace(workSize);
+    QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
 
-    update(mMapDocument->renderer()->boundingRect(changedArea, workSize));
+    update(mMapDocument->renderer()->boundingRect(changedArea, workSpace));
 }
 
 void TileSelectionItem::layerChanged(Layer *layer)
@@ -99,7 +99,7 @@ void TileSelectionItem::currentLayerChanged(Layer *layer)
 void TileSelectionItem::updateBoundingRect()
 {
     const QRect b = mMapDocument->selectedArea().boundingRect();
-	QRect workSize;
-	mMapDocument->currentWorkSpace(workSize);
-    mBoundingRect = mMapDocument->renderer()->boundingRect(b, workSize);
+	QRect workSpace;
+	mMapDocument->currentWorkSpace(workSpace);
+    mBoundingRect = mMapDocument->renderer()->boundingRect(b, workSpace);
 }

--- a/src/tiled/tileselectionitem.cpp
+++ b/src/tiled/tileselectionitem.cpp
@@ -62,7 +62,9 @@ void TileSelectionItem::paint(QPainter *painter,
     highlight.setAlpha(128);
 
     MapRenderer *renderer = mMapDocument->renderer();
-    renderer->drawTileSelection(painter, selection, highlight,
+	QRect workSize;
+	mMapDocument->currentWorkSpace(workSize);
+    renderer->drawTileSelection(painter, selection, workSize, highlight,
                                 option->exposedRect);
 }
 
@@ -74,7 +76,11 @@ void TileSelectionItem::selectionChanged(const QRegion &newSelection,
 
     // Make sure changes within the bounding rect are updated
     const QRect changedArea = newSelection.xored(oldSelection).boundingRect();
-    update(mMapDocument->renderer()->boundingRect(changedArea));
+
+    QRect workSize;
+	mMapDocument->currentWorkSpace(workSize);
+
+    update(mMapDocument->renderer()->boundingRect(changedArea, workSize));
 }
 
 void TileSelectionItem::layerChanged(Layer *layer)
@@ -93,5 +99,7 @@ void TileSelectionItem::currentLayerChanged(Layer *layer)
 void TileSelectionItem::updateBoundingRect()
 {
     const QRect b = mMapDocument->selectedArea().boundingRect();
-    mBoundingRect = mMapDocument->renderer()->boundingRect(b);
+	QRect workSize;
+	mMapDocument->currentWorkSpace(workSize);
+    mBoundingRect = mMapDocument->renderer()->boundingRect(b, workSize);
 }

--- a/src/tiled/tileselectionitem.cpp
+++ b/src/tiled/tileselectionitem.cpp
@@ -24,6 +24,7 @@
 #include "map.h"
 #include "mapdocument.h"
 #include "maprenderer.h"
+#include "workspace.h"
 
 #include <QApplication>
 #include <QPainter>
@@ -62,7 +63,7 @@ void TileSelectionItem::paint(QPainter *painter,
     highlight.setAlpha(128);
 
     MapRenderer *renderer = mMapDocument->renderer();
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
     renderer->drawTileSelection(painter, selection, workSpace, highlight,
                                 option->exposedRect);
@@ -77,7 +78,7 @@ void TileSelectionItem::selectionChanged(const QRegion &newSelection,
     // Make sure changes within the bounding rect are updated
     const QRect changedArea = newSelection.xored(oldSelection).boundingRect();
 
-    QRect workSpace;
+    WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
 
     update(mMapDocument->renderer()->boundingRect(changedArea, workSpace));
@@ -99,7 +100,7 @@ void TileSelectionItem::currentLayerChanged(Layer *layer)
 void TileSelectionItem::updateBoundingRect()
 {
     const QRect b = mMapDocument->selectedArea().boundingRect();
-	QRect workSpace;
+	WorkSpace workSpace;
 	mMapDocument->currentWorkSpace(workSpace);
     mBoundingRect = mMapDocument->renderer()->boundingRect(b, workSpace);
 }

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -478,10 +478,15 @@ void TilesetDock::updateCurrentTiles()
         if (maxY < index.row()) maxY = index.row();
     }
 
+	Map* map = mMapDocument->map();
+
+	// LUCA TODO: Make sure these are the correct values for tile sizes, ask Bjorn
     // Create a tile layer from the current selection
     TileLayer *tileLayer = new TileLayer(QString(), 0, 0,
                                          maxX - minX + 1,
-                                         maxY - minY + 1);
+                                         maxY - minY + 1,
+										 map->tileWidth(),
+										 map->tileHeight());
 
     const TilesetModel *model = view->tilesetModel();
     for (const QModelIndex &index : indexes) {

--- a/src/tiled/tilestampmanager.cpp
+++ b/src/tiled/tilestampmanager.cpp
@@ -131,7 +131,7 @@ static TileStamp stampFromContext(AbstractTool *selectedTool)
         const Map *map = mapDocument->map();
         Map *copyMap = new Map(map->orientation(),
                                copy->width(), copy->height(),
-                               map->tileWidth(), map->tileHeight());
+                               copy->tileWidth(), copy->tileHeight());
 
         // Add tileset references to map
         foreach (const SharedTileset &tileset, copy->usedTilesets())

--- a/src/tiled/tilestampmodel.cpp
+++ b/src/tiled/tilestampmodel.cpp
@@ -117,9 +117,9 @@ bool TileStampModel::setData(const QModelIndex &index, const QVariant &value, in
     return false;
 }
 
-static QPixmap renderThumbnail(const ThumbnailRenderer &renderer, const QRect &workSize)
+static QPixmap renderThumbnail(const ThumbnailRenderer &renderer, const QRect &workSpace)
 {
-    return QPixmap::fromImage(renderer.render(QSize(64, 64), workSize)
+    return QPixmap::fromImage(renderer.render(QSize(64, 64), workSpace)
                               .scaled(32, 32,
                                       Qt::IgnoreAspectRatio,
                                       Qt::SmoothTransformation));
@@ -139,8 +139,8 @@ QVariant TileStampModel::data(const QModelIndex &index, int role) const
                 QPixmap thumbnail = mThumbnailCache.value(map);
                 if (thumbnail.isNull()) {
                     ThumbnailRenderer renderer(map);
-					const QRect workSize(map->width(), map->height(), map->tileWidth(), map->tileHeight());
-                    thumbnail = renderThumbnail(renderer, workSize);
+					const QRect workSpace(map->width(), map->height(), map->tileWidth(), map->tileHeight());
+                    thumbnail = renderThumbnail(renderer, workSpace);
                     mThumbnailCache.insert(map, thumbnail);
                 }
                 return thumbnail;
@@ -165,8 +165,8 @@ QVariant TileStampModel::data(const QModelIndex &index, int role) const
                 QPixmap thumbnail = mThumbnailCache.value(map);
                 if (thumbnail.isNull()) {
                     ThumbnailRenderer renderer(map);
-					const QRect workSize(map->width(), map->height(), map->tileWidth(), map->tileHeight());
-                    thumbnail = renderThumbnail(renderer, workSize);
+					const QRect workSpace(map->width(), map->height(), map->tileWidth(), map->tileHeight());
+                    thumbnail = renderThumbnail(renderer, workSpace);
                     mThumbnailCache.insert(map, thumbnail);
                 }
                 return thumbnail;

--- a/src/tiled/tilestampmodel.cpp
+++ b/src/tiled/tilestampmodel.cpp
@@ -117,9 +117,9 @@ bool TileStampModel::setData(const QModelIndex &index, const QVariant &value, in
     return false;
 }
 
-static QPixmap renderThumbnail(const ThumbnailRenderer &renderer)
+static QPixmap renderThumbnail(const ThumbnailRenderer &renderer, const QRect &workSize)
 {
-    return QPixmap::fromImage(renderer.render(QSize(64, 64))
+    return QPixmap::fromImage(renderer.render(QSize(64, 64), workSize)
                               .scaled(32, 32,
                                       Qt::IgnoreAspectRatio,
                                       Qt::SmoothTransformation));
@@ -139,7 +139,8 @@ QVariant TileStampModel::data(const QModelIndex &index, int role) const
                 QPixmap thumbnail = mThumbnailCache.value(map);
                 if (thumbnail.isNull()) {
                     ThumbnailRenderer renderer(map);
-                    thumbnail = renderThumbnail(renderer);
+					const QRect workSize(map->width(), map->height(), map->tileWidth(), map->tileHeight());
+                    thumbnail = renderThumbnail(renderer, workSize);
                     mThumbnailCache.insert(map, thumbnail);
                 }
                 return thumbnail;
@@ -164,7 +165,8 @@ QVariant TileStampModel::data(const QModelIndex &index, int role) const
                 QPixmap thumbnail = mThumbnailCache.value(map);
                 if (thumbnail.isNull()) {
                     ThumbnailRenderer renderer(map);
-                    thumbnail = renderThumbnail(renderer);
+					const QRect workSize(map->width(), map->height(), map->tileWidth(), map->tileHeight());
+                    thumbnail = renderThumbnail(renderer, workSize);
                     mThumbnailCache.insert(map, thumbnail);
                 }
                 return thumbnail;

--- a/src/tiled/tilestampmodel.cpp
+++ b/src/tiled/tilestampmodel.cpp
@@ -21,6 +21,7 @@
 #include "tilestampmodel.h"
 
 #include "thumbnailrenderer.h"
+#include "workspace.h"
 
 namespace Tiled {
 namespace Internal {
@@ -117,7 +118,7 @@ bool TileStampModel::setData(const QModelIndex &index, const QVariant &value, in
     return false;
 }
 
-static QPixmap renderThumbnail(const ThumbnailRenderer &renderer, const QRect &workSpace)
+static QPixmap renderThumbnail(const ThumbnailRenderer &renderer, const WorkSpace &workSpace)
 {
     return QPixmap::fromImage(renderer.render(QSize(64, 64), workSpace)
                               .scaled(32, 32,
@@ -139,7 +140,7 @@ QVariant TileStampModel::data(const QModelIndex &index, int role) const
                 QPixmap thumbnail = mThumbnailCache.value(map);
                 if (thumbnail.isNull()) {
                     ThumbnailRenderer renderer(map);
-					const QRect workSpace(map->width(), map->height(), map->tileWidth(), map->tileHeight());
+					const WorkSpace workSpace(map->width(), map->height(), map->tileWidth(), map->tileHeight());
                     thumbnail = renderThumbnail(renderer, workSpace);
                     mThumbnailCache.insert(map, thumbnail);
                 }
@@ -165,7 +166,7 @@ QVariant TileStampModel::data(const QModelIndex &index, int role) const
                 QPixmap thumbnail = mThumbnailCache.value(map);
                 if (thumbnail.isNull()) {
                     ThumbnailRenderer renderer(map);
-					const QRect workSpace(map->width(), map->height(), map->tileWidth(), map->tileHeight());
+					const WorkSpace workSpace(map->width(), map->height(), map->tileWidth(), map->tileHeight());
                     thumbnail = renderThumbnail(renderer, workSpace);
                     mThumbnailCache.insert(map, thumbnail);
                 }

--- a/src/tiled/undocommands.h
+++ b/src/tiled/undocommands.h
@@ -28,6 +28,7 @@ enum UndoCommands {
     Cmd_EraseTiles,
     Cmd_PaintTileLayer,
     Cmd_ChangeLayerOffset,
+	Cmd_ChangeLayerTileSize,
     Cmd_ChangeLayerOpacity,
     Cmd_ChangeTileTerrain,
     Cmd_ChangeTilesetTileOffset

--- a/src/tiled/workspace.h
+++ b/src/tiled/workspace.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "map.h"
+#include "layer.h"
+#include "tilelayer.h"
+
+namespace Tiled {
+namespace Internal {
+
+class WorkSpace
+{
+public:
+	WorkSpace(int width, int height, int tileWidth, int tileHeight)
+		: mWidth(width)
+		, mHeight(height)
+		, mTileWidth(tileWidth)
+		, mTileHeight(tileHeight)
+	{}
+
+	 int width() const { return mWidth; }
+	 int height() const { return mHeight; }
+	 int tileWidth() const { return mTileWidth; }
+	 int tileHeight() const { return mTileHeight; }
+}
+
+}
+}

--- a/src/tmxrasterizer/tmxrasterizer.cpp
+++ b/src/tmxrasterizer/tmxrasterizer.cpp
@@ -109,6 +109,7 @@ int TmxRasterizer::render(const QString &mapFileName,
         yScale = (qreal) mSize / mapSize.height();
         xScale = yScale = qMin(1.0, qMin(xScale, yScale));
     } else if (mTileSize > 0) {
+		// LUCA TODO: Ask Bjorn if this is okay to stay
         xScale = (qreal) mTileSize / map->tileWidth();
         yScale = (qreal) mTileSize / map->tileHeight();
     } else {

--- a/src/tmxrasterizer/tmxrasterizer.cpp
+++ b/src/tmxrasterizer/tmxrasterizer.cpp
@@ -150,9 +150,9 @@ int TmxRasterizer::render(const QString &mapFileName,
         const ImageLayer *imageLayer = dynamic_cast<const ImageLayer*>(layer);
 
         if (tileLayer) {
-			const QRect workSize(tileLayer->width(), tileLayer->height(),
+			const QRect workSpace(tileLayer->width(), tileLayer->height(),
 					             tileLayer->tileWidth(), tileLayer->tileHeight());
-            renderer->drawTileLayer(&painter, tileLayer, workSize);
+            renderer->drawTileLayer(&painter, tileLayer, workSpace);
         } else if (imageLayer) {
             renderer->drawImageLayer(&painter, mapWorkSize, imageLayer);
         }

--- a/src/tmxrasterizer/tmxrasterizer.cpp
+++ b/src/tmxrasterizer/tmxrasterizer.cpp
@@ -101,7 +101,9 @@ int TmxRasterizer::render(const QString &mapFileName,
         break;
     }
 
-    QSize mapSize = renderer->mapSize();
+	const QRect mapWorkSize(map->width(), map->height(), map->tileWidth(), map->tileHeight());
+
+    QSize mapSize = renderer->workSize(mapWorkSize);
     qreal xScale, yScale;
 
     if (mSize > 0) {
@@ -132,8 +134,6 @@ int TmxRasterizer::render(const QString &mapFileName,
     painter.setTransform(QTransform::fromScale(xScale, yScale));
 
     painter.translate(margins.left(), margins.top());
-
-	const QRect mapWorkSize(map->width(), map->height(), map->tileWidth(), map->tileHeight());
 
     // Perform a similar rendering than found in exportasimagedialog.cpp
     LayerIterator iterator(map);

--- a/src/tmxrasterizer/tmxrasterizer.cpp
+++ b/src/tmxrasterizer/tmxrasterizer.cpp
@@ -37,6 +37,7 @@
 #include "orthogonalrenderer.h"
 #include "staggeredrenderer.h"
 #include "tilelayer.h"
+#include "workspace.h"
 
 #include <QDebug>
 #include <QImageWriter>
@@ -101,9 +102,9 @@ int TmxRasterizer::render(const QString &mapFileName,
         break;
     }
 
-	const QRect mapWorkSize(map->width(), map->height(), map->tileWidth(), map->tileHeight());
+	const WorkSpace mapWorkSpace(map->width(), map->height(), map->tileWidth(), map->tileHeight());
 
-    QSize mapSize = renderer->workSize(mapWorkSize);
+    QSize mapSize = renderer->workSize(mapWorkSpace);
     qreal xScale, yScale;
 
     if (mSize > 0) {
@@ -150,11 +151,11 @@ int TmxRasterizer::render(const QString &mapFileName,
         const ImageLayer *imageLayer = dynamic_cast<const ImageLayer*>(layer);
 
         if (tileLayer) {
-			const QRect workSpace(tileLayer->width(), tileLayer->height(),
+			const WorkSpace workSpace(tileLayer->width(), tileLayer->height(),
 					             tileLayer->tileWidth(), tileLayer->tileHeight());
             renderer->drawTileLayer(&painter, tileLayer, workSpace);
         } else if (imageLayer) {
-            renderer->drawImageLayer(&painter, mapWorkSize, imageLayer);
+            renderer->drawImageLayer(&painter, mapWorkSpace, imageLayer);
         }
 
         painter.translate(-offset);

--- a/src/tmxrasterizer/tmxrasterizer.cpp
+++ b/src/tmxrasterizer/tmxrasterizer.cpp
@@ -133,6 +133,8 @@ int TmxRasterizer::render(const QString &mapFileName,
 
     painter.translate(margins.left(), margins.top());
 
+	const QRect mapWorkSize(map->width(), map->height(), map->tileWidth(), map->tileHeight());
+
     // Perform a similar rendering than found in exportasimagedialog.cpp
     LayerIterator iterator(map);
     while (const Layer *layer = iterator.next()) {
@@ -148,9 +150,11 @@ int TmxRasterizer::render(const QString &mapFileName,
         const ImageLayer *imageLayer = dynamic_cast<const ImageLayer*>(layer);
 
         if (tileLayer) {
-            renderer->drawTileLayer(&painter, tileLayer);
+			const QRect workSize(tileLayer->width(), tileLayer->height(),
+					             tileLayer->tileWidth(), tileLayer->tileHeight());
+            renderer->drawTileLayer(&painter, tileLayer, workSize);
         } else if (imageLayer) {
-            renderer->drawImageLayer(&painter, imageLayer);
+            renderer->drawImageLayer(&painter, mapWorkSize, imageLayer);
         }
 
         painter.translate(-offset);

--- a/src/tmxviewer/moc_predefs.h
+++ b/src/tmxviewer/moc_predefs.h
@@ -1,0 +1,357 @@
+#define OBJC_NEW_PROPERTIES 1
+#define _LP64 1
+#define __APPLE_CC__ 6000
+#define __APPLE__ 1
+#define __ATOMIC_ACQUIRE 2
+#define __ATOMIC_ACQ_REL 4
+#define __ATOMIC_CONSUME 1
+#define __ATOMIC_RELAXED 0
+#define __ATOMIC_RELEASE 3
+#define __ATOMIC_SEQ_CST 5
+#define __BIGGEST_ALIGNMENT__ 16
+#define __BLOCKS__ 1
+#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
+#define __CHAR16_TYPE__ unsigned short
+#define __CHAR32_TYPE__ unsigned int
+#define __CHAR_BIT__ 8
+#define __CONSTANT_CFSTRINGS__ 1
+#define __DBL_DECIMAL_DIG__ 17
+#define __DBL_DENORM_MIN__ 4.9406564584124654e-324
+#define __DBL_DIG__ 15
+#define __DBL_EPSILON__ 2.2204460492503131e-16
+#define __DBL_HAS_DENORM__ 1
+#define __DBL_HAS_INFINITY__ 1
+#define __DBL_HAS_QUIET_NAN__ 1
+#define __DBL_MANT_DIG__ 53
+#define __DBL_MAX_10_EXP__ 308
+#define __DBL_MAX_EXP__ 1024
+#define __DBL_MAX__ 1.7976931348623157e+308
+#define __DBL_MIN_10_EXP__ (-307)
+#define __DBL_MIN_EXP__ (-1021)
+#define __DBL_MIN__ 2.2250738585072014e-308
+#define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
+#define __DEPRECATED 1
+#define __DYNAMIC__ 1
+#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101000
+#define __EXCEPTIONS 1
+#define __FINITE_MATH_ONLY__ 0
+#define __FLT_DECIMAL_DIG__ 9
+#define __FLT_DENORM_MIN__ 1.40129846e-45F
+#define __FLT_DIG__ 6
+#define __FLT_EPSILON__ 1.19209290e-7F
+#define __FLT_EVAL_METHOD__ 0
+#define __FLT_HAS_DENORM__ 1
+#define __FLT_HAS_INFINITY__ 1
+#define __FLT_HAS_QUIET_NAN__ 1
+#define __FLT_MANT_DIG__ 24
+#define __FLT_MAX_10_EXP__ 38
+#define __FLT_MAX_EXP__ 128
+#define __FLT_MAX__ 3.40282347e+38F
+#define __FLT_MIN_10_EXP__ (-37)
+#define __FLT_MIN_EXP__ (-125)
+#define __FLT_MIN__ 1.17549435e-38F
+#define __FLT_RADIX__ 2
+#define __FXSR__ 1
+#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
+#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
+#define __GCC_ATOMIC_INT_LOCK_FREE 2
+#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
+#define __GCC_ATOMIC_LONG_LOCK_FREE 2
+#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
+#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
+#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
+#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
+#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
+#define __GLIBCXX_BITSIZE_INT_N_0 128
+#define __GLIBCXX_TYPE_INT_N_0 __int128
+#define __GNUC_GNU_INLINE__ 1
+#define __GNUC_MINOR__ 2
+#define __GNUC_PATCHLEVEL__ 1
+#define __GNUC__ 4
+#define __GNUG__ 4
+#define __GXX_ABI_VERSION 1002
+#define __GXX_EXPERIMENTAL_CXX0X__ 1
+#define __GXX_RTTI 1
+#define __GXX_WEAK__ 1
+#define __INT16_C_SUFFIX__ 
+#define __INT16_FMTd__ "hd"
+#define __INT16_FMTi__ "hi"
+#define __INT16_MAX__ 32767
+#define __INT16_TYPE__ short
+#define __INT32_C_SUFFIX__ 
+#define __INT32_FMTd__ "d"
+#define __INT32_FMTi__ "i"
+#define __INT32_MAX__ 2147483647
+#define __INT32_TYPE__ int
+#define __INT64_C_SUFFIX__ LL
+#define __INT64_FMTd__ "lld"
+#define __INT64_FMTi__ "lli"
+#define __INT64_MAX__ 9223372036854775807LL
+#define __INT64_TYPE__ long long int
+#define __INT8_C_SUFFIX__ 
+#define __INT8_FMTd__ "hhd"
+#define __INT8_FMTi__ "hhi"
+#define __INT8_MAX__ 127
+#define __INT8_TYPE__ signed char
+#define __INTMAX_C_SUFFIX__ L
+#define __INTMAX_FMTd__ "ld"
+#define __INTMAX_FMTi__ "li"
+#define __INTMAX_MAX__ 9223372036854775807L
+#define __INTMAX_TYPE__ long int
+#define __INTMAX_WIDTH__ 64
+#define __INTPTR_FMTd__ "ld"
+#define __INTPTR_FMTi__ "li"
+#define __INTPTR_MAX__ 9223372036854775807L
+#define __INTPTR_TYPE__ long int
+#define __INTPTR_WIDTH__ 64
+#define __INT_FAST16_FMTd__ "hd"
+#define __INT_FAST16_FMTi__ "hi"
+#define __INT_FAST16_MAX__ 32767
+#define __INT_FAST16_TYPE__ short
+#define __INT_FAST32_FMTd__ "d"
+#define __INT_FAST32_FMTi__ "i"
+#define __INT_FAST32_MAX__ 2147483647
+#define __INT_FAST32_TYPE__ int
+#define __INT_FAST64_FMTd__ "ld"
+#define __INT_FAST64_FMTi__ "li"
+#define __INT_FAST64_MAX__ 9223372036854775807L
+#define __INT_FAST64_TYPE__ long int
+#define __INT_FAST8_FMTd__ "hhd"
+#define __INT_FAST8_FMTi__ "hhi"
+#define __INT_FAST8_MAX__ 127
+#define __INT_FAST8_TYPE__ signed char
+#define __INT_LEAST16_FMTd__ "hd"
+#define __INT_LEAST16_FMTi__ "hi"
+#define __INT_LEAST16_MAX__ 32767
+#define __INT_LEAST16_TYPE__ short
+#define __INT_LEAST32_FMTd__ "d"
+#define __INT_LEAST32_FMTi__ "i"
+#define __INT_LEAST32_MAX__ 2147483647
+#define __INT_LEAST32_TYPE__ int
+#define __INT_LEAST64_FMTd__ "ld"
+#define __INT_LEAST64_FMTi__ "li"
+#define __INT_LEAST64_MAX__ 9223372036854775807L
+#define __INT_LEAST64_TYPE__ long int
+#define __INT_LEAST8_FMTd__ "hhd"
+#define __INT_LEAST8_FMTi__ "hhi"
+#define __INT_LEAST8_MAX__ 127
+#define __INT_LEAST8_TYPE__ signed char
+#define __INT_MAX__ 2147483647
+#define __LDBL_DECIMAL_DIG__ 21
+#define __LDBL_DENORM_MIN__ 3.64519953188247460253e-4951L
+#define __LDBL_DIG__ 18
+#define __LDBL_EPSILON__ 1.08420217248550443401e-19L
+#define __LDBL_HAS_DENORM__ 1
+#define __LDBL_HAS_INFINITY__ 1
+#define __LDBL_HAS_QUIET_NAN__ 1
+#define __LDBL_MANT_DIG__ 64
+#define __LDBL_MAX_10_EXP__ 4932
+#define __LDBL_MAX_EXP__ 16384
+#define __LDBL_MAX__ 1.18973149535723176502e+4932L
+#define __LDBL_MIN_10_EXP__ (-4931)
+#define __LDBL_MIN_EXP__ (-16381)
+#define __LDBL_MIN__ 3.36210314311209350626e-4932L
+#define __LITTLE_ENDIAN__ 1
+#define __LONG_LONG_MAX__ 9223372036854775807LL
+#define __LONG_MAX__ 9223372036854775807L
+#define __LP64__ 1
+#define __MACH__ 1
+#define __MMX__ 1
+#define __NO_MATH_INLINES 1
+#define __OBJC_BOOL_IS_BOOL 0
+#define __OPTIMIZE__ 1
+#define __ORDER_BIG_ENDIAN__ 4321
+#define __ORDER_LITTLE_ENDIAN__ 1234
+#define __ORDER_PDP_ENDIAN__ 3412
+#define __PIC__ 2
+#define __POINTER_WIDTH__ 64
+#define __PRAGMA_REDEFINE_EXTNAME 1
+#define __PTRDIFF_FMTd__ "ld"
+#define __PTRDIFF_FMTi__ "li"
+#define __PTRDIFF_MAX__ 9223372036854775807L
+#define __PTRDIFF_TYPE__ long int
+#define __PTRDIFF_WIDTH__ 64
+#define __REGISTER_PREFIX__ 
+#define __SCHAR_MAX__ 127
+#define __SHRT_MAX__ 32767
+#define __SIG_ATOMIC_MAX__ 2147483647
+#define __SIG_ATOMIC_WIDTH__ 32
+#define __SIZEOF_DOUBLE__ 8
+#define __SIZEOF_FLOAT__ 4
+#define __SIZEOF_INT128__ 16
+#define __SIZEOF_INT__ 4
+#define __SIZEOF_LONG_DOUBLE__ 16
+#define __SIZEOF_LONG_LONG__ 8
+#define __SIZEOF_LONG__ 8
+#define __SIZEOF_POINTER__ 8
+#define __SIZEOF_PTRDIFF_T__ 8
+#define __SIZEOF_SHORT__ 2
+#define __SIZEOF_SIZE_T__ 8
+#define __SIZEOF_WCHAR_T__ 4
+#define __SIZEOF_WINT_T__ 4
+#define __SIZE_FMTX__ "lX"
+#define __SIZE_FMTo__ "lo"
+#define __SIZE_FMTu__ "lu"
+#define __SIZE_FMTx__ "lx"
+#define __SIZE_MAX__ 18446744073709551615UL
+#define __SIZE_TYPE__ long unsigned int
+#define __SIZE_WIDTH__ 64
+#define __SSE2_MATH__ 1
+#define __SSE2__ 1
+#define __SSE3__ 1
+#define __SSE_MATH__ 1
+#define __SSE__ 1
+#define __SSP__ 1
+#define __SSSE3__ 1
+#define __STDC_HOSTED__ 1
+#define __STDC_UTF_16__ 1
+#define __STDC_UTF_32__ 1
+#define __STDC__ 1
+#define __UINT16_C_SUFFIX__ 
+#define __UINT16_FMTX__ "hX"
+#define __UINT16_FMTo__ "ho"
+#define __UINT16_FMTu__ "hu"
+#define __UINT16_FMTx__ "hx"
+#define __UINT16_MAX__ 65535
+#define __UINT16_TYPE__ unsigned short
+#define __UINT32_C_SUFFIX__ U
+#define __UINT32_FMTX__ "X"
+#define __UINT32_FMTo__ "o"
+#define __UINT32_FMTu__ "u"
+#define __UINT32_FMTx__ "x"
+#define __UINT32_MAX__ 4294967295U
+#define __UINT32_TYPE__ unsigned int
+#define __UINT64_C_SUFFIX__ ULL
+#define __UINT64_FMTX__ "llX"
+#define __UINT64_FMTo__ "llo"
+#define __UINT64_FMTu__ "llu"
+#define __UINT64_FMTx__ "llx"
+#define __UINT64_MAX__ 18446744073709551615ULL
+#define __UINT64_TYPE__ long long unsigned int
+#define __UINT8_C_SUFFIX__ 
+#define __UINT8_FMTX__ "hhX"
+#define __UINT8_FMTo__ "hho"
+#define __UINT8_FMTu__ "hhu"
+#define __UINT8_FMTx__ "hhx"
+#define __UINT8_MAX__ 255
+#define __UINT8_TYPE__ unsigned char
+#define __UINTMAX_C_SUFFIX__ UL
+#define __UINTMAX_FMTX__ "lX"
+#define __UINTMAX_FMTo__ "lo"
+#define __UINTMAX_FMTu__ "lu"
+#define __UINTMAX_FMTx__ "lx"
+#define __UINTMAX_MAX__ 18446744073709551615UL
+#define __UINTMAX_TYPE__ long unsigned int
+#define __UINTMAX_WIDTH__ 64
+#define __UINTPTR_FMTX__ "lX"
+#define __UINTPTR_FMTo__ "lo"
+#define __UINTPTR_FMTu__ "lu"
+#define __UINTPTR_FMTx__ "lx"
+#define __UINTPTR_MAX__ 18446744073709551615UL
+#define __UINTPTR_TYPE__ long unsigned int
+#define __UINTPTR_WIDTH__ 64
+#define __UINT_FAST16_FMTX__ "hX"
+#define __UINT_FAST16_FMTo__ "ho"
+#define __UINT_FAST16_FMTu__ "hu"
+#define __UINT_FAST16_FMTx__ "hx"
+#define __UINT_FAST16_MAX__ 65535
+#define __UINT_FAST16_TYPE__ unsigned short
+#define __UINT_FAST32_FMTX__ "X"
+#define __UINT_FAST32_FMTo__ "o"
+#define __UINT_FAST32_FMTu__ "u"
+#define __UINT_FAST32_FMTx__ "x"
+#define __UINT_FAST32_MAX__ 4294967295U
+#define __UINT_FAST32_TYPE__ unsigned int
+#define __UINT_FAST64_FMTX__ "lX"
+#define __UINT_FAST64_FMTo__ "lo"
+#define __UINT_FAST64_FMTu__ "lu"
+#define __UINT_FAST64_FMTx__ "lx"
+#define __UINT_FAST64_MAX__ 18446744073709551615UL
+#define __UINT_FAST64_TYPE__ long unsigned int
+#define __UINT_FAST8_FMTX__ "hhX"
+#define __UINT_FAST8_FMTo__ "hho"
+#define __UINT_FAST8_FMTu__ "hhu"
+#define __UINT_FAST8_FMTx__ "hhx"
+#define __UINT_FAST8_MAX__ 255
+#define __UINT_FAST8_TYPE__ unsigned char
+#define __UINT_LEAST16_FMTX__ "hX"
+#define __UINT_LEAST16_FMTo__ "ho"
+#define __UINT_LEAST16_FMTu__ "hu"
+#define __UINT_LEAST16_FMTx__ "hx"
+#define __UINT_LEAST16_MAX__ 65535
+#define __UINT_LEAST16_TYPE__ unsigned short
+#define __UINT_LEAST32_FMTX__ "X"
+#define __UINT_LEAST32_FMTo__ "o"
+#define __UINT_LEAST32_FMTu__ "u"
+#define __UINT_LEAST32_FMTx__ "x"
+#define __UINT_LEAST32_MAX__ 4294967295U
+#define __UINT_LEAST32_TYPE__ unsigned int
+#define __UINT_LEAST64_FMTX__ "lX"
+#define __UINT_LEAST64_FMTo__ "lo"
+#define __UINT_LEAST64_FMTu__ "lu"
+#define __UINT_LEAST64_FMTx__ "lx"
+#define __UINT_LEAST64_MAX__ 18446744073709551615UL
+#define __UINT_LEAST64_TYPE__ long unsigned int
+#define __UINT_LEAST8_FMTX__ "hhX"
+#define __UINT_LEAST8_FMTo__ "hho"
+#define __UINT_LEAST8_FMTu__ "hhu"
+#define __UINT_LEAST8_FMTx__ "hhx"
+#define __UINT_LEAST8_MAX__ 255
+#define __UINT_LEAST8_TYPE__ unsigned char
+#define __USER_LABEL_PREFIX__ _
+#define __VERSION__ "4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)"
+#define __WCHAR_MAX__ 2147483647
+#define __WCHAR_TYPE__ int
+#define __WCHAR_WIDTH__ 32
+#define __WINT_TYPE__ int
+#define __WINT_WIDTH__ 32
+#define __amd64 1
+#define __amd64__ 1
+#define __apple_build_version__ 8020042
+#define __block __attribute__((__blocks__(byref)))
+#define __clang__ 1
+#define __clang_major__ 8
+#define __clang_minor__ 1
+#define __clang_patchlevel__ 0
+#define __clang_version__ "8.1.0 (clang-802.0.42)"
+#define __core2 1
+#define __core2__ 1
+#define __cplusplus 201103L
+#define __cpp_alias_templates 200704
+#define __cpp_attributes 200809
+#define __cpp_constexpr 200704
+#define __cpp_decltype 200707
+#define __cpp_delegating_constructors 200604
+#define __cpp_exceptions 199711
+#define __cpp_inheriting_constructors 200802
+#define __cpp_initializer_lists 200806
+#define __cpp_lambdas 200907
+#define __cpp_nsdmi 200809
+#define __cpp_range_based_for 200907
+#define __cpp_raw_strings 200710
+#define __cpp_ref_qualifiers 200710
+#define __cpp_rtti 199711
+#define __cpp_rvalue_references 200610
+#define __cpp_static_assert 200410
+#define __cpp_unicode_characters 200704
+#define __cpp_unicode_literals 200710
+#define __cpp_user_defined_literals 200809
+#define __cpp_variadic_templates 200704
+#define __llvm__ 1
+#define __nonnull _Nonnull
+#define __null_unspecified _Null_unspecified
+#define __nullable _Nullable
+#define __pic__ 2
+#define __private_extern__ extern
+#define __strong 
+#define __tune_core2__ 1
+#define __unsafe_unretained 
+#define __weak __attribute__((objc_gc(weak)))
+#define __x86_64 1
+#define __x86_64__ 1

--- a/src/tmxviewer/tmxviewer.cpp
+++ b/src/tmxviewer/tmxviewer.cpp
@@ -38,6 +38,7 @@
 #include "staggeredrenderer.h"
 #include "tilelayer.h"
 #include "tileset.h"
+#include "workspace.h"
 
 #include <QCoreApplication>
 #include <QDebug>
@@ -62,7 +63,7 @@ public:
         const QPointF &position = mapObject->position();
 
 		const Map* map = renderer->map();
-		const QRect workSpace(map->width(), map->height(), map->tileWidth(), map->tileHeight());
+		const WorkSpace workSpace(map->width(), map->height(), map->tileWidth(), map->tileHeight());
         const QPointF pixelPos = renderer->pixelToScreenCoords(position, workSpace);
 
         QRectF boundingRect = renderer->boundingRect(mapObject, workSpace);
@@ -83,7 +84,7 @@ public:
         const QColor &color = mMapObject->objectGroup()->color();
         p->translate(-pos());
 		const Map* map = mRenderer->map();
-		const QRect workSpace(map->width(), map->height(), map->tileWidth(), map->tileHeight());
+		const WorkSpace workSpace(map->width(), map->height(), map->tileWidth(), map->tileHeight());
         mRenderer->drawMapObject(p, workSpace, mMapObject,
                                  color.isValid() ? color : Qt::darkGray);
     }
@@ -112,14 +113,16 @@ public:
 
     QRectF boundingRect() const override
     {
-		const QRect workSpace(mTileLayer->width(), mTileLayer->height(),
+		const WorkSpace workSpace(mTileLayer->width(), mTileLayer->height(),
 				             mTileLayer->tileWidth(), mTileLayer->tileHeight());
         return mRenderer->boundingRect(mTileLayer->bounds(), workSpace);
     }
 
     void paint(QPainter *p, const QStyleOptionGraphicsItem *option, QWidget *) override
     {
-        mRenderer->drawTileLayer(p, mTileLayer, option->rect);
+		const WorkSpace workSpace(mTileLayer->width(), mTileLayer->height(),
+				                  mTileLayer->tileWidth(), mTileLayer->tileHeight());
+        mRenderer->drawTileLayer(p, mTileLayer, workSpace, option->rect);
     }
 
 private:

--- a/src/tmxviewer/tmxviewer.cpp
+++ b/src/tmxviewer/tmxviewer.cpp
@@ -62,10 +62,10 @@ public:
         const QPointF &position = mapObject->position();
 
 		const Map* map = renderer->map();
-		const QRect workSize(map->width(), map->height(), map->tileWidth(), map->tileHeight());
-        const QPointF pixelPos = renderer->pixelToScreenCoords(position, workSize);
+		const QRect workSpace(map->width(), map->height(), map->tileWidth(), map->tileHeight());
+        const QPointF pixelPos = renderer->pixelToScreenCoords(position, workSpace);
 
-        QRectF boundingRect = renderer->boundingRect(mapObject, workSize);
+        QRectF boundingRect = renderer->boundingRect(mapObject, workSpace);
         boundingRect.translate(-pixelPos);
         mBoundingRect = boundingRect;
 
@@ -83,8 +83,8 @@ public:
         const QColor &color = mMapObject->objectGroup()->color();
         p->translate(-pos());
 		const Map* map = mRenderer->map();
-		const QRect workSize(map->width(), map->height(), map->tileWidth(), map->tileHeight());
-        mRenderer->drawMapObject(p, workSize, mMapObject,
+		const QRect workSpace(map->width(), map->height(), map->tileWidth(), map->tileHeight());
+        mRenderer->drawMapObject(p, workSpace, mMapObject,
                                  color.isValid() ? color : Qt::darkGray);
     }
 
@@ -112,9 +112,9 @@ public:
 
     QRectF boundingRect() const override
     {
-		const QRect workSize(mTileLayer->width(), mTileLayer->height(),
+		const QRect workSpace(mTileLayer->width(), mTileLayer->height(),
 				             mTileLayer->tileWidth(), mTileLayer->tileHeight());
-        return mRenderer->boundingRect(mTileLayer->bounds(), workSize);
+        return mRenderer->boundingRect(mTileLayer->bounds(), workSpace);
     }
 
     void paint(QPainter *p, const QStyleOptionGraphicsItem *option, QWidget *) override

--- a/src/tmxviewer/tmxviewer.cpp
+++ b/src/tmxviewer/tmxviewer.cpp
@@ -60,9 +60,12 @@ public:
         , mRenderer(renderer)
     {
         const QPointF &position = mapObject->position();
-        const QPointF pixelPos = renderer->pixelToScreenCoords(position);
 
-        QRectF boundingRect = renderer->boundingRect(mapObject);
+		const Map* map = renderer->map();
+		const QRect workSize(map->width(), map->height(), map->tileWidth(), map->tileHeight());
+        const QPointF pixelPos = renderer->pixelToScreenCoords(position, workSize);
+
+        QRectF boundingRect = renderer->boundingRect(mapObject, workSize);
         boundingRect.translate(-pixelPos);
         mBoundingRect = boundingRect;
 
@@ -79,7 +82,9 @@ public:
     {
         const QColor &color = mMapObject->objectGroup()->color();
         p->translate(-pos());
-        mRenderer->drawMapObject(p, mMapObject,
+		const Map* map = mRenderer->map();
+		const QRect workSize(map->width(), map->height(), map->tileWidth(), map->tileHeight());
+        mRenderer->drawMapObject(p, workSize, mMapObject,
                                  color.isValid() ? color : Qt::darkGray);
     }
 
@@ -107,7 +112,9 @@ public:
 
     QRectF boundingRect() const override
     {
-        return mRenderer->boundingRect(mTileLayer->bounds());
+		const QRect workSize(mTileLayer->width(), mTileLayer->height(),
+				             mTileLayer->tileWidth(), mTileLayer->tileHeight());
+        return mRenderer->boundingRect(mTileLayer->bounds(), workSize);
     }
 
     void paint(QPainter *p, const QStyleOptionGraphicsItem *option, QWidget *) override

--- a/tests/staggeredrenderer/test_staggeredrenderer.cpp
+++ b/tests/staggeredrenderer/test_staggeredrenderer.cpp
@@ -38,7 +38,8 @@ void test_StaggeredRenderer::initTestCase()
     mMap = new Map(Map::Staggered, 10, 10, 64, 32);
     TileLayer *tileLayer = new TileLayer(QString(),
                                          0, 0,
-                                         mMap->width(), mMap->height());
+                                         mMap->width(), mMap->height(),
+										 mMap->tileWidth(), mMap->tileHeight());
     mMap->addLayer(tileLayer);
 }
 


### PR DESCRIPTION
Hey Bjorn, so this is the new PR for a redo of the Tile Size by Layer PR.

I'd like to keep that other one up for now because I use it as a refresher on what how things connect to each other in Tiled.

This is kind of an early PR to see if this is heading the right direction. I mostly just want your thoughts whenever you have time to spare from GSoC. The next thing I'll be working on is in the "Plans" section.

**What I've done**
I made a class called `WorkSpace` which stores tile sizes and sizes (possibly more later).  The `MapDocument` now has a function called `currentWorkSpace` which returns a `WorkSpace` with `TileLayer` specs if a `TileLayer` is active or the `Map` specs if not.

Then I pass that `WorkSpace` everywhere that needs the current map's tile sizes.

All the `MapRenderer` methods now take a `WorkSpace` and use that instead of the `Map`. Later, I think we could get rid of the `Map` dependency and just use a `WorkSpace` (or something similar)?

The grids are now according to the current work space's tile size and size.

**What I haven't done**
- Updated the .py plugins
- Allowed for width/height changes per `TileLayer`.

**Plans**
- I want to do `TileLayer` resizing using the same prompt as the `Map`.


I hope this is a better design than what I had last time!

Luca