### PR TITLE
Ability to reset MapEditor's layout to default layout without terminating/restarting Tiled

### DIFF
--- a/src/tiled/editor.h
+++ b/src/tiled/editor.h
@@ -66,6 +66,8 @@ public:
     virtual StandardActions enabledStandardActions() const = 0;
     virtual void performStandardAction(StandardAction action) = 0;
 
+    virtual void resetLayout() = 0;
+
 signals:
     void enabledStandardActionsChanged();
 };

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -462,7 +462,7 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     mViewsAndToolbarsAction = new QAction(tr("Views and Toolbars"), this);
     mViewsAndToolbarsAction->setMenu(mViewsAndToolbarsMenu);
 
-    mResetDefaultLayout = new QAction(tr("Reset To Default Layout"),this);
+    mResetToDefaultLayout = new QAction(tr("Reset to Default Layout"), this);
 
     mShowObjectTypesEditor = new QAction(tr("Object Types Editor"), this);
     mShowObjectTypesEditor->setCheckable(true);
@@ -500,7 +500,7 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     connect(mDocumentManager, SIGNAL(reloadError(QString)),
             this, SLOT(reloadError(QString)));
 
-    connect(mResetDefaultLayout,SIGNAL(triggered(bool)),this,SLOT(resetDefaultLayout()));
+    connect(mResetToDefaultLayout, &QAction::triggered, this, &MainWindow::resetToDefaultLayout);
 
     QShortcut *switchToLeftDocument = new QShortcut(tr("Alt+Left"), this);
     connect(switchToLeftDocument, SIGNAL(activated()),
@@ -1317,21 +1317,16 @@ void MainWindow::updateRecentFilesMenu()
     mUi->menuRecentFiles->setEnabled(numRecentFiles > 0);
 }
 
-void MainWindow::resetDefaultLayout()
+void MainWindow::resetToDefaultLayout()
 {
-    //This function is triggered upon clicking View > Reset to Default Layout
-    QMessageBox::StandardButton userResponse;
-    userResponse = QMessageBox::question(this, tr("Reset Editor Layout"),
-                                         tr("This will terminate the program and any unsaved progress may be lost, Are you sure you want to Continue ?")
-                                         ,QMessageBox::Yes|QMessageBox::No);
+    //uncheck actionClearView if in case its already checked
+    mUi->actionClearView->setChecked(false);
 
-    if (userResponse == QMessageBox::No)
-        return;
+    //reset mapEditor layout
+    auto *editor = qobject_cast<MapEditor*>(mDocumentManager->editor(Document::MapDocumentType));
+    editor->resetLayout();
 
-    mSettings.beginGroup(QLatin1String("MapEditor"));
-    mSettings.remove(QLatin1String("State"));
-    mSettings.endGroup();
-    QApplication::exit();
+    updateViewsAndToolbarsMenu();//this is to gaurantee that this sub-menu is up-to-date
 }
 
 void MainWindow::updateViewsAndToolbarsMenu()
@@ -1354,7 +1349,7 @@ void MainWindow::updateViewsAndToolbarsMenu()
 
         //Layout Arrangement
         mViewsAndToolbarsMenu->addSeparator();
-        mViewsAndToolbarsMenu->addAction(MainWindow::mResetDefaultLayout);
+        mViewsAndToolbarsMenu->addAction(MainWindow::mResetToDefaultLayout);
     }
 }
 

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -1319,14 +1319,15 @@ void MainWindow::updateRecentFilesMenu()
 
 void MainWindow::resetToDefaultLayout()
 {
-    //uncheck actionClearView if in case its already checked
+    // Make sure we're not in Clear View mode
     mUi->actionClearView->setChecked(false);
 
-    //reset mapEditor layout
-    auto *mapEditor = static_cast<MapEditor*>(mDocumentManager->editor(Document::MapDocumentType));
-    mapEditor->resetLayout();
+    // Reset the Console dock
+    addDockWidget(Qt::BottomDockWidgetArea, mConsoleDock);
+    mConsoleDock->setVisible(false);
 
-    updateViewsAndToolbarsMenu();//this is to gaurantee that this sub-menu is up-to-date
+    // Reset the layout of the current editor
+    mDocumentManager->currentEditor()->resetLayout();
 }
 
 void MainWindow::updateViewsAndToolbarsMenu()
