### PR TITLE
fix python scripts for updated tiled interfaces

### DIFF
--- a/src/plugins/python/pythonbind.cpp
+++ b/src/plugins/python/pythonbind.cpp
@@ -259,22 +259,22 @@ extern PyTypeObject PyTiledTile_Type;
 
 typedef struct {
     PyObject_HEAD
-    Tiled::SharedTileset *obj;
-    PyBindGenWrapperFlags flags:8;
-} PyTiledSharedTileset;
-
-
-extern PyTypeObject PyTiledSharedTileset_Type;
-
-
-typedef struct {
-    PyObject_HEAD
     Tiled::Tileset *obj;
     PyBindGenWrapperFlags flags:8;
 } PyTiledTileset;
 
 
 extern PyTypeObject PyTiledTileset_Type;
+
+
+typedef struct {
+    PyObject_HEAD
+    Tiled::SharedTileset *obj;
+    PyBindGenWrapperFlags flags:8;
+} PyTiledSharedTileset;
+
+
+extern PyTypeObject PyTiledSharedTileset_Type;
 
 
 typedef struct {
@@ -3111,114 +3111,6 @@ PyTypeObject PyTiledTile_Type = {
 
 
 static int
-_wrap_PyTiledSharedTileset__tp_init(void)
-{
-    PyErr_SetString(PyExc_TypeError, "class 'SharedTileset' cannot be constructed ()");
-    return -1;
-}
-
-static PyMethodDef PyTiledSharedTileset_methods[] = {
-    {NULL, NULL, 0, NULL}
-};
-
-static void
-_wrap_PyTiledSharedTileset__tp_dealloc(PyTiledSharedTileset *self)
-{
-        Tiled::SharedTileset *tmp = self->obj;
-        self->obj = NULL;
-        if (!(self->flags&PYBINDGEN_WRAPPER_FLAG_OBJECT_NOT_OWNED)) {
-            delete tmp;
-        }
-    Py_TYPE(self)->tp_free((PyObject*)self);
-}
-
-static PyObject*
-_wrap_PyTiledSharedTileset__tp_richcompare (PyTiledSharedTileset *PYBINDGEN_UNUSED(self), PyTiledSharedTileset *other, int opid)
-{
-
-    if (!PyObject_IsInstance((PyObject*) other, (PyObject*) &PyTiledSharedTileset_Type)) {
-        Py_INCREF(Py_NotImplemented);
-        return Py_NotImplemented;
-    }
-    switch (opid)
-    {
-    case Py_LT:
-        Py_INCREF(Py_NotImplemented);
-        return Py_NotImplemented;
-    case Py_LE:
-        Py_INCREF(Py_NotImplemented);
-        return Py_NotImplemented;
-    case Py_EQ:
-        Py_INCREF(Py_NotImplemented);
-        return Py_NotImplemented;
-    case Py_NE:
-        Py_INCREF(Py_NotImplemented);
-        return Py_NotImplemented;
-    case Py_GE:
-        Py_INCREF(Py_NotImplemented);
-        return Py_NotImplemented;
-    case Py_GT:
-        Py_INCREF(Py_NotImplemented);
-        return Py_NotImplemented;
-    } /* closes switch (opid) */
-    Py_INCREF(Py_NotImplemented);
-    return Py_NotImplemented;
-}
-
-PyTypeObject PyTiledSharedTileset_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    (char *) "tiled.Tiled.SharedTileset",            /* tp_name */
-    sizeof(PyTiledSharedTileset),                  /* tp_basicsize */
-    0,                                 /* tp_itemsize */
-    /* methods */
-    (destructor)_wrap_PyTiledSharedTileset__tp_dealloc,        /* tp_dealloc */
-    (printfunc)0,                      /* tp_print */
-    (getattrfunc)NULL,       /* tp_getattr */
-    (setattrfunc)NULL,       /* tp_setattr */
-    (cmpfunc)NULL,           /* tp_compare */
-    (reprfunc)NULL,             /* tp_repr */
-    (PyNumberMethods*)NULL,     /* tp_as_number */
-    (PySequenceMethods*)NULL, /* tp_as_sequence */
-    (PyMappingMethods*)NULL,   /* tp_as_mapping */
-    (hashfunc)NULL,             /* tp_hash */
-    (ternaryfunc)NULL,          /* tp_call */
-    (reprfunc)NULL,              /* tp_str */
-    (getattrofunc)NULL,     /* tp_getattro */
-    (setattrofunc)NULL,     /* tp_setattro */
-    (PyBufferProcs*)NULL,  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                      /* tp_flags */
-    NULL,                        /* Documentation string */
-    (traverseproc)NULL,     /* tp_traverse */
-    (inquiry)NULL,             /* tp_clear */
-    (richcmpfunc)_wrap_PyTiledSharedTileset__tp_richcompare,   /* tp_richcompare */
-    0,             /* tp_weaklistoffset */
-    (getiterfunc)NULL,          /* tp_iter */
-    (iternextfunc)NULL,     /* tp_iternext */
-    (struct PyMethodDef*)PyTiledSharedTileset_methods, /* tp_methods */
-    (struct PyMemberDef*)0,              /* tp_members */
-    0,                     /* tp_getset */
-    NULL,                              /* tp_base */
-    NULL,                              /* tp_dict */
-    (descrgetfunc)NULL,    /* tp_descr_get */
-    (descrsetfunc)NULL,    /* tp_descr_set */
-    0,                 /* tp_dictoffset */
-    (initproc)_wrap_PyTiledSharedTileset__tp_init,             /* tp_init */
-    (allocfunc)PyType_GenericAlloc,           /* tp_alloc */
-    (newfunc)PyType_GenericNew,               /* tp_new */
-    (freefunc)0,             /* tp_free */
-    (inquiry)NULL,             /* tp_is_gc */
-    NULL,                              /* tp_bases */
-    NULL,                              /* tp_mro */
-    NULL,                              /* tp_cache */
-    NULL,                              /* tp_subclasses */
-    NULL,                              /* tp_weaklist */
-    (destructor) NULL                  /* tp_del */
-};
-
-
-
-
-static int
 _wrap_PyTiledTileset__tp_init(void)
 {
     PyErr_SetString(PyExc_TypeError, "class 'Tileset' cannot be constructed ()");
@@ -3598,6 +3490,135 @@ PyTypeObject PyTiledTileset_Type = {
     (descrsetfunc)NULL,    /* tp_descr_set */
     0,                 /* tp_dictoffset */
     (initproc)_wrap_PyTiledTileset__tp_init,             /* tp_init */
+    (allocfunc)PyType_GenericAlloc,           /* tp_alloc */
+    (newfunc)PyType_GenericNew,               /* tp_new */
+    (freefunc)0,             /* tp_free */
+    (inquiry)NULL,             /* tp_is_gc */
+    NULL,                              /* tp_bases */
+    NULL,                              /* tp_mro */
+    NULL,                              /* tp_cache */
+    NULL,                              /* tp_subclasses */
+    NULL,                              /* tp_weaklist */
+    (destructor) NULL                  /* tp_del */
+};
+
+
+
+
+static int
+_wrap_PyTiledSharedTileset__tp_init(void)
+{
+    PyErr_SetString(PyExc_TypeError, "class 'SharedTileset' cannot be constructed ()");
+    return -1;
+}
+
+
+PyObject *
+_wrap_PyTiledSharedTileset_data(PyTiledSharedTileset *self)
+{
+    PyObject *py_retval;
+    Tiled::Tileset *retval;
+    PyTiledTileset *py_Tileset;
+
+    retval = self->obj->data();
+    if (!(retval)) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+    py_Tileset = PyObject_New(PyTiledTileset, &PyTiledTileset_Type);
+    py_Tileset->obj = retval;
+    py_Tileset->flags = PYBINDGEN_WRAPPER_FLAG_OBJECT_NOT_OWNED;
+    py_retval = Py_BuildValue((char *) "N", py_Tileset);
+    return py_retval;
+}
+
+static PyMethodDef PyTiledSharedTileset_methods[] = {
+    {(char *) "data", (PyCFunction) _wrap_PyTiledSharedTileset_data, METH_NOARGS, NULL },
+    {NULL, NULL, 0, NULL}
+};
+
+static void
+_wrap_PyTiledSharedTileset__tp_dealloc(PyTiledSharedTileset *self)
+{
+        Tiled::SharedTileset *tmp = self->obj;
+        self->obj = NULL;
+        if (!(self->flags&PYBINDGEN_WRAPPER_FLAG_OBJECT_NOT_OWNED)) {
+            delete tmp;
+        }
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static PyObject*
+_wrap_PyTiledSharedTileset__tp_richcompare (PyTiledSharedTileset *PYBINDGEN_UNUSED(self), PyTiledSharedTileset *other, int opid)
+{
+
+    if (!PyObject_IsInstance((PyObject*) other, (PyObject*) &PyTiledSharedTileset_Type)) {
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    }
+    switch (opid)
+    {
+    case Py_LT:
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    case Py_LE:
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    case Py_EQ:
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    case Py_NE:
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    case Py_GE:
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    case Py_GT:
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    } /* closes switch (opid) */
+    Py_INCREF(Py_NotImplemented);
+    return Py_NotImplemented;
+}
+
+PyTypeObject PyTiledSharedTileset_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    (char *) "tiled.Tiled.SharedTileset",            /* tp_name */
+    sizeof(PyTiledSharedTileset),                  /* tp_basicsize */
+    0,                                 /* tp_itemsize */
+    /* methods */
+    (destructor)_wrap_PyTiledSharedTileset__tp_dealloc,        /* tp_dealloc */
+    (printfunc)0,                      /* tp_print */
+    (getattrfunc)NULL,       /* tp_getattr */
+    (setattrfunc)NULL,       /* tp_setattr */
+    (cmpfunc)NULL,           /* tp_compare */
+    (reprfunc)NULL,             /* tp_repr */
+    (PyNumberMethods*)NULL,     /* tp_as_number */
+    (PySequenceMethods*)NULL, /* tp_as_sequence */
+    (PyMappingMethods*)NULL,   /* tp_as_mapping */
+    (hashfunc)NULL,             /* tp_hash */
+    (ternaryfunc)NULL,          /* tp_call */
+    (reprfunc)NULL,              /* tp_str */
+    (getattrofunc)NULL,     /* tp_getattro */
+    (setattrofunc)NULL,     /* tp_setattro */
+    (PyBufferProcs*)NULL,  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,                      /* tp_flags */
+    NULL,                        /* Documentation string */
+    (traverseproc)NULL,     /* tp_traverse */
+    (inquiry)NULL,             /* tp_clear */
+    (richcmpfunc)_wrap_PyTiledSharedTileset__tp_richcompare,   /* tp_richcompare */
+    0,             /* tp_weaklistoffset */
+    (getiterfunc)NULL,          /* tp_iter */
+    (iternextfunc)NULL,     /* tp_iternext */
+    (struct PyMethodDef*)PyTiledSharedTileset_methods, /* tp_methods */
+    (struct PyMemberDef*)0,              /* tp_members */
+    0,                     /* tp_getset */
+    NULL,                              /* tp_base */
+    NULL,                              /* tp_dict */
+    (descrgetfunc)NULL,    /* tp_descr_get */
+    (descrsetfunc)NULL,    /* tp_descr_set */
+    0,                 /* tp_dictoffset */
+    (initproc)_wrap_PyTiledSharedTileset__tp_init,             /* tp_init */
     (allocfunc)PyType_GenericAlloc,           /* tp_alloc */
     (newfunc)PyType_GenericNew,               /* tp_new */
     (freefunc)0,             /* tp_free */
@@ -4085,31 +4106,6 @@ _wrap_PyTiledMap_isTilesetUsed(PyTiledMap *self, PyObject *args, PyObject *kwarg
 
 
 PyObject *
-_wrap_PyTiledMap_layerAt(PyTiledMap *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    Tiled::Layer *retval;
-    int idx;
-    const char *keywords[] = {"idx", NULL};
-    PyTiledLayer *py_Layer;
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "i", (char **) keywords, &idx)) {
-        return NULL;
-    }
-    retval = self->obj->layerAt(idx);
-    if (!(retval)) {
-        Py_INCREF(Py_None);
-        return Py_None;
-    }
-    py_Layer = PyObject_New(PyTiledLayer, &PyTiledLayer_Type);
-    py_Layer->obj = retval;
-    py_Layer->flags = PYBINDGEN_WRAPPER_FLAG_OBJECT_NOT_OWNED;
-    py_retval = Py_BuildValue((char *) "N", py_Layer);
-    return py_retval;
-}
-
-
-PyObject *
 _wrap_PyTiledMap_removeTilesetAt(PyTiledMap *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
@@ -4456,6 +4452,31 @@ _wrap_PyTiledMap_tilesetCount(PyTiledMap *self)
 }
 
 
+PyObject *
+_wrap_PyTiledMap_layerAt(PyTiledMap *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    Tiled::Layer *retval;
+    int idx;
+    const char *keywords[] = {"idx", NULL};
+    PyTiledLayer *py_Layer;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "i", (char **) keywords, &idx)) {
+        return NULL;
+    }
+    retval = self->obj->layerAt(idx);
+    if (!(retval)) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+    py_Layer = PyObject_New(PyTiledLayer, &PyTiledLayer_Type);
+    py_Layer->obj = retval;
+    py_Layer->flags = PYBINDGEN_WRAPPER_FLAG_OBJECT_NOT_OWNED;
+    py_retval = Py_BuildValue((char *) "N", py_Layer);
+    return py_retval;
+}
+
+
 static PyObject*
 _wrap_PyTiledMap__copy__(PyTiledMap *self)
 {
@@ -4471,7 +4492,6 @@ static PyMethodDef PyTiledMap_methods[] = {
     {(char *) "setOrientation", (PyCFunction) _wrap_PyTiledMap_setOrientation, METH_KEYWORDS|METH_VARARGS, NULL },
     {(char *) "setHeight", (PyCFunction) _wrap_PyTiledMap_setHeight, METH_KEYWORDS|METH_VARARGS, NULL },
     {(char *) "isTilesetUsed", (PyCFunction) _wrap_PyTiledMap_isTilesetUsed, METH_KEYWORDS|METH_VARARGS, NULL },
-    {(char *) "layerAt", (PyCFunction) _wrap_PyTiledMap_layerAt, METH_KEYWORDS|METH_VARARGS, NULL },
     {(char *) "removeTilesetAt", (PyCFunction) _wrap_PyTiledMap_removeTilesetAt, METH_KEYWORDS|METH_VARARGS, NULL },
     {(char *) "orientation", (PyCFunction) _wrap_PyTiledMap_orientation, METH_NOARGS, NULL },
     {(char *) "tileLayerCount", (PyCFunction) _wrap_PyTiledMap_tileLayerCount, METH_NOARGS, NULL },
@@ -4489,6 +4509,7 @@ static PyMethodDef PyTiledMap_methods[] = {
     {(char *) "objectGroupCount", (PyCFunction) _wrap_PyTiledMap_objectGroupCount, METH_NOARGS, NULL },
     {(char *) "setWidth", (PyCFunction) _wrap_PyTiledMap_setWidth, METH_KEYWORDS|METH_VARARGS, NULL },
     {(char *) "tilesetCount", (PyCFunction) _wrap_PyTiledMap_tilesetCount, METH_NOARGS, NULL },
+    {(char *) "layerAt", (PyCFunction) _wrap_PyTiledMap_layerAt, METH_KEYWORDS|METH_VARARGS, NULL },
     {(char *) "__copy__", (PyCFunction) _wrap_PyTiledMap__copy__, METH_NOARGS, NULL},
     {NULL, NULL, 0, NULL}
 };
@@ -6067,17 +6088,17 @@ inittiled_Tiled(void)
         return NULL;
     }
     PyModule_AddObject(m, (char *) "Tile", (PyObject *) &PyTiledTile_Type);
-    /* Register the 'Tiled::SharedTileset' class */
-    if (PyType_Ready(&PyTiledSharedTileset_Type)) {
-        return NULL;
-    }
-    PyModule_AddObject(m, (char *) "SharedTileset", (PyObject *) &PyTiledSharedTileset_Type);
     /* Register the 'Tiled::Tileset' class */
     PyTiledTileset_Type.tp_base = &PyTiledObject_Type;
     if (PyType_Ready(&PyTiledTileset_Type)) {
         return NULL;
     }
     PyModule_AddObject(m, (char *) "Tileset", (PyObject *) &PyTiledTileset_Type);
+    /* Register the 'Tiled::SharedTileset' class */
+    if (PyType_Ready(&PyTiledSharedTileset_Type)) {
+        return NULL;
+    }
+    PyModule_AddObject(m, (char *) "SharedTileset", (PyObject *) &PyTiledSharedTileset_Type);
     /* Register the 'Tiled::Layer' class */
     PyTiledLayer_Type.tp_base = &PyTiledObject_Type;
     if (PyType_Ready(&PyTiledLayer_Type)) {

--- a/src/plugins/python/scripts/fotf.py
+++ b/src/plugins/python/scripts/fotf.py
@@ -41,11 +41,10 @@ class Fury(Plugin):
     decnum = (int(re.findall('[0-9]+', f).pop())-1)/10
     if decnum >= len(decs): decnum %= len(decs)
     gfxf = dirname(f)+'/../DEC/DECOR%02i.LBM' % decs[decnum]
-    t = Tiled.Tileset('DECOR', 16,16, 0, 0)
-    t.loadFromImage(fr.readtilegfx(gfxf), '')
-
+    t = Tiled.Tileset.create('DECOR', 16,16, 0, 0)
+    t.data().loadFromImage(fr.readtilegfx(gfxf), '')
     l = Tiled.TileLayer('Tiles',0,0, fr.w, fr.h)
-    fr.populatetiles(l, t)
+    fr.populatetiles(l, t.data())
     # have to pass ownership so can't add tileset before populating layer
     m.addTileset(t)
     m.addLayer(l)

--- a/src/plugins/python/scripts/mappy.py
+++ b/src/plugins/python/scripts/mappy.py
@@ -89,9 +89,9 @@ class Mappy(Plugin, FMPPicklerMixin):
 
     m.setProperty('chunks', cls.picklechunks(chunks))
 
-    tset = Tiled.Tileset('Tiles', hd.blockwidth, hd.blockheight, 0, 0)
+    tset = Tiled.Tileset.create('Tiles', hd.blockwidth, hd.blockheight, 0, 0)
     cmap = list(FMPColormap.unpack(chunks['CMAP'].data))
-    tset.loadFromImage(FMPTileGfx.unpack(hd, chunks['BGFX'].data, cmap), "")
+    tset.data().loadFromImage(FMPTileGfx.unpack(hd, chunks['BGFX'].data, cmap), "")
 
     blks = FMPBlocks(chunks['BKDT'].data, hd).blocks
 
@@ -100,7 +100,7 @@ class Mappy(Plugin, FMPPicklerMixin):
       print 'populating',c
       lay = Tiled.TileLayer(c,0,0,hd.mapwidth, hd.mapheight)
       lvl = list(FMPLayer.unpack(hd, chunks[c].data))
-      FMPLayer.populate(lay, blks, tset, hd, lvl)
+      FMPLayer.populate(lay, blks, tset.data(), hd, lvl)
       m.addLayer(lay)
 
     m.addTileset(tset)

--- a/src/plugins/python/scripts/pk2.py
+++ b/src/plugins/python/scripts/pk2.py
@@ -44,10 +44,10 @@ class PK2(Plugin):
     img = QImage()
     imgfile = dirname(f)+'/../../gfx/tiles/'+str(lvl.tileFile)
     img.load(imgfile, 'BMP')
-    t = Tiled.Tileset('Tiles', 32,32, 0, 0)
-    t.setTransparentColor(QColor(img.color(255)))
-    t.loadFromImage(img, imgfile)
-
+    t = Tiled.Tileset.create('Tiles', 32,32, 0, 0)
+    t.data().setTransparentColor(QColor(img.color(255)))
+    t.data().loadFromImage(img, imgfile)
+    
     # find common bounding box for the layers
     bb = ['','',10,10]
     for l in [lay1,lay2,lay3]:
@@ -63,7 +63,7 @@ class PK2(Plugin):
     maps.append(m)
 
     # -- background image
-    lai = Tiled.ImageLayer('Scenery', 0,0, bb[2], bb[3])
+    lai = Tiled.ImageLayer('Scenery', bb[2], bb[3])
     img = QImage()
     imgfile = dirname(f)+'/../../gfx/scenery/'+str(lvl.fieldFile)
     img.load(imgfile, 'BMP')
@@ -91,9 +91,9 @@ class PK2(Plugin):
         img = QImage()
         img.load(sprdir+sprfile, 'BMP')
         print 'loading', sprdir+sprfile
-        sprts = Tiled.Tileset(sprfile, 32,32, 0, 0)
-        sprts.setTransparentColor(QColor(img.color(255)))
-        sprts.loadFromImage(img, sprdir+sprfile)
+        sprts = Tiled.Tileset.create(sprfile, 32,32, 0, 0)
+        sprts.data().setTransparentColor(QColor(img.color(255)))
+        sprts.data().loadFromImage(img, sprdir+sprfile)
         lay3.spriteGfx[str(spr.kuvatiedosto)] = sprts
 
       #sprgfx[(str(spr.kuvatiedosto]
@@ -101,9 +101,8 @@ class PK2(Plugin):
 
       #print spr
 
-    la3 = Tiled.ObjectGroup('Sprites', 0,0, bb[2], bb[3])
+    la3 = Tiled.ObjectGroup('Sprites', bb[2], bb[3])
     lay3.doSprites(la3, bb)
-
     m.addLayer(lai)
     m.addTileset(t)
     for sprts in lay3.spriteGfx.values():
@@ -237,7 +236,7 @@ class PK2MAPLAYER(cpystruct.CpyStruct("asciinum lx, ly, w, h;")):
           spr = self.sprites[sprite]
           obj = Tiled.MapObject(str(spr.kuvatiedosto), '', QPointF(rx, ry), QSizeF(1, 1)) #spr.width, spr.height))
           # 0 should point to the actual sprite but how?
-          obj.setCell(Tiled.Cell(self.spriteGfx[str(spr.kuvatiedosto)].tileAt(0)))
+          obj.setCell(Tiled.Cell(self.spriteGfx[str(spr.kuvatiedosto)].data().tileAt(0)))
           la.addObject(obj)
 
   def doTiles(self, ts, la, bb):
@@ -249,7 +248,7 @@ class PK2MAPLAYER(cpystruct.CpyStruct("asciinum lx, ly, w, h;")):
           ry = self.ly.num + y - bb[1]
           if tile == 149: print 'start @',rx,ry
           if tile == 150: print 'end @',rx,ry
-          ti = ts.tileAt(tile)
+          ti = ts.data().tileAt(tile)
           if ti != None and rx < bb[2] and ry < bb[3]:
             # app should check that coords are within layer
             #print rx,ry,self.ly,y

--- a/src/plugins/python/scripts/zst.py
+++ b/src/plugins/python/scripts/zst.py
@@ -62,9 +62,9 @@ class ZST(Plugin):
         fh.seek(tilemapbase+tilebase)
         readTileset(fh, img)
  
-        tsets.append(Tiled.Tileset('Pal%i'%pal, 8,8, 0, 0))
-        tsets[pal].setTransparentColor(QColor(img.color(0)))
-        tsets[pal].loadFromImage(img, 'script')
+        tsets.append(Tiled.Tileset.create('Pal%i'%pal, 8,8, 0, 0))
+        tsets[pal].data().setTransparentColor(QColor(img.color(0)))
+        tsets[pal].data().loadFromImage(img, 'script')
 
       la = Tiled.TileLayer('Back', 0,0, 64,32)
       fh.seek(tilemapbase)
@@ -73,7 +73,7 @@ class ZST(Plugin):
         for x in range(32):
           t = parseTile(unpack('H', fh.read(2))[0])
           try:
-            tile = tsets[t.pal].tileAt(t.idx)
+            tile = tsets[t.pal].data().tileAt(t.idx)
             pix = tile.image()
             tile.setImage(pix)
             """ overriding tile gfx could be an alternative to palgroup layers
@@ -90,7 +90,7 @@ class ZST(Plugin):
           for x in range(32, la.width()):
             t = parseTile(unpack('H', fh.read(2))[0])
             try:
-              tile = tsets[t.pal].tileAt(t.idx)
+              tile = tsets[t.pal].data().tileAt(t.idx)
               la.setCell(x, y, Tiled.Cell(tile))
             except:
               print 'out of range %i,%i: %i' % (x,y,t.idx)

--- a/src/plugins/python/tiledbinding.py
+++ b/src/plugins/python/tiledbinding.py
@@ -59,9 +59,10 @@ cls_tile.add_method('width', 'int', [])
 cls_tile.add_method('height', 'int', [])
 #cls_tile.add_method('size', 'QSize', [])
 
-cls_sharedtileset = tiled.add_class('SharedTileset')
-
 cls_tileset = tiled.add_class('Tileset', cls_object)
+cls_sharedtileset = tiled.add_class('SharedTileset')
+cls_sharedtileset.add_method('data', retval('Tiled::Tileset*',reference_existing_object=True), [])
+
 cls_tileset.add_method('create', 'Tiled::SharedTileset',
                        [('QString','name'), ('int','tileWidth'), ('int','tileHeight'), ('int','tileSpacing'), ('int','margin')],
                        is_static=True)


### PR DESCRIPTION
I added SharedTileset data() method, regenerated pythonbind.cpp (I think, change order of lines in python file caused change of many lines), and fixed scripts for this and other interfaces changes (I tested them all, but don't know, what SNES game used by the author or original plugin - they can have different tiles format, as I know, maybe I write my own plugin for NES format in future, I know it much better).