### PR TITLE
Reopen save dialog when user heeds file extension warning

### DIFF
--- a/src/tiled/documentmanager.cpp
+++ b/src/tiled/documentmanager.cpp
@@ -467,14 +467,14 @@ bool DocumentManager::saveDocumentAs(Document *document)
                 !Utils::fileNameMatchesNameFilter(QFileInfo(fileName).fileName(), selectedFilter))
             {
                 QMessageBox messageBox(QMessageBox::Warning,
-                    QCoreApplication::translate("Tiled::Internal::MainWindow", "Extension Mismatch"),
-                    QCoreApplication::translate("Tiled::Internal::MainWindow", "The file extension does not match the chosen file type."),
-                    QMessageBox::Yes | QMessageBox::No,
-                    mWidget->window());
+                                       QCoreApplication::translate("Tiled::Internal::MainWindow", "Extension Mismatch"),
+                                       QCoreApplication::translate("Tiled::Internal::MainWindow", "The file extension does not match the chosen file type."),
+                                       QMessageBox::Yes | QMessageBox::No,
+                                       mWidget->window());
 
                 messageBox.setInformativeText(QCoreApplication::translate("Tiled::Internal::MainWindow",
-                                                                        "Tiled may not automatically recognize your file when loading. "
-                                                                        "Are you sure you want to save with this extension?"));
+                                                                          "Tiled may not automatically recognize your file when loading. "
+                                                                          "Are you sure you want to save with this extension?"));
 
                 int answer = messageBox.exec();
                 if (answer != QMessageBox::Yes)

--- a/src/tiled/documentmanager.cpp
+++ b/src/tiled/documentmanager.cpp
@@ -457,30 +457,31 @@ bool DocumentManager::saveDocumentAs(Document *document)
             fileName += defaultFileName;
         }
 
-        fileName = QFileDialog::getSaveFileName(mWidget->window(), QString(),
-                                                fileName,
-                                                filter,
-                                                &selectedFilter);
+        while (true) {
+            fileName = QFileDialog::getSaveFileName(mWidget->window(), QString(),
+                                                    fileName,
+                                                    filter,
+                                                    &selectedFilter);
 
-        if (!fileName.isEmpty() &&
-            !Utils::fileNameMatchesNameFilter(QFileInfo(fileName).fileName(), selectedFilter))
-        {
-            QMessageBox messageBox(QMessageBox::Warning,
-                                   QCoreApplication::translate("Tiled::Internal::MainWindow", "Extension Mismatch"),
-                                   QCoreApplication::translate("Tiled::Internal::MainWindow", "The file extension does not match the chosen file type."),
-                                   QMessageBox::Yes | QMessageBox::No,
-                                   mWidget->window());
+            if (!fileName.isEmpty() &&
+                !Utils::fileNameMatchesNameFilter(QFileInfo(fileName).fileName(), selectedFilter))
+            {
+                QMessageBox messageBox(QMessageBox::Warning,
+                    QCoreApplication::translate("Tiled::Internal::MainWindow", "Extension Mismatch"),
+                    QCoreApplication::translate("Tiled::Internal::MainWindow", "The file extension does not match the chosen file type."),
+                    QMessageBox::Yes | QMessageBox::No,
+                    mWidget->window());
 
-            messageBox.setInformativeText(QCoreApplication::translate("Tiled::Internal::MainWindow",
-                                                                      "Tiled may not automatically recognize your file when loading. "
-                                                                      "Are you sure you want to save with this extension?"));
+                messageBox.setInformativeText(QCoreApplication::translate("Tiled::Internal::MainWindow",
+                                                                        "Tiled may not automatically recognize your file when loading. "
+                                                                        "Are you sure you want to save with this extension?"));
 
-            int answer = messageBox.exec();
-            if (answer != QMessageBox::Yes)
-                return QString();
+                int answer = messageBox.exec();
+                if (answer != QMessageBox::Yes)
+                    continue;
+            }
+            return fileName;
         }
-
-        return fileName;
     };
 
     if (auto mapDocument = qobject_cast<MapDocument*>(document)) {


### PR DESCRIPTION
Proposed fix for https://github.com/bjorn/tiled/issues/1782.

With this change, the save dialog will re-open afters users answer no to the "Tiled may not automatically recognize your file when loading. Are you sure you want to save with this extension?" dialog.

The diff whitespace looks funny on Github for some reason, I'm not too sure why considering it's all spaces (and indented correctly).