@@ -1337,7 +1338,6 @@ void MainWindow::updateViewsAndToolbarsMenu()
 
     if (Editor *editor = mDocumentManager->currentEditor()) {
         mViewsAndToolbarsMenu->addSeparator();
-
         const auto dockWidgets = editor->dockWidgets();
         for (auto dockWidget : dockWidgets)
             mViewsAndToolbarsMenu->addAction(dockWidget->toggleViewAction());
@@ -1346,7 +1346,6 @@ void MainWindow::updateViewsAndToolbarsMenu()
         const auto toolBars = editor->toolBars();
         for (auto toolBar : toolBars)
             mViewsAndToolbarsMenu->addAction(toolBar->toggleViewAction());
-
 
         mViewsAndToolbarsMenu->addSeparator();
         mViewsAndToolbarsMenu->addAction(mResetToDefaultLayout);

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -1323,8 +1323,8 @@ void MainWindow::resetToDefaultLayout()
     mUi->actionClearView->setChecked(false);
 
     //reset mapEditor layout
-    auto *editor = qobject_cast<MapEditor*>(mDocumentManager->editor(Document::MapDocumentType));
-    editor->resetLayout();
+    auto *mapEditor = static_cast<MapEditor*>(mDocumentManager->editor(Document::MapDocumentType));
+    mapEditor->resetLayout();
 
     updateViewsAndToolbarsMenu();//this is to gaurantee that this sub-menu is up-to-date
 }
@@ -1347,9 +1347,9 @@ void MainWindow::updateViewsAndToolbarsMenu()
         for (auto toolBar : toolBars)
             mViewsAndToolbarsMenu->addAction(toolBar->toggleViewAction());
 
-        //Layout Arrangement
+
         mViewsAndToolbarsMenu->addSeparator();
-        mViewsAndToolbarsMenu->addAction(MainWindow::mResetToDefaultLayout);
+        mViewsAndToolbarsMenu->addAction(mResetToDefaultLayout);
     }
 }
 

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -461,6 +461,9 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     mViewsAndToolbarsMenu = new QMenu(this);
     mViewsAndToolbarsAction = new QAction(tr("Views and Toolbars"), this);
     mViewsAndToolbarsAction->setMenu(mViewsAndToolbarsMenu);
+
+    mResetDefaultLayout = new QAction(tr("Reset To Default Layout"),this);
+
     mShowObjectTypesEditor = new QAction(tr("Object Types Editor"), this);
     mShowObjectTypesEditor->setCheckable(true);
     mUi->menuView->insertAction(mUi->actionShowGrid, mViewsAndToolbarsAction);
@@ -496,6 +499,8 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
             this, SLOT(closeDocument(int)));
     connect(mDocumentManager, SIGNAL(reloadError(QString)),
             this, SLOT(reloadError(QString)));
+
+    connect(mResetDefaultLayout,SIGNAL(triggered(bool)),this,SLOT(resetDefaultLayout()));
 
     QShortcut *switchToLeftDocument = new QShortcut(tr("Alt+Left"), this);
     connect(switchToLeftDocument, SIGNAL(activated()),
@@ -1312,6 +1317,23 @@ void MainWindow::updateRecentFilesMenu()
     mUi->menuRecentFiles->setEnabled(numRecentFiles > 0);
 }
 
+void MainWindow::resetDefaultLayout()
+{
+    //This function is triggered upon clicking View > Reset to Default Layout
+    QMessageBox::StandardButton userResponse;
+    userResponse = QMessageBox::question(this, tr("Reset Editor Layout"),
+                                         tr("This will terminate the program and any unsaved progress may be lost, Are you sure you want to Continue ?")
+                                         ,QMessageBox::Yes|QMessageBox::No);
+
+    if (userResponse == QMessageBox::No)
+        return;
+
+    mSettings.beginGroup(QLatin1String("MapEditor"));
+    mSettings.remove(QLatin1String("State"));
+    mSettings.endGroup();
+    QApplication::exit();
+}
+
 void MainWindow::updateViewsAndToolbarsMenu()
 {
     mViewsAndToolbarsMenu->clear();
@@ -1326,10 +1348,13 @@ void MainWindow::updateViewsAndToolbarsMenu()
             mViewsAndToolbarsMenu->addAction(dockWidget->toggleViewAction());
 
         mViewsAndToolbarsMenu->addSeparator();
-
         const auto toolBars = editor->toolBars();
         for (auto toolBar : toolBars)
             mViewsAndToolbarsMenu->addAction(toolBar->toggleViewAction());
+
+        //Layout Arrangement
+        mViewsAndToolbarsMenu->addSeparator();
+        mViewsAndToolbarsMenu->addAction(MainWindow::mResetDefaultLayout);
     }
 }
 

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -1349,7 +1349,7 @@ void MainWindow::updateViewsAndToolbarsMenu()
 
 
         mViewsAndToolbarsMenu->addSeparator();
