### PR TITLE
Various improvements for templates

### DIFF
--- a/src/libtiled/mapobject.cpp
+++ b/src/libtiled/mapobject.cpp
@@ -256,7 +256,7 @@ MapObject *MapObject::clone() const
 
 const MapObject *MapObject::templateObject() const
 {
-    if (!mTemplateRef.templateGroup)
+    if (!isTemplateInstance())
         return nullptr;
 
     auto objectTemplate = mTemplateRef.templateGroup->findTemplate(mTemplateRef.templateId);
@@ -303,12 +303,12 @@ void MapObject::syncWithTemplate()
 
 bool MapObject::isTemplateInstance() const
 {
-    return templateRef().templateGroup;
+    return mTemplateRef.templateGroup;
 }
 
 TemplateGroup *MapObject::templateGroup() const
 {
-    return templateRef().templateGroup;
+    return mTemplateRef.templateGroup;
 }
 
 void MapObject::flipRectObject(const QTransform &flipTransform)

--- a/src/libtiled/mapobject.cpp
+++ b/src/libtiled/mapobject.cpp
@@ -92,7 +92,8 @@ MapObject::MapObject(const QString &name, const QString &type,
     mObjectGroup(nullptr),
     mRotation(0.0f),
     mVisible(true),
-    mChangedProperties(0)
+    mChangedProperties(0),
+    mTemplateBase(false)
 {
 }
 

--- a/src/libtiled/mapobject.h
+++ b/src/libtiled/mapobject.h
@@ -210,6 +210,10 @@ public:
 
     bool isTemplateInstance() const;
 
+    bool isTemplateBase() const;
+    void markAsTemplateBase();
+
+
     TemplateGroup *templateGroup() const;
 
 private:
@@ -231,6 +235,7 @@ private:
     qreal mRotation;
     bool mVisible;
     ChangedProperties mChangedProperties;
+    bool mTemplateBase;
 };
 
 /**
@@ -477,6 +482,12 @@ inline void MapObject::setPropertyChanged(Property property, bool state)
 
 inline bool MapObject::propertyChanged(Property property) const
 { return mChangedProperties.testFlag(property); }
+
+inline bool MapObject::isTemplateBase() const
+{ return mTemplateBase; }
+
+inline void MapObject::markAsTemplateBase()
+{ mTemplateBase = true; }
 
 } // namespace Tiled
 

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -784,13 +784,13 @@ void MapWriterPrivate::writeObject(QXmlStreamWriter &w,
 
     bool isTemplateInstance = mapObject.isTemplateInstance();
 
+    if (!mapObject.isTemplateBase())
+        w.writeAttribute(QLatin1String("id"), QString::number(id));
+
     if (isTemplateInstance) {
         unsigned tid = mTidMapper.templateRefToTid(mapObject.templateRef());
         w.writeAttribute(QLatin1String("tid"), QString::number(tid));
     }
-
-    if (!mapObject.isTemplateBase())
-        w.writeAttribute(QLatin1String("id"), QString::number(id));
 
     if (shouldWrite(!name.isEmpty(), isTemplateInstance, mapObject.propertyChanged(MapObject::NameProperty)))
         w.writeAttribute(QLatin1String("name"), name);

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -789,7 +789,7 @@ void MapWriterPrivate::writeObject(QXmlStreamWriter &w,
         w.writeAttribute(QLatin1String("tid"), QString::number(tid));
     }
 
-    if (id != 0)
+    if (!mapObject.isTemplateBase())
         w.writeAttribute(QLatin1String("id"), QString::number(id));
 
     if (shouldWrite(!name.isEmpty(), isTemplateInstance, mapObject.propertyChanged(MapObject::NameProperty)))
@@ -803,7 +803,7 @@ void MapWriterPrivate::writeObject(QXmlStreamWriter &w,
         w.writeAttribute(QLatin1String("gid"), QString::number(gid));
     }
 
-    if (id != 0) {
+    if (!mapObject.isTemplateBase()) {
         w.writeAttribute(QLatin1String("x"), QString::number(pos.x()));
         w.writeAttribute(QLatin1String("y"), QString::number(pos.y()));
     }

--- a/src/libtiled/objecttemplate.h
+++ b/src/libtiled/objecttemplate.h
@@ -68,7 +68,7 @@ inline void ObjectTemplate::setObject(const MapObject *object)
 {
     delete mObject;
     mObject = object->clone();
-    mObject->setId(0);
+    mObject->markAsTemplateBase();
 }
 
 inline unsigned ObjectTemplate::id() const

--- a/src/tiled/abstractobjecttool.cpp
+++ b/src/tiled/abstractobjecttool.cpp
@@ -333,10 +333,18 @@ void AbstractObjectTool::showContextMenu(MapObjectItem *clickedObjectItem,
     }
 
     if (selectedObjects.size() == 1) {
-        // Saving objects with embedded tilesets is disabled
-        auto cell = selectedObjects.first()->cell();
-        if (cell.isEmpty() || cell.tileset()->isExternal())
-            menu.addAction(tr("Save As Template"), this, SLOT(saveSelectedObject()));
+        MapObject *currentObject = selectedObjects.first();
+        if (!(currentObject->isTemplateBase() || currentObject->isTemplateInstance())) {
+            const Cell cell = selectedObjects.first()->cell();
+            // Saving objects with embedded tilesets is disabled
+            if (cell.isEmpty() || cell.tileset()->isExternal())
+                menu.addAction(tr("Save As Template"), this, SLOT(saveSelectedObject()));
+        }
+
+        if (currentObject->isTemplateBase()) { // Hide this operations for template base
+            duplicateAction->setVisible(false);
+            removeAction->setVisible(false);
+        }
     }
 
     bool anyIsTemplateInstance = std::any_of(selectedObjects.begin(),

--- a/src/tiled/abstractobjecttool.h
+++ b/src/tiled/abstractobjecttool.h
@@ -73,6 +73,7 @@ private slots:
     void removeObjects();
     void resetTileSize();
     void saveSelectedObject();
+    void detachSelectedObjects();
     void changeTile();
 
     void flipHorizontally();

--- a/src/tiled/changemapobject.h
+++ b/src/tiled/changemapobject.h
@@ -111,5 +111,24 @@ private:
     QVector<bool> mOldChangeStates;
 };
 
+class DetachObjects : public QUndoCommand
+{
+public:
+    /**
+     * Creates an undo command that detaches the given template instances from their templates.
+     */
+    DetachObjects(MapDocument *mapDocument,
+                  QList<MapObject *> mapObjects,
+                  QUndoCommand *parent = nullptr);
+
+    void redo() override;
+    void undo() override;
+
+private:
+    MapDocument *mMapDocument;
+    QList<MapObject*> mMapObjects;
+    QVector<TemplateRef> mTemplateRefs;
+    QVector<Properties> mProperties;
+};
 } // namespace Internal
 } // namespace Tiled

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -112,13 +112,13 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     , mDocumentManager(DocumentManager::instance())
     , mTmxMapFormat(new TmxMapFormat(this))
     , mTsxTilesetFormat(new TsxTilesetFormat(this))
