### PR TITLE
Improve tab closing functionality (#1720)

### DIFF
--- a/src/tiled/documentmanager.cpp
+++ b/src/tiled/documentmanager.cpp
@@ -544,8 +544,6 @@ void DocumentManager::closeOtherDocuments(int index)
         if (!mMultiDocumentClose)
             return;
     }
-
-    mMultiDocumentClose = false;
 }
 
 void DocumentManager::closeDocumentsToRight(int index)
@@ -562,8 +560,6 @@ void DocumentManager::closeDocumentsToRight(int index)
         if (!mMultiDocumentClose)
             return;
     }
-
-    mMultiDocumentClose = false;
 }
 
 void DocumentManager::closeDocumentAt(int index)
@@ -1034,10 +1030,10 @@ bool DocumentManager::eventFilter(QObject *, QEvent *event)
     switch (event->type()) {
         case QEvent::MouseButtonRelease: {
             // middle-click tab closing
-            QMouseEvent *mevent = static_cast<QMouseEvent*>(event);
+            QMouseEvent *mouseEvent = static_cast<QMouseEvent*>(event);
 
-            if (mevent->button() == Qt::MidButton) {
-                int index = mTabBar->tabAt(mevent->pos());
+            if (mouseEvent->button() == Qt::MidButton) {
+                int index = mTabBar->tabAt(mouseEvent->pos());
 
                 if (index != -1) {
                     documentCloseRequested(index);
@@ -1053,6 +1049,7 @@ bool DocumentManager::eventFilter(QObject *, QEvent *event)
     return false;
 }
 
-void DocumentManager::abortMultiDocumentClose() {
+void DocumentManager::abortMultiDocumentClose()
+{
     mMultiDocumentClose = false;
 }

--- a/src/tiled/documentmanager.cpp
+++ b/src/tiled/documentmanager.cpp
@@ -761,13 +761,8 @@ void DocumentManager::tabContextMenuRequested(const QPoint &pos)
     menu.addSeparator();
 
     QAction *closeTab = menu.addAction(tr("Close"));
-
+    closeTab->setIcon(QIcon(QStringLiteral(":/images/16x16/window-close.png")));
     Utils::setThemeIcon(closeTab, "window-close");
-    if (closeTab->icon().isNull()) {
-        QIcon closeIcon;
-        closeIcon.addFile(QStringLiteral(":/images/16x16/window-close.png"), QSize(), QIcon::Normal, QIcon::Off);
-        closeTab->setIcon(closeIcon);
-    }
     connect(closeTab, &QAction::triggered, [this, index] {
         documentCloseRequested(index);
     });

--- a/src/tiled/documentmanager.cpp
+++ b/src/tiled/documentmanager.cpp
@@ -537,9 +537,9 @@ void DocumentManager::closeOtherDocuments(int index)
 
     mMultiDocumentClose = true;
 
-    for (int i = mTabBar->count(); i > 0; --i) {
-        if (i-1 != index)
-            documentCloseRequested(i-1);
+    for (int i = mTabBar->count() - 1; i >= 0; --i) {
+        if (i != index)
+            documentCloseRequested(i);
 
         if (!mMultiDocumentClose)
             return;
@@ -553,9 +553,8 @@ void DocumentManager::closeDocumentsToRight(int index)
 
     mMultiDocumentClose = true;
 
-    for (int i = mTabBar->count(); i > 0; --i) {
-        if (i-1 > index)
-            documentCloseRequested(i-1);
+    for (int i = mTabBar->count() - 1; i > index; --i) {
+        documentCloseRequested(i);
 
         if (!mMultiDocumentClose)
             return;

--- a/src/tiled/documentmanager.cpp
+++ b/src/tiled/documentmanager.cpp
@@ -1024,25 +1024,20 @@ bool DocumentManager::askForAdjustment(const Tileset &tileset)
     return r == QMessageBox::Yes;
 }
 
-bool DocumentManager::eventFilter(QObject *, QEvent *event)
+bool DocumentManager::eventFilter(QObject *object, QEvent *event)
 {
-    switch (event->type()) {
-        case QEvent::MouseButtonRelease: {
-            // middle-click tab closing
-            QMouseEvent *mouseEvent = static_cast<QMouseEvent*>(event);
+    if (object == mTabBar && event->type() == QEvent::MouseButtonRelease) {
+        // middle-click tab closing
+        QMouseEvent *mouseEvent = static_cast<QMouseEvent*>(event);
 
-            if (mouseEvent->button() == Qt::MidButton) {
-                int index = mTabBar->tabAt(mouseEvent->pos());
+        if (mouseEvent->button() == Qt::MidButton) {
+            int index = mTabBar->tabAt(mouseEvent->pos());
 
-                if (index != -1) {
-                    documentCloseRequested(index);
-                    return true;
-                }
+            if (index != -1) {
+                documentCloseRequested(index);
+                return true;
             }
         }
-        break;
-    default:
-        break;
     }
 
     return false;

--- a/src/tiled/documentmanager.cpp
+++ b/src/tiled/documentmanager.cpp
@@ -534,12 +534,9 @@ void DocumentManager::closeOtherDocuments(int index)
     if (index == -1)
         return;
 
-    const int count = mTabBar->count();
-
-    for (int i = count; i > 0; --i) {
-        if (i-1 != index) {
+    for (int i = mTabBar->count(); i > 0; --i) {
+        if (i-1 != index)
             documentCloseRequested(i-1);
-        }
     }
 }
 
@@ -548,12 +545,9 @@ void DocumentManager::closeDocumentsToRight(int index)
     if (index == -1)
         return;
 
-    const int count = mTabBar->count();
-
-    for (int i = count; i > 0; --i) {
-        if (i-1 > index) {
+    for (int i = mTabBar->count(); i > 0; --i) {
+        if (i-1 > index)
             documentCloseRequested(i-1);
-        }
     }
 }
 
@@ -751,20 +745,26 @@ void DocumentManager::tabContextMenuRequested(const QPoint &pos)
 
     menu.addSeparator();
 
-    QIcon close_icon = QIcon::fromTheme(QString::fromLatin1("window-close"));
-    QAction *closeTab = menu.addAction(close_icon, tr("Close"));
+    QAction *closeTab = menu.addAction(tr("Close"));
+
+    Utils::setThemeIcon(closeTab, "window-close");
+    if (closeTab->icon().isNull()) {
+        QIcon closeIcon;
+        closeIcon.addFile(QStringLiteral(":/images/16x16/window-close.png"), QSize(), QIcon::Normal, QIcon::Off);
+        closeTab->setIcon(closeIcon);
+    }
     connect(closeTab, &QAction::triggered, [this, index] {
-        this->documentCloseRequested(index);
+        documentCloseRequested(index);
     });
 
     QAction *closeOtherTabs = menu.addAction(tr("Close Other Tabs"));
     connect(closeOtherTabs, &QAction::triggered, [this, index] {
-        this->closeOtherDocuments(index);
+        closeOtherDocuments(index);
     });
 
-    QAction *closeTabsToRight = menu.addAction(tr("Close Tabs To The Right"));
+    QAction *closeTabsToRight = menu.addAction(tr("Close Tabs to the Right"));
     connect(closeTabsToRight, &QAction::triggered, [this, index] {
-        this->closeDocumentsToRight(index);
+        closeDocumentsToRight(index);
     });
 
     menu.exec(mTabBar->mapToGlobal(pos));

--- a/src/tiled/documentmanager.cpp
+++ b/src/tiled/documentmanager.cpp
@@ -126,6 +126,7 @@ DocumentManager::DocumentManager(QObject *parent)
     , mMapEditor(nullptr) // todo: look into removing this
     , mUndoGroup(new QUndoGroup(this))
     , mFileSystemWatcher(new FileSystemWatcher(this))
+    , mMultiDocumentClose(false)
 {
     mBrokenLinksWidget->setVisible(false);
 
@@ -534,10 +535,17 @@ void DocumentManager::closeOtherDocuments(int index)
     if (index == -1)
         return;
 
+    mMultiDocumentClose = true;
+
     for (int i = mTabBar->count(); i > 0; --i) {
         if (i-1 != index)
             documentCloseRequested(i-1);
+
+        if (!mMultiDocumentClose)
+            return;
     }
+
+    mMultiDocumentClose = false;
 }
 
 void DocumentManager::closeDocumentsToRight(int index)
@@ -545,10 +553,17 @@ void DocumentManager::closeDocumentsToRight(int index)
     if (index == -1)
         return;
 
+    mMultiDocumentClose = true;
+
     for (int i = mTabBar->count(); i > 0; --i) {
         if (i-1 > index)
             documentCloseRequested(i-1);
+
+        if (!mMultiDocumentClose)
+            return;
     }
+
+    mMultiDocumentClose = false;
 }
 
 void DocumentManager::closeDocumentAt(int index)
@@ -1041,4 +1056,8 @@ bool DocumentManager::eventFilter(QObject *, QEvent *event)
     }
 
     return false;
+}
+
+void DocumentManager::abortMultiDocumentClose() {
+    mMultiDocumentClose = false;
 }

--- a/src/tiled/documentmanager.h
+++ b/src/tiled/documentmanager.h
@@ -136,6 +136,16 @@ public:
     void closeCurrentDocument();
 
     /**
+     * Closes all documents except the one pointed to by index.
+     */
+    void closeOtherDocuments(int index);
+
+    /**
+     * Closes all documents whose tabs are to the right of the index.
+     */
+    void closeDocumentsToRight(int index);
+
+    /**
      * Closes the document at the given \a index. Will not ask the user whether
      * to save any changes!
      */
@@ -252,6 +262,8 @@ private:
 
     void addToTilesetDocument(const SharedTileset &tileset, MapDocument *mapDocument);
     void removeFromTilesetDocument(const SharedTileset &tileset, MapDocument *mapDocument);
+
+    bool eventFilter(QObject *object, QEvent *event) override;
 
     QList<Document*> mDocuments;
     TilesetDocumentsModel *mTilesetDocumentsModel;

--- a/src/tiled/documentmanager.h
+++ b/src/tiled/documentmanager.h
@@ -197,6 +197,12 @@ public:
     void centerMapViewOn(const QPointF &pos)
     { centerMapViewOn(pos.x(), pos.y()); }
 
+    /**
+     * Unsets a flag to stop closeOtherDocuments() and closeDocumentsToRight()
+     * when Cancel is pressed
+     */
+    void abortMultiDocumentClose();
+
 signals:
     void fileOpenRequested();
     void fileOpenRequested(const QString &path);
@@ -286,6 +292,8 @@ private:
     QMap<SharedTileset, TilesetDocument*> mTilesetToDocument;
 
     static DocumentManager *mInstance;
+
+    bool mMultiDocumentClose;
 };
 
 inline TilesetDocumentsModel *DocumentManager::tilesetDocumentsModel() const

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -801,11 +801,9 @@ bool MainWindow::confirmSave(Document *document)
     switch (ret) {
     case QMessageBox::Save:    return saveFile();
     case QMessageBox::Discard: return true;
-    case QMessageBox::Cancel: {
-        mDocumentManager->abortMultiDocumentClose();
-        return false;
-    }
+    case QMessageBox::Cancel:
     default:
+        mDocumentManager->abortMultiDocumentClose();
         return false;
     }
 }

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -801,7 +801,10 @@ bool MainWindow::confirmSave(Document *document)
     switch (ret) {
     case QMessageBox::Save:    return saveFile();
     case QMessageBox::Discard: return true;
-    case QMessageBox::Cancel:
+    case QMessageBox::Cancel: {
+        mDocumentManager->abortMultiDocumentClose();
+        return false;
+    }
     default:
         return false;
     }


### PR DESCRIPTION
This commit adds "Close", "Close Other Tabs", and "Close Tabs To The
Right" to the document tab context menu. It also adds the ability to
close tabs with middle-click.