-        mViewsAndToolbarsMenu->addAction(mResetToDefaultLayout);
+        mViewsAndToolbarsMenu->addAction(MainWindow::mResetToDefaultLayout);
     }
 }
 

--- a/src/tiled/mainwindow.cpp
+++ b/src/tiled/mainwindow.cpp
@@ -1349,7 +1349,7 @@ void MainWindow::updateViewsAndToolbarsMenu()
 
 
         mViewsAndToolbarsMenu->addSeparator();
-        mViewsAndToolbarsMenu->addAction(MainWindow::mResetToDefaultLayout);
+        mViewsAndToolbarsMenu->addAction(mResetToDefaultLayout);
     }
 }
 

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -108,7 +108,6 @@ protected:
     void dropEvent(QDropEvent *) override;
 
 private slots:
-    //File tab
     void newMap();
     void openFile();
     bool saveFile();
@@ -121,7 +120,6 @@ private slots:
     void closeFile();
     void closeAllFiles();
 
-    //Edit Tab
     void cut();
     void copy();
     void paste();
@@ -129,7 +127,6 @@ private slots:
     void delete_();
     void openPreferences();
 
-    //View Tab
     void labelVisibilityActionTriggered(QAction *action);
     void zoomIn();
     void zoomOut();
@@ -218,6 +215,7 @@ private:
     QAction *mShowObjectTypesEditor;
 
     QAction *mResetToDefaultLayout;
+
     void setupQuickStamps();
 
     AutomappingManager *mAutomappingManager;

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -136,7 +136,7 @@ private slots:
     void zoomNormal();
     void setFullScreen(bool fullScreen);
     void toggleClearView(bool clearView);
-    void resetDefaultLayout();
+    void resetToDefaultLayout();
 
     bool newTileset(const QString &path = QString());
     void reloadTilesetImages();
@@ -217,7 +217,7 @@ private:
     QAction *mViewsAndToolbarsAction;
     QAction *mShowObjectTypesEditor;
 
-    QAction *mResetDefaultLayout;
+    QAction *mResetToDefaultLayout;
     void setupQuickStamps();
 
     AutomappingManager *mAutomappingManager;

--- a/src/tiled/mainwindow.h
+++ b/src/tiled/mainwindow.h
@@ -108,6 +108,7 @@ protected:
     void dropEvent(QDropEvent *) override;
 
 private slots:
+    //File tab
     void newMap();
     void openFile();
     bool saveFile();
@@ -120,6 +121,7 @@ private slots:
     void closeFile();
     void closeAllFiles();
 
+    //Edit Tab
     void cut();
     void copy();
     void paste();
@@ -127,12 +129,14 @@ private slots:
     void delete_();
     void openPreferences();
 
+    //View Tab
     void labelVisibilityActionTriggered(QAction *action);
     void zoomIn();
     void zoomOut();
     void zoomNormal();
     void setFullScreen(bool fullScreen);
     void toggleClearView(bool clearView);
+    void resetDefaultLayout();
 
     bool newTileset(const QString &path = QString());
     void reloadTilesetImages();
@@ -213,6 +217,7 @@ private:
     QAction *mViewsAndToolbarsAction;
     QAction *mShowObjectTypesEditor;
 
+    QAction *mResetDefaultLayout;
     void setupQuickStamps();
 
     AutomappingManager *mAutomappingManager;

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -570,6 +570,64 @@ void MapEditor::showMessage(const QString &text, int timeout)
     mMainWindow->statusBar()->showMessage(text, timeout);
 }
 
