### PR TITLE
New chunk based format for infinite maps

### DIFF
--- a/src/libtiled/gidmapper.cpp
+++ b/src/libtiled/gidmapper.cpp
@@ -157,16 +157,11 @@ QByteArray GidMapper::encodeLayerData(const TileLayer &tileLayer,
     if (bounds.isEmpty())
         bounds = QRect(0, 0, tileLayer.width(), tileLayer.height());
 
-    const int startX = bounds.x();
-    const int startY = bounds.y();
-    const int endX = startX + bounds.width() - 1;
-    const int endY = startY + bounds.height() - 1;
-
     QByteArray tileData;
-    tileData.reserve((endX - startX + 1) * (endY - startY + 1) * 4);
+    tileData.reserve(bounds.width() * bounds.height() * 4);
 
-    for (int y = startY; y <= endY; ++y) {
-        for (int x = startX; x <= endX; ++x) {
+    for (int y = bounds.top(); y <= bounds.bottom(); ++y) {
+        for (int x = bounds.left(); x <= bounds.right(); ++x) {
             const unsigned gid = cellToGid(tileLayer.cellAt(x, y));
             tileData.append((char) (gid));
             tileData.append((char) (gid >> 8));
@@ -204,8 +199,8 @@ GidMapper::DecodeError GidMapper::decodeLayerData(TileLayer &tileLayer,
         return CorruptLayerData;
 
     const unsigned char *data = reinterpret_cast<const unsigned char*>(decodedData.constData());
-    int x = 0;
-    int y = 0;
+    int x = bounds.x();
+    int y = bounds.y();
     bool ok;
 
     for (int i = 0; i < size - 3; i += 4) {
@@ -220,11 +215,11 @@ GidMapper::DecodeError GidMapper::decodeLayerData(TileLayer &tileLayer,
             return isEmpty() ? TileButNoTilesets : InvalidTile;
         }
 
-        tileLayer.setCell(x + bounds.x(), y + bounds.y(), result);
+        tileLayer.setCell(x, y, result);
 
         x++;
-        if (x == bounds.width()) {
-            x = 0;
+        if (x == bounds.right() + 1) {
+            x = bounds.x();
             y++;
         }
     }

--- a/src/libtiled/gidmapper.h
+++ b/src/libtiled/gidmapper.h
@@ -54,6 +54,11 @@ public:
     QByteArray encodeLayerData(const TileLayer &tileLayer,
                                Map::LayerDataFormat format) const;
 
+    QByteArray encodeChunkData(const TileLayer &tileLayer,
+                               int chunkStartX,
+                               int chunkStartY,
+                               Map::LayerDataFormat format) const;
+
     enum DecodeError {
         NoError = 0,
         CorruptLayerData,
@@ -63,8 +68,13 @@ public:
 
     DecodeError decodeLayerData(TileLayer &tileLayer,
                                 const QByteArray &layerData,
+                                Map::LayerDataFormat format) const;
+
+    DecodeError decodeChunkData(TileLayer &tileLayer,
+                                const QByteArray &layerData,
                                 Map::LayerDataFormat format,
-                                int startX, int startY) const;
+                                int startX,
+                                int startY) const;
 
     unsigned invalidTile() const;
 

--- a/src/libtiled/gidmapper.h
+++ b/src/libtiled/gidmapper.h
@@ -52,12 +52,8 @@ public:
     unsigned cellToGid(const Cell &cell) const;
 
     QByteArray encodeLayerData(const TileLayer &tileLayer,
-                               Map::LayerDataFormat format) const;
-
-    QByteArray encodeChunkData(const TileLayer &tileLayer,
-                               int chunkStartX,
-                               int chunkStartY,
-                               Map::LayerDataFormat format) const;
+                               Map::LayerDataFormat format,
+                               QRect bounds = QRect()) const;
 
     enum DecodeError {
         NoError = 0,
@@ -68,13 +64,8 @@ public:
 
     DecodeError decodeLayerData(TileLayer &tileLayer,
                                 const QByteArray &layerData,
-                                Map::LayerDataFormat format) const;
-
-    DecodeError decodeChunkData(TileLayer &tileLayer,
-                                const QByteArray &layerData,
                                 Map::LayerDataFormat format,
-                                int startX,
-                                int startY) const;
+                                QRect bounds = QRect()) const;
 
     unsigned invalidTile() const;
 

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -641,17 +641,12 @@ void MapWriterPrivate::writeTileLayer(QXmlStreamWriter &w,
     if (!compression.isEmpty())
         w.writeAttribute(QLatin1String("compression"), compression);
 
-    int startX = 0;
-    int startY = 0;
-    int endX = tileLayer.width() - 1;
-    int endY = tileLayer.height() - 1;
-
     if (tileLayer.map()->infinite()) {
         QRect bounds = tileLayer.bounds().translated(-tileLayer.position());
-        startX = bounds.left();
-        startY = bounds.top();
-        endX = bounds.right() + 1;
-        endY = bounds.bottom() + 1;
+        int startX = bounds.left();
+        int startY = bounds.top();
+        int endX = bounds.right() + 1;
+        int endY = bounds.bottom() + 1;
 
         int chunkStartX = startX;
         int chunkStartY = startY;
@@ -683,7 +678,7 @@ void MapWriterPrivate::writeTileLayer(QXmlStreamWriter &w,
             chunkStartY += CHUNK_SIZE;
         }
     } else {
-        writeTileLayerData(w, tileLayer, QRect(0, 0, endX + 1, endY + 1));
+        writeTileLayerData(w, tileLayer, QRect(0, 0, tileLayer.width(), tileLayer.height()));
     }
 
     w.writeEndElement(); // </data>

--- a/src/libtiled/varianttomapconverter.cpp
+++ b/src/libtiled/varianttomapconverter.cpp
@@ -494,9 +494,7 @@ TileLayer *VariantToMapConverter::toTileLayer(const QVariantMap &variantMap)
         const QByteArray data = dataVariant.toByteArray();
         GidMapper::DecodeError error = mGidMapper.decodeLayerData(*tileLayer,
                                                                   data,
-                                                                  layerDataFormat,
-                                                                  startX,
-                                                                  startY);
+                                                                  layerDataFormat);
 
         switch (error) {
         case GidMapper::CorruptLayerData:


### PR DESCRIPTION
I've removed `startx` and `starty` attributes from Tile Layer. Now, for infinite maps, each 16x16 chunk will be stored along with its `startx` and `starty` coordinates.