### PR TITLE
Ability to reset widgets layout arrangement to default setting

### DIFF
--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -380,6 +380,9 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     mViewsAndToolbarsMenu = new QMenu(this);
     mViewsAndToolbarsAction = new QAction(tr("Views and Toolbars"), this);
     mViewsAndToolbarsAction->setMenu(mViewsAndToolbarsMenu);
+
+    mResetDefaultLayout = new QAction(tr("Reset To Default Layout"),this);
+
     mShowObjectTypesEditor = new QAction(tr("Object Types Editor"), this);
     mShowObjectTypesEditor->setCheckable(true);
     mUi->menuView->insertAction(mUi->actionShowGrid, mViewsAndToolbarsAction);
@@ -415,6 +418,8 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
             this, SLOT(closeDocument(int)));
     connect(mDocumentManager, SIGNAL(reloadError(QString)),
             this, SLOT(reloadError(QString)));
+
+    connect(mResetDefaultLayout,SIGNAL(triggered(bool)),this,SLOT(resetDefaultLayout()));
 
     QShortcut *switchToLeftDocument = new QShortcut(tr("Alt+Left"), this);
     connect(switchToLeftDocument, SIGNAL(activated()),
@@ -1366,6 +1371,23 @@ void MainWindow::updateRecentFilesMenu()
     mUi->menuRecentFiles->setEnabled(numRecentFiles > 0);
 }
 
+void MainWindow::resetDefaultLayout()
+{
+    //This function is triggered upon clicking View > Reset to Default Layout
+    QMessageBox::StandardButton userResponse;
+    userResponse = QMessageBox::question(this, tr("Reset Editor Layout"),
+                                         tr("This will terminate the program and any unsaved progress may be lost, Are you sure you want to Continue ?")
+                                         ,QMessageBox::Yes|QMessageBox::No);
+
+    if (userResponse == QMessageBox::No)
+        return;
+
+    mSettings.beginGroup(QLatin1String("MapEditor"));
+    mSettings.remove(QLatin1String("State"));
+    mSettings.endGroup();
+    QApplication::exit();
+}
+
 void MainWindow::updateViewsAndToolbarsMenu()
 {
     mViewsAndToolbarsMenu->clear();
@@ -1380,10 +1402,13 @@ void MainWindow::updateViewsAndToolbarsMenu()
             mViewsAndToolbarsMenu->addAction(dockWidget->toggleViewAction());
 
         mViewsAndToolbarsMenu->addSeparator();
-
         const auto toolBars = editor->toolBars();
         for (auto toolBar : toolBars)
             mViewsAndToolbarsMenu->addAction(toolBar->toggleViewAction());
+
+        //Layout Arrangement
+        mViewsAndToolbarsMenu->addSeparator();
+        mViewsAndToolbarsMenu->addAction(MainWindow::mResetDefaultLayout);
     }
 }
 

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -109,6 +109,7 @@ protected:
     void dropEvent(QDropEvent *) override;
 
 private slots:
+    //File tab
     void newMap();
     void openFile();
     bool saveFile();
@@ -121,6 +122,7 @@ private slots:
     void closeFile();
     void closeAllFiles();
 
+    //Edit Tab
     void cut();
     void copy();
     void paste();
@@ -128,12 +130,14 @@ private slots:
     void delete_();
     void openPreferences();
 
+    //View Tab
     void labelVisibilityActionTriggered(QAction *action);
     void zoomIn();
     void zoomOut();
     void zoomNormal();
     void setFullScreen(bool fullScreen);
     void toggleClearView(bool clearView);
+    void resetDefaultLayout();
 
     bool newTileset(const QString &path = QString());
     void reloadTilesetImages();
@@ -211,6 +215,7 @@ private:
     QAction *mViewsAndToolbarsAction;
     QAction *mShowObjectTypesEditor;
 
+    QAction *mResetDefaultLayout;
     void setupQuickStamps();
 
     AutomappingManager *mAutomappingManager;


### PR DESCRIPTION
This adds a missing feature in tiled that will allow a user to reset their editor layout to the default setting that tiled comes with.