### PR TITLE
Fixed a bug where selection rectangle's shadow moved when zooming

### DIFF
--- a/src/tiled/selectionrectangle.cpp
+++ b/src/tiled/selectionrectangle.cpp
@@ -20,6 +20,9 @@
 
 #include "selectionrectangle.h"
 
+#include "mapview.h"
+#include "zoomable.h"
+
 #include <QApplication>
 #include <QPainter>
 #include <QPalette>
@@ -45,7 +48,8 @@ QRectF SelectionRectangle::boundingRect() const
 }
 
 void SelectionRectangle::paint(QPainter *painter,
-                               const QStyleOptionGraphicsItem *, QWidget *)
+                               const QStyleOptionGraphicsItem *,
+                               QWidget *widget)
 {
     if (mRectangle.isNull())
         return;
@@ -56,7 +60,8 @@ void SelectionRectangle::paint(QPainter *painter,
     QPen pen(black, 2, Qt::DotLine);
     pen.setCosmetic(true);
     painter->setPen(pen);
-    painter->drawRect(mRectangle.translated(1, 1));
+    const qreal scale = static_cast<MapView*>(widget->parent())->zoomable()->scale();
+    painter->drawRect(mRectangle.translated(1 / scale, 1 / scale));
 
     // Draw a rectangle in the highlight color
     QColor highlight = QApplication::palette().highlight().color();

--- a/src/tiled/selectionrectangle.cpp
+++ b/src/tiled/selectionrectangle.cpp
@@ -55,12 +55,15 @@ void SelectionRectangle::paint(QPainter *painter,
         return;
 
     // Draw a shadow
+    qreal scale = 1.0;
+    if (widget)
+        if (MapView *mapView = dynamic_cast<MapView*>(widget->parent()))
+            scale = mapView->zoomable()->scale();
     QColor black(Qt::black);
     black.setAlpha(128);
     QPen pen(black, 2, Qt::DotLine);
     pen.setCosmetic(true);
     painter->setPen(pen);
-    const qreal scale = static_cast<MapView*>(widget->parent())->zoomable()->scale();
     painter->drawRect(mRectangle.translated(1 / scale, 1 / scale));
 
     // Draw a rectangle in the highlight color


### PR DESCRIPTION
This change fixes an issue where the shadow of the selection rectangle would drift away from the selection based on the current zoom level (more zoom = more drift). With this change, the shadow is always on pixel away from the selection.