+void MapEditor::resetLayout()
+{
+    /*
+     * Re-Arranges dockWidgets and toolBars to default layout
+    */
+
+    QList<QDockWidget*> docks = this->dockWidgets();
+    QList<QToolBar*> toolBars = this->toolBars();
+
+    for(auto dock : docks){
+        mMainWindow->removeDockWidget(dock);
+    }
+    for(auto toolBar : toolBars){
+        mMainWindow->removeToolBar(toolBar);
+    }
+
+    //re-Adding Dock Widgets in their Default Position
+    mMainWindow->addToolBar(Qt::TopToolBarArea, mMainToolBar);
+    mMainWindow->addToolBar(Qt::TopToolBarArea, mToolsToolBar);
+    mMainWindow->addToolBar(Qt::TopToolBarArea, mToolSpecificToolBar);
+
+    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mLayerDock);
+    mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mPropertiesDock);
+    mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mMapsDock);
+    mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mUndoDock);
+    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mObjectsDock);
+    mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mTemplatesDock);
+    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mMiniMapDock);
+    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mTerrainDock);
+    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mWangDock);
+    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mTilesetDock);
+    mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mTileStampsDock);
+
+    mMainWindow->tabifyDockWidget(mUndoDock, mMapsDock);
+    mMainWindow->tabifyDockWidget(mTemplatesDock, mTileStampsDock);
+    mMainWindow->tabifyDockWidget(mMiniMapDock, mObjectsDock);
+    mMainWindow->tabifyDockWidget(mObjectsDock, mLayerDock);
+    mMainWindow->tabifyDockWidget(mTerrainDock, mWangDock);
+    mMainWindow->tabifyDockWidget(mWangDock, mTilesetDock);
+
+    mMapsDock->setVisible(false);
+    mUndoDock->setVisible(false);
+    mTemplatesDock->setVisible(false);
+    mWangDock->setVisible(false);
+    mTileStampsDock->setVisible(false);
+
+    mMainToolBar->setVisible(true);
+    mToolsToolBar->setVisible(true);
+    mToolSpecificToolBar->setVisible(true);
+
+    mPropertiesDock->setVisible(true);
+    mLayerDock->setVisible(true);
+    mObjectsDock->setVisible(true);
+    mMiniMapDock->setVisible(true);
+    mTerrainDock->setVisible(true);
+    mTilesetDock->setVisible(true);
+}
+
 void MapEditor::setSelectedTool(AbstractTool *tool)
 {
     if (mSelectedTool == tool)

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -593,10 +593,10 @@ void MapEditor::resetLayout()
     mToolsToolBar->setVisible(true);
     mToolSpecificToolBar->setVisible(true);
 
+    mMiniMapDock->setVisible(true);
     mPropertiesDock->setVisible(true);
     mLayerDock->setVisible(true);
     mObjectsDock->setVisible(true);
-    mMiniMapDock->setVisible(true);
     mTerrainDock->setVisible(true);
     mTilesetDock->setVisible(true);
 

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -215,7 +215,7 @@ MapEditor::MapEditor(QObject *parent)
     mTemplatesDock->setPropertiesDock(mPropertiesDock);
     mTileStampsDock = new TileStampsDock(mTileStampManager, mMainWindow);
 
-    resetLayout(); //Adds the dock widgets and toolbars into their default position
+    resetLayout();
 
     mComboBoxProxyModel->setSourceModel(mReversingProxyModel);
     mLayerComboBox->setModel(mComboBoxProxyModel);
@@ -529,53 +529,46 @@ void MapEditor::performStandardAction(StandardAction action)
     }
 }
 