-    , mTtxTemplateGroupFormat(new TtxTemplateGroupFormat(this))
+    , mTgxTemplateGroupFormat(new TgxTemplateGroupFormat(this))
 {
     mUi->setupUi(this);
 
     PluginManager::addObject(mTmxMapFormat);
     PluginManager::addObject(mTsxTilesetFormat);
-    PluginManager::addObject(mTtxTemplateGroupFormat);
+    PluginManager::addObject(mTgxTemplateGroupFormat);
 
     ActionManager::registerAction(mUi->actionNewMap, "file.new_map");
     ActionManager::registerAction(mUi->actionNewTileset, "file.new_tileset");

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -58,7 +58,7 @@ class MapView;
 class ObjectTypesEditor;
 class TmxMapFormat;
 class TsxTilesetFormat;
-class TtxTemplateGroupFormat;
+class TgxTemplateGroupFormat;
 class Zoomable;
 
 /**
@@ -220,7 +220,7 @@ private:
 
     TmxMapFormat *mTmxMapFormat;
     TsxTilesetFormat *mTsxTilesetFormat;
-    TtxTemplateGroupFormat *mTtxTemplateGroupFormat;
+    TgxTemplateGroupFormat *mTgxTemplateGroupFormat;
 
     QPointer<PreferencesDialog> mPreferencesDialog;
 

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -25,6 +25,7 @@
 #include "addremovemapobject.h"
 #include "addremovetileset.h"
 #include "changelayer.h"
+#include "changemapobject.h"
 #include "changemapobjectsorder.h"
 #include "changeproperties.h"
 #include "changeselectedarea.h"
@@ -1093,6 +1094,14 @@ void MapDocument::moveObjectsDown(const QList<MapObject *> &objects)
 
     if (command->childCount() > 0)
         mUndoStack->push(command.take());
+}
+
+void MapDocument::detachObjects(const QList<MapObject *> &objects)
+{
+    if (objects.isEmpty())
+        return;
+
+    mUndoStack->push(new DetachObjects(this, objects));
 }
 
 void MapDocument::createRenderer()

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -134,8 +134,15 @@ void MapDocument::saveSelectedObject(const QString &name, int groupIndex)
     if (mSelectedObjects.size() != 1)
         return;
 
-    auto model = ObjectTemplateModel::instance();
-    model->saveObjectToDocument(mSelectedObjects.first(), name, groupIndex);
+    ObjectTemplateModel* model = ObjectTemplateModel::instance();
+    MapObject *object = mSelectedObjects.first();
+
+    if (ObjectTemplate *objectTemplate = model->saveObjectToDocument(object, name, groupIndex)) {
+        // Convert the saved object into an instance and clear the changed properties flags
+        object->setTemplateRef({objectTemplate->templateGroup(), objectTemplate->id()});
+        object->setChangedProperties(0);
+        emit objectsChanged(mSelectedObjects);
+    }
 }
 
 bool MapDocument::save(const QString &fileName, QString *error)

--- a/src/tiled/mapdocument.cpp
+++ b/src/tiled/mapdocument.cpp
@@ -946,6 +946,19 @@ void MapDocument::updateTemplateInstances(const MapObject *mapObject)
     emit objectsChanged(objectList);
 }
 
+void MapDocument::selectAllInstances(const MapObject *mapObject)
+{
+    QList<MapObject*> objectList;
+    for (ObjectGroup *group : mMap->objectGroups()) {
+        for (auto object : group->objects()) {
+            if (object->isTemplateInstance() && object->templateObject() == mapObject) {
+                objectList.append(object);
+            }
+        }
+    }
+    setSelectedObjects(objectList);
+}
+
 void MapDocument::deselectObjects(const QList<MapObject *> &objects)
 {
     // Unset the current object when it was part of this list of objects

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -159,6 +159,7 @@ public:
                             ObjectGroup *objectGroup);
     void moveObjectsUp(const QList<MapObject*> &objects);
     void moveObjectsDown(const QList<MapObject*> &objects);
+    void detachObjects(const QList<MapObject*> &objects);
 
     /**
      * Returns the layer model. Can be used to modify the layer stack of the

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -306,6 +306,7 @@ private slots:
 
 public slots:
     void updateTemplateInstances(const MapObject *mapObject);
+    void selectAllInstances(const MapObject *mapObject);
 
 private:
     void deselectObjects(const QList<MapObject*> &objects);

--- a/src/tiled/mapdocumentactionhandler.cpp
+++ b/src/tiled/mapdocumentactionhandler.cpp
@@ -635,6 +635,12 @@ void MapDocumentActionHandler::moveObjectsToGroup(ObjectGroup *objectGroup)
     }
 }
 
+void MapDocumentActionHandler::selectAllInstances(const MapObject *mapObject)
+{
+    if (mMapDocument)
+        mMapDocument->selectAllInstances(mapObject);
+}
+
 void MapDocumentActionHandler::updateActions()
 {
     Map *map = nullptr;

--- a/src/tiled/mapdocumentactionhandler.h
+++ b/src/tiled/mapdocumentactionhandler.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <QObject>
+#include "mapobject.h"
 
 class QAction;
 class QMenu;
@@ -29,6 +30,7 @@ class QMenu;
 namespace Tiled {
 
 class ObjectGroup;
+class MapObject;
 
 namespace Internal {
 
@@ -129,6 +131,8 @@ public slots:
     void duplicateObjects();
     void removeObjects();
     void moveObjectsToGroup(ObjectGroup *);
+
+    void selectAllInstances(const MapObject *);
 
 private slots:
     void updateActions();

--- a/src/tiled/newtemplatedialog.cpp
+++ b/src/tiled/newtemplatedialog.cpp
@@ -89,11 +89,11 @@ void NewTemplateDialog::newTemplateGroup()
 {
     FormatHelper<TemplateGroupFormat> helper(FileFormat::ReadWrite);
     QString filter = helper.filter();
-    QString selectedFilter = TtxTemplateGroupFormat().nameFilter();
+    QString selectedFilter = TgxTemplateGroupFormat().nameFilter();
 
     Preferences *prefs = Preferences::instance();
     QString suggestedFileName = prefs->lastPath(Preferences::TemplateDocumentsFile);
-    suggestedFileName += tr("/untitled.ttx");
+    suggestedFileName += tr("/untitled.tgx");
 
     QString fileName = QFileDialog::getSaveFileName(nullptr, tr("Save File"),
                                                     suggestedFileName,

--- a/src/tiled/newtemplatedialog.cpp
+++ b/src/tiled/newtemplatedialog.cpp
@@ -42,7 +42,7 @@ NewTemplateDialog::NewTemplateDialog(const QString &objectName, QWidget *parent)
     mUi->templateName->setText(objectName);
 
     connect(mUi->createGroupButton, &QPushButton::pressed,
-            this, &NewTemplateDialog::newTemplateGroup);
+            this, &NewTemplateDialog::createGroup);
 
     auto model = ObjectTemplateModel::instance();
     mUi->groupsComboBox->setModel(model);
@@ -78,9 +78,13 @@ void NewTemplateDialog::updateOkButton()
     okButton->setDisabled(noTemplateName || index == -1);
 }
 
-/**
- * This code is duplicated from the templates dock.
- */
+void NewTemplateDialog::createGroup()
+{
+    newTemplateGroup();
+    mUi->groupsComboBox->setCurrentIndex(mUi->groupsComboBox->count() - 1);
+    updateOkButton();
+}
+
 void NewTemplateDialog::newTemplateGroup()
 {
     FormatHelper<TemplateGroupFormat> helper(FileFormat::ReadWrite);
@@ -91,7 +95,7 @@ void NewTemplateDialog::newTemplateGroup()
     QString suggestedFileName = prefs->lastPath(Preferences::TemplateDocumentsFile);
     suggestedFileName += tr("/untitled.ttx");
 
-    QString fileName = QFileDialog::getSaveFileName(this, tr("Save File"),
+    QString fileName = QFileDialog::getSaveFileName(nullptr, tr("Save File"),
                                                     suggestedFileName,
                                                     filter,
                                                     &selectedFilter);
@@ -110,7 +114,7 @@ void NewTemplateDialog::newTemplateGroup()
 
     QString error;
     if (!templateGroupDocument->save(fileName, &error)) {
-        QMessageBox::critical(this, tr("Error Creating Template Group"), error);
+        QMessageBox::critical(nullptr, tr("Error Creating Template Group"), error);
         return;
     }
 
@@ -119,8 +123,4 @@ void NewTemplateDialog::newTemplateGroup()
 
     prefs->setLastPath(Preferences::TemplateDocumentsFile,
                        QFileInfo(fileName).path());
-
-    mUi->groupsComboBox->setCurrentIndex(mUi->groupsComboBox->count() - 1);
-
-    updateOkButton();
 }

--- a/src/tiled/newtemplatedialog.h
+++ b/src/tiled/newtemplatedialog.h
@@ -39,12 +39,13 @@ class NewTemplateDialog : public QDialog
 public:
     explicit NewTemplateDialog(const QString &objectName, QWidget *parent = nullptr);
     ~NewTemplateDialog();
+    static void newTemplateGroup();
 
     void createTemplate(QString &name, int &index);
 
 private slots:
     void updateOkButton();
-    void newTemplateGroup();
+    void createGroup();
 
 private:
     Ui::NewTemplateDialog *mUi;

--- a/src/tiled/objecttemplatemodel.cpp
+++ b/src/tiled/objecttemplatemodel.cpp
@@ -191,7 +191,7 @@ bool ObjectTemplateModel::addTemplateGroup(TemplateGroup *templateGroup)
     return true;
 }
 
-bool ObjectTemplateModel::saveObjectToDocument(MapObject *object, QString name, int documentIndex)
+ObjectTemplate *ObjectTemplateModel::saveObjectToDocument(MapObject *object, QString name, int documentIndex)
 {
     auto document = mTemplateDocuments.at(documentIndex);
     auto templateGroup = document->templateGroup();
@@ -209,10 +209,10 @@ bool ObjectTemplateModel::saveObjectToDocument(MapObject *object, QString name, 
     document->addTemplate(objectTemplate);
     endInsertRows();
 
-    if (!document->save(document->fileName()))
-        return false;
-
-    return true;
+    if (document->save(document->fileName()))
+        return objectTemplate;
+    else
+        return nullptr;
 }
 
 ObjectTemplate *ObjectTemplateModel::toObjectTemplate(const QModelIndex &index) const

--- a/src/tiled/objecttemplatemodel.h
+++ b/src/tiled/objecttemplatemodel.h
@@ -53,7 +53,7 @@ public:
     bool addNewDocument(TemplateGroupDocument *document);
     bool addDocument(TemplateGroupDocument *document);
     bool addTemplateGroup(TemplateGroup *templateGroup);
-    bool saveObjectToDocument(MapObject *object, QString name, int documentIndex);
+    ObjectTemplate *saveObjectToDocument(MapObject *object, QString name, int documentIndex);
     ObjectTemplate *toObjectTemplate(const QModelIndex &index) const;
     void save(const TemplateGroup *templateGroup) const;
 

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -644,6 +644,7 @@ void PropertyBrowser::addMapObjectProperties()
     QtProperty *groupProperty = mGroupManager->addProperty(tr("Object"));
 
     addProperty(IdProperty, QVariant::Int, tr("ID"), groupProperty)->setEnabled(false);
+    addProperty(TemplateInstanceProperty, QVariant::Bool, tr("Template Instance"), groupProperty)->setEnabled(false);
     addProperty(NameProperty, QVariant::String, tr("Name"), groupProperty);
 
     QtVariantProperty *typeProperty =
@@ -1557,6 +1558,7 @@ void PropertyBrowser::updateProperties()
                                                                 : QPalette::Active;
 
         mIdToProperty[IdProperty]->setValue(mapObject->id());
+        mIdToProperty[TemplateInstanceProperty]->setValue(mapObject->isTemplateInstance());
         mIdToProperty[NameProperty]->setValue(mapObject->name());
         mIdToProperty[TypeProperty]->setValue(type);
         mIdToProperty[TypeProperty]->setValueColor(palette().color(typeColorGroup, QPalette::WindowText));

--- a/src/tiled/propertybrowser.h
+++ b/src/tiled/propertybrowser.h
@@ -157,7 +157,8 @@ private:
         CornerCountProperty,
         WangColorProbabilityProperty,
         CustomProperty,
-        InfiniteProperty
+        InfiniteProperty,
+        TemplateInstanceProperty
     };
 
     void addMapProperties();

--- a/src/tiled/templatesdock.cpp
+++ b/src/tiled/templatesdock.cpp
@@ -210,7 +210,7 @@ void TemplatesDock::openTemplateGroup()
 
     Preferences *prefs = Preferences::instance();
     QString suggestedFileName = prefs->lastPath(Preferences::TemplateDocumentsFile);
-    QString selectedFilter = TtxTemplateGroupFormat().nameFilter();
+    QString selectedFilter = TgxTemplateGroupFormat().nameFilter();
 
     QString fileName = QFileDialog::getOpenFileName(this, tr("Open Template Group"),
                                                     suggestedFileName,

--- a/src/tiled/templatesdock.cpp
+++ b/src/tiled/templatesdock.cpp
@@ -297,6 +297,7 @@ void TemplatesDock::setTemplate(ObjectTemplate *objectTemplate)
         Map *map = new Map(orientation, 1, 1, 1, 1);
 
         mObject = objectTemplate->object()->clone();
+        mObject->markAsTemplateBase();
 
         if (Tile *tile = mObject->cell().tile()) {
             map->addTileset(tile->sharedTileset());

--- a/src/tiled/templatesdock.h
+++ b/src/tiled/templatesdock.h
@@ -61,7 +61,6 @@ signals:
 
 private slots:
     void setSelectedTool(AbstractTool*tool);
-    void newTemplateGroup();
     void openTemplateGroup();
     void setTemplate(ObjectTemplate *objectTemplate);
 

--- a/src/tiled/templatesdock.h
+++ b/src/tiled/templatesdock.h
@@ -106,8 +106,16 @@ signals:
     void focusInEvent(QFocusEvent *event) override;
     void focusOutEvent(QFocusEvent *event) override;
 
+protected:
+    void contextMenuEvent(QContextMenuEvent *event) override;
+
 public slots:
     void updateSelection(const QItemSelection &selected, const QItemSelection &deselected);
+    void selectAllInstances();
+
+private:
+    QAction *mActionSelectAllInstances;
+    ObjectTemplate *mObjectTemplate;
 };
 
 inline void TemplatesDock::setPropertiesDock(PropertiesDock *propertiesDock)

--- a/src/tiled/tmxmapformat.cpp
+++ b/src/tiled/tmxmapformat.cpp
@@ -167,12 +167,12 @@ bool TsxTilesetFormat::supportsFile(const QString &fileName) const
     return false;
 }
 
-TtxTemplateGroupFormat::TtxTemplateGroupFormat(QObject *parent)
+TgxTemplateGroupFormat::TgxTemplateGroupFormat(QObject *parent)
     : TemplateGroupFormat(parent)
 {
 }
 
-TemplateGroup *TtxTemplateGroupFormat::read(const QString &fileName)
+TemplateGroup *TgxTemplateGroupFormat::read(const QString &fileName)
 {
     mError.clear();
 
@@ -184,7 +184,7 @@ TemplateGroup *TtxTemplateGroupFormat::read(const QString &fileName)
     return templateGroup;
 }
 
-bool TtxTemplateGroupFormat::write(const TemplateGroup *templateGroup, const QString &fileName)
+bool TgxTemplateGroupFormat::write(const TemplateGroup *templateGroup, const QString &fileName)
 {
     Preferences *prefs = Preferences::instance();
 
@@ -200,9 +200,9 @@ bool TtxTemplateGroupFormat::write(const TemplateGroup *templateGroup, const QSt
     return result;
 }
 
-bool TtxTemplateGroupFormat::supportsFile(const QString &fileName) const
+bool TgxTemplateGroupFormat::supportsFile(const QString &fileName) const
 {
-    if (fileName.endsWith(QLatin1String(".ttx"), Qt::CaseInsensitive))
+    if (fileName.endsWith(QLatin1String(".tgx"), Qt::CaseInsensitive))
         return true;
 
     if (fileName.endsWith(QLatin1String(".xml"), Qt::CaseInsensitive)) {

--- a/src/tiled/tmxmapformat.h
+++ b/src/tiled/tmxmapformat.h
@@ -104,23 +104,23 @@ private:
 };
 
 /**
- * A reader and writer for Tiled's .ttx template format.
+ * A reader and writer for Tiled's .tgx template format.
  */
-class TtxTemplateGroupFormat : public TemplateGroupFormat
+class TgxTemplateGroupFormat : public TemplateGroupFormat
 {
     Q_OBJECT
     Q_INTERFACES(Tiled::TemplateGroupFormat)
 
 public:
-    TtxTemplateGroupFormat(QObject *parent = nullptr);
+    TgxTemplateGroupFormat(QObject *parent = nullptr);
 
     TemplateGroup *read(const QString &fileName) override;
 
     bool write(const TemplateGroup *templateGroup, const QString &fileName) override;
 
-    QString nameFilter() const override { return tr("Tiled template group files (*.ttx)"); }
+    QString nameFilter() const override { return tr("Tiled template group files (*.tgx)"); }
 
-    QString shortName() const override { return QLatin1String("ttx"); }
+    QString shortName() const override { return QLatin1String("tgx"); }
 
     bool supportsFile(const QString &fileName) const override;
 


### PR DESCRIPTION
This pull request contains various minor improvements to templates

- [x] Enable detaching template instances from the template.
- [x] Disable some tools when using templates.
- [x] Create Template instance indicator in the properties dock.
- [x] Convert an object to a template instance after saving it as a template.
- [x] Removed code duplication for creating new template group.

I'm not sure about these two
- [x] Select all instances in the current map when a template is selected.
- [x] Change the format from ttx to something else like ttg.