-Zoomable *MapEditor::zoomable() const
-{
-    if (auto view = currentMapView())
-        return view->zoomable();
-    return nullptr;
-}
-
-void MapEditor::showMessage(const QString &text, int timeout)
-{
-    mMainWindow->statusBar()->showMessage(text, timeout);
-}
-
+/**
+ * Arranges views and toolbars to default layout.
+ */
 void MapEditor::resetLayout()
 {
-    // Arranges dockWidgets and toolBars to default layout
-
-    QList<QDockWidget*> docks = this->dockWidgets();
-    QList<QToolBar*> toolBars = this->toolBars();
-
-    for(auto dock : docks){
-        mMainWindow->removeDockWidget(dock);
-    }
-    for(auto toolBar : toolBars){
-        mMainWindow->removeToolBar(toolBar);
+    // Remove dock widgets and set them to visible
+    const QList<QDockWidget*> dockWidgets = this->dockWidgets();
+    for (auto dockWidget : dockWidgets) {
+        mMainWindow->removeDockWidget(dockWidget);
+        dockWidget->setVisible(true);
     }
 
-    // Adding Dock Widgets and ToolBars in their Default Position
-    mMainWindow->addToolBar(Qt::TopToolBarArea, mMainToolBar);
-    mMainWindow->addToolBar(Qt::TopToolBarArea, mToolsToolBar);
-    mMainWindow->addToolBar(Qt::TopToolBarArea, mToolSpecificToolBar);
+    // Make sure all toolbars are visible
+    const QList<QToolBar*> toolBars = this->toolBars();
+    for (auto toolBar : toolBars)
+        toolBar->setVisible(true);
 
-    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mLayerDock);
+    // Adding dock widgets and toolbars in their default position
+    mMainWindow->addToolBar(mMainToolBar);
+    mMainWindow->addToolBar(mToolsToolBar);
+    mMainWindow->addToolBar(mToolSpecificToolBar);
+
     mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mPropertiesDock);
     mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mMapsDock);
     mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mUndoDock);
-    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mObjectsDock);
+    mMainWindow->tabifyDockWidget(mUndoDock, mMapsDock);
+
     mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mTemplatesDock);
+    mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mTileStampsDock);
+    mMainWindow->tabifyDockWidget(mTemplatesDock, mTileStampsDock);
+
+    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mLayerDock);
+    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mObjectsDock);
     mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mMiniMapDock);
+    mMainWindow->tabifyDockWidget(mMiniMapDock, mObjectsDock);
+    mMainWindow->tabifyDockWidget(mObjectsDock, mLayerDock);
+
     mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mTerrainDock);
     mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mWangDock);
     mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mTilesetDock);
-    mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mTileStampsDock);
-
-    mMainWindow->tabifyDockWidget(mUndoDock, mMapsDock);
-    mMainWindow->tabifyDockWidget(mTemplatesDock, mTileStampsDock);
-    mMainWindow->tabifyDockWidget(mMiniMapDock, mObjectsDock);
-    mMainWindow->tabifyDockWidget(mObjectsDock, mLayerDock);
     mMainWindow->tabifyDockWidget(mTerrainDock, mWangDock);
     mMainWindow->tabifyDockWidget(mWangDock, mTilesetDock);
 
@@ -586,20 +579,18 @@ void MapEditor::resetLayout()
     mTemplatesDock->setVisible(false);
     mWangDock->setVisible(false);
     mTileStampsDock->setVisible(false);
+}
 
-    // Toolbars and dockwidgets are required to be set visible
-    // otherwise they won't be visible if "Reset To Default Layout" is clicked
-    mMainToolBar->setVisible(true);
-    mToolsToolBar->setVisible(true);
-    mToolSpecificToolBar->setVisible(true);
+Zoomable *MapEditor::zoomable() const
+{
+    if (auto view = currentMapView())
+        return view->zoomable();
+    return nullptr;
+}
 
-    mMiniMapDock->setVisible(true);
-    mPropertiesDock->setVisible(true);
-    mLayerDock->setVisible(true);
-    mObjectsDock->setVisible(true);
-    mTerrainDock->setVisible(true);
-    mTilesetDock->setVisible(true);
-
+void MapEditor::showMessage(const QString &text, int timeout)
+{
+    mMainWindow->statusBar()->showMessage(text, timeout);
 }
 
 void MapEditor::setSelectedTool(AbstractTool *tool)

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -211,40 +211,11 @@ MapEditor::MapEditor(QObject *parent)
 
     mToolManager->createShortcuts(mMainWindow);
 
-    mMainWindow->addToolBar(mMainToolBar);
-    mMainWindow->addToolBar(mToolsToolBar);
-    mMainWindow->addToolBar(mToolSpecificToolBar);
-
     mPropertiesDock = new PropertiesDock(mMainWindow);
     mTemplatesDock->setPropertiesDock(mPropertiesDock);
     mTileStampsDock = new TileStampsDock(mTileStampManager, mMainWindow);
 
-    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mLayerDock);
-    mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mPropertiesDock);
-    mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mMapsDock);
-    mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mUndoDock);
-    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mObjectsDock);
-    mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mTemplatesDock);
-    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mMiniMapDock);
-    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mTerrainDock);
-    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mWangDock);
-    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mTilesetDock);
-    mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mTileStampsDock);
-
-    mMainWindow->tabifyDockWidget(mUndoDock, mMapsDock);
-    mMainWindow->tabifyDockWidget(mTemplatesDock, mTileStampsDock);
-    mMainWindow->tabifyDockWidget(mMiniMapDock, mObjectsDock);
-    mMainWindow->tabifyDockWidget(mObjectsDock, mLayerDock);
-    mMainWindow->tabifyDockWidget(mTerrainDock, mWangDock);
-    mMainWindow->tabifyDockWidget(mWangDock, mTilesetDock);
-
-    // These dock widgets may not be immediately useful to many people, so
-    // they are hidden by default.
-    mMapsDock->setVisible(false);
-    mUndoDock->setVisible(false);
-    mTemplatesDock->setVisible(false);
-    mWangDock->setVisible(false);
-    mTileStampsDock->setVisible(false);
+    resetLayout(); //Adds the dock widgets and toolbars into their default position
 
     mComboBoxProxyModel->setSourceModel(mReversingProxyModel);
     mLayerComboBox->setModel(mComboBoxProxyModel);
@@ -573,9 +544,8 @@ void MapEditor::showMessage(const QString &text, int timeout)
 void MapEditor::resetLayout()
 {
     /*
-     * Re-Arranges dockWidgets and toolBars to default layout
+     * Arranges dockWidgets and toolBars to default layout
     */
-
     QList<QDockWidget*> docks = this->dockWidgets();
     QList<QToolBar*> toolBars = this->toolBars();
 
@@ -586,7 +556,8 @@ void MapEditor::resetLayout()
         mMainWindow->removeToolBar(toolBar);
     }
 
-    //re-Adding Dock Widgets in their Default Position
+    //Adding Dock Widgets and ToolBars in their Default Position
+
     mMainWindow->addToolBar(Qt::TopToolBarArea, mMainToolBar);
     mMainWindow->addToolBar(Qt::TopToolBarArea, mToolsToolBar);
     mMainWindow->addToolBar(Qt::TopToolBarArea, mToolSpecificToolBar);
@@ -610,6 +581,8 @@ void MapEditor::resetLayout()
     mMainWindow->tabifyDockWidget(mTerrainDock, mWangDock);
     mMainWindow->tabifyDockWidget(mWangDock, mTilesetDock);
 
+    // These dock widgets may not be immediately useful to many people, so
+    // they are hidden by default.
     mMapsDock->setVisible(false);
     mUndoDock->setVisible(false);
     mTemplatesDock->setVisible(false);
@@ -626,6 +599,7 @@ void MapEditor::resetLayout()
     mMiniMapDock->setVisible(true);
     mTerrainDock->setVisible(true);
     mTilesetDock->setVisible(true);
+
 }
 
 void MapEditor::setSelectedTool(AbstractTool *tool)

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -543,9 +543,8 @@ void MapEditor::showMessage(const QString &text, int timeout)
 
 void MapEditor::resetLayout()
 {
-    /*
-     * Arranges dockWidgets and toolBars to default layout
-    */
+    // Arranges dockWidgets and toolBars to default layout
+
     QList<QDockWidget*> docks = this->dockWidgets();
     QList<QToolBar*> toolBars = this->toolBars();
 
@@ -556,8 +555,7 @@ void MapEditor::resetLayout()
         mMainWindow->removeToolBar(toolBar);
     }
 
-    //Adding Dock Widgets and ToolBars in their Default Position
-
+    // Adding Dock Widgets and ToolBars in their Default Position
     mMainWindow->addToolBar(Qt::TopToolBarArea, mMainToolBar);
     mMainWindow->addToolBar(Qt::TopToolBarArea, mToolsToolBar);
     mMainWindow->addToolBar(Qt::TopToolBarArea, mToolSpecificToolBar);
@@ -589,6 +587,8 @@ void MapEditor::resetLayout()
     mWangDock->setVisible(false);
     mTileStampsDock->setVisible(false);
 
+    // Toolbars and dockwidgets are required to be set visible
+    // otherwise they won't be visible if "Reset To Default Layout" is clicked
     mMainToolBar->setVisible(true);
     mToolsToolBar->setVisible(true);
     mToolSpecificToolBar->setVisible(true);

--- a/src/tiled/mapeditor.h
+++ b/src/tiled/mapeditor.h
@@ -102,6 +102,8 @@ public:
 
     void showMessage(const QString &text, int timeout = 0);
 
+    void resetLayout();
+
 public slots:
     void setSelectedTool(AbstractTool *tool);
 

--- a/src/tiled/mapeditor.h
+++ b/src/tiled/mapeditor.h
@@ -77,7 +77,7 @@ class MapEditor : public Editor
 
 public:
     explicit MapEditor(QObject *parent = nullptr);
-    ~MapEditor();
+    ~MapEditor() override;
 
     void saveState() override;
     void restoreState() override;
@@ -96,13 +96,13 @@ public:
     StandardActions enabledStandardActions() const override;
     void performStandardAction(StandardAction action) override;
 
+    void resetLayout() override;
+
     MapView *viewForDocument(MapDocument *mapDocument) const;
     MapView *currentMapView() const;
     Zoomable *zoomable() const override;
 
     void showMessage(const QString &text, int timeout = 0);
-
-    void resetLayout();
 
 public slots:
     void setSelectedTool(AbstractTool *tool);

--- a/src/tiled/tileseteditor.cpp
+++ b/src/tiled/tileseteditor.cpp
@@ -173,21 +173,9 @@ TilesetEditor::TilesetEditor(QObject *parent)
     , mCurrentTilesetDocument(nullptr)
     , mCurrentTile(nullptr)
 {
-    mTerrainDock->setVisible(false);
-    mTileCollisionDock->setVisible(false);
-    mWangDock->setVisible(false);
-
     mMainWindow->setDockOptions(mMainWindow->dockOptions() | QMainWindow::GroupedDragging);
     mMainWindow->setDockNestingEnabled(true);
     mMainWindow->setCentralWidget(mWidgetStack);
-    mMainWindow->addToolBar(mMainToolBar);
-    mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mPropertiesDock);
-    mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mUndoDock);
-    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mTerrainDock);
-    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mTileCollisionDock);
-    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mWangDock);
-
-    mUndoDock->setVisible(false);
 
     QAction *editTerrain = mTerrainDock->toggleViewAction();
     QAction *editCollision = mTileCollisionDock->toggleViewAction();
@@ -219,6 +207,8 @@ TilesetEditor::TilesetEditor(QObject *parent)
     mTilesetToolBar->addAction(mShowAnimationEditor);
 
     mMainWindow->statusBar()->addPermanentWidget(mZoomComboBox);
+
+    resetLayout();
 
     connect(mMainWindow, &TilesetEditorWindow::urlsDropped, this, &TilesetEditor::addTiles);
 
@@ -457,6 +447,32 @@ void TilesetEditor::performStandardAction(StandardAction action)
         mTileCollisionDock->delete_();
         break;
     }
+}
+
+void TilesetEditor::resetLayout()
+{
+    // Remove dock widgets (this also hides them)
+    const QList<QDockWidget*> dockWidgets = this->dockWidgets();
+    for (auto dockWidget : dockWidgets)
+        mMainWindow->removeDockWidget(dockWidget);
+
+    // Show Properties dock by default
+    mPropertiesDock->setVisible(true);
+
+    // Make sure all toolbars are visible
+    const QList<QToolBar*> toolBars = this->toolBars();
+    for (auto toolBar : toolBars)
+        toolBar->setVisible(true);
+
+    mMainWindow->addToolBar(mMainToolBar);
+    mMainWindow->addToolBar(mTilesetToolBar);
+
+    mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mPropertiesDock);
+    mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, mUndoDock);
+
+    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mTerrainDock);
+    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mTileCollisionDock);
+    mMainWindow->addDockWidget(Qt::RightDockWidgetArea, mWangDock);
 }
 
 TilesetView *TilesetEditor::currentTilesetView() const

--- a/src/tiled/tileseteditor.h
+++ b/src/tiled/tileseteditor.h
@@ -77,6 +77,8 @@ public:
     StandardActions enabledStandardActions() const override;
     void performStandardAction(StandardAction action) override;
 
+    void resetLayout() override;
+
     TilesetView *currentTilesetView() const;
     Tileset *currentTileset() const;
     Zoomable *zoomable() const override;


### PR DESCRIPTION
This allows the user to reset the MapEditor's widget layout to default layout setting that tiled comes with, without requiring them to restart the Tiled.