### PR TITLE
Fix broken tileset inside template

### DIFF
--- a/src/tiled/brokenlinks.h
+++ b/src/tiled/brokenlinks.h
@@ -45,6 +45,7 @@ class TilesetDocument;
 
 enum BrokenLinkType {
     MapTilesetReference,
+    ObjectTemplateTilesetReference,
     TilesetTileImageSource,
     TilesetImageSource,
     ObjectTemplateReference,
@@ -96,8 +97,6 @@ private slots:
     void tilesetAdded(int index, Tileset *tileset);
     void tilesetRemoved(Tileset *tileset);
     void tilesetReplaced(int index, Tileset *newTileset, Tileset *oldTileset);
-
-    void objectTemplateReplaced();
 
 private:
     void connectToTileset(const SharedTileset &tileset);

--- a/src/tiled/documentmanager.h
+++ b/src/tiled/documentmanager.h
@@ -38,6 +38,7 @@ class QTabBar;
 namespace Tiled {
 
 class FileSystemWatcher;
+class ObjectTemplate;
 
 namespace Internal {
 
@@ -207,6 +208,8 @@ signals:
     void fileOpenRequested();
     void fileOpenRequested(const QString &path);
     void fileSaveRequested();
+    void templateOpenRequested(const ObjectTemplate *objectTemplate);
+    void templateTilesetReplaceRequested();
 
     /**
      * Emitted when the current displayed map document changed.

--- a/src/tiled/documentmanager.h
+++ b/src/tiled/documentmanager.h
@@ -208,8 +208,8 @@ signals:
     void fileOpenRequested();
     void fileOpenRequested(const QString &path);
     void fileSaveRequested();
-    void templateOpenRequested(const ObjectTemplate *objectTemplate);
-    void templateTilesetReplaceRequested();
+    void templateOpenRequested(const QString &path);
+    void templateTilesetReplaced();
 
     /**
      * Emitted when the current displayed map document changed.

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -264,6 +264,11 @@ MapEditor::MapEditor(QObject *parent)
     connect(mTilesetDock, &TilesetDock::stampCaptured, this, &MapEditor::setStamp);
     connect(mTilesetDock, &TilesetDock::localFilesDropped, this, &MapEditor::filesDroppedOnTilesetDock);
     connect(mTemplatesDock, &TemplatesDock::currentTemplateChanged, mToolManager, &ToolManager::setObjectTemplate);
+    connect(DocumentManager::instance(), &DocumentManager::templateOpenRequested,
+            mTemplatesDock, &TemplatesDock::openTemplate);
+
+    connect(mTemplatesDock, &TemplatesDock::templateTilesetReplaced,
+            DocumentManager::instance(), &DocumentManager::templateTilesetReplaceRequested);
 
     connect(mStampBrush, &StampBrush::stampChanged, this, &MapEditor::setStamp);
     connect(mBucketFillTool, &BucketFillTool::stampChanged, this, &MapEditor::setStamp);

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -268,7 +268,7 @@ MapEditor::MapEditor(QObject *parent)
             mTemplatesDock, &TemplatesDock::openTemplate);
 
     connect(mTemplatesDock, &TemplatesDock::templateTilesetReplaced,
-            DocumentManager::instance(), &DocumentManager::templateTilesetReplaceRequested);
+            DocumentManager::instance(), &DocumentManager::templateTilesetReplaced);
 
     connect(mStampBrush, &StampBrush::stampChanged, this, &MapEditor::setStamp);
     connect(mBucketFillTool, &BucketFillTool::stampChanged, this, &MapEditor::setStamp);

--- a/src/tiled/templatesdock.cpp
+++ b/src/tiled/templatesdock.cpp
@@ -33,6 +33,7 @@
 #include "preferences.h"
 #include "propertiesdock.h"
 #include "replacetileset.h"
+#include "templatemanager.h"
 #include "tilesetmanager.h"
 #include "tilesetdocument.h"
 #include "tmxmapformat.h"
@@ -186,6 +187,11 @@ TemplatesDock::~TemplatesDock()
     delete mDummyMapDocument;
 }
 
+void TemplatesDock::openTemplate(const ObjectTemplate *objectTemplate)
+{
+    setTemplate(TemplateManager::instance()->loadObjectTemplate(objectTemplate->fileName()));
+}
+
 void TemplatesDock::setSelectedTool(AbstractTool *tool)
 {
     mMapScene->disableSelectedTool();
@@ -275,13 +281,16 @@ void TemplatesDock::checkTileset()
 
     auto tileset = cell.tileset();
 
+    QString templateName = QFileInfo(mObjectTemplate->fileName()).fileName();
+
     if (tileset->imageStatus() == LoadingError) {
         mFixTilesetButton->setVisible(true);
         mFixTilesetButton->setText(tr("Open Tileset"));
         mFixTilesetButton->setToolTip(tileset->imageSource().fileName());
 
         mDescriptionLabel->setVisible(true);
-        mDescriptionLabel->setText(tr("Couldn't find: \"%1\"").arg(tileset->imageSource().fileName()));
+        mDescriptionLabel->setText(tr("%1 :Couldn't find \"%2\"").arg(templateName,
+                                                                      tileset->imageSource().fileName()));
         mDescriptionLabel->setToolTip(tileset->imageSource().fileName());
     } else if (!tileset->fileName().isEmpty() && tileset->status() == LoadingError) {
         mFixTilesetButton->setVisible(true);
@@ -289,7 +298,8 @@ void TemplatesDock::checkTileset()
         mFixTilesetButton->setToolTip(tileset->fileName());
 
         mDescriptionLabel->setVisible(true);
-        mDescriptionLabel->setText(tr("Couldn't find: \"%1\"").arg(tileset->fileName()));
+        mDescriptionLabel->setText(tr("%1 :Couldn't find \"%2\"").arg(templateName,
+                                                                      tileset->fileName()));
         mDescriptionLabel->setToolTip(tileset->fileName());
     } else {
         mFixTilesetButton->setVisible(false);
@@ -408,6 +418,7 @@ void TemplatesDock::fixTileset()
         }
     }
 }
+
 TemplatesView::TemplatesView(QWidget *parent)
     : QTreeView(parent)
 {

--- a/src/tiled/templatesdock.h
+++ b/src/tiled/templatesdock.h
@@ -62,7 +62,8 @@ signals:
     void templateTilesetReplaced();
 
 public slots:
-    void openTemplate(const ObjectTemplate *objectTemplate);
+    void openTemplate(const QString &path);
+    void bringToFront();
 
 private slots:
     void setSelectedTool(AbstractTool *tool);
@@ -107,6 +108,7 @@ class TemplatesView : public QTreeView
 public:
     QSize sizeHint() const override;
     TemplatesView(QWidget *parent = nullptr);
+    void setSelectedTemplate(const QString &path);
 
 signals:
     void currentTemplateChanged(ObjectTemplate *objectTemplate);

--- a/src/tiled/templatesdock.h
+++ b/src/tiled/templatesdock.h
@@ -59,6 +59,10 @@ signals:
     void currentTemplateChanged(ObjectTemplate *objectTemplate);
     void templateEdited(const ObjectTemplate *objectTemplate);
     void setTile(Tile *tile);
+    void templateTilesetReplaced();
+
+public slots:
+    void openTemplate(const ObjectTemplate *objectTemplate);
 
 private slots:
     void setSelectedTool(AbstractTool *tool);

--- a/src/tiled/templatesdock.h
+++ b/src/tiled/templatesdock.h
@@ -25,6 +25,9 @@
 #include <QTreeView>
 #include <QAction>
 
+class QPushButton;
+class QLabel;
+
 namespace Tiled {
 
 class ObjectTemplate;
@@ -60,6 +63,7 @@ signals:
 private slots:
     void setSelectedTool(AbstractTool *tool);
     void setTemplate(ObjectTemplate *objectTemplate);
+    void checkTileset();
 
     void undo();
     void redo();
@@ -73,12 +77,15 @@ protected:
 
 private:
     void retranslateUi();
+    void fixTileset();
 
     TemplatesView *mTemplatesView;
 
     QAction *mChooseDirectory;
     QAction *mUndoAction;
     QAction *mRedoAction;
+    QPushButton *mFixTilesetButton;
+    QLabel *mDescriptionLabel;
 
     MapDocument *mDummyMapDocument;
     MapScene *mMapScene;


### PR DESCRIPTION
This pull request aims to enable fixing bad links inside templates (#1732).

Tileset bad reference and tileset bad image reference can be fixed from the templates view independent from the map. I provided a button and a label that shows the bad file link to allow fixing things and update the template and consequently the instances.

![fixing](https://user-images.githubusercontent.com/7282243/33732320-d074e9dc-db8e-11e7-8268-9d775a1e0024.png)

This works without using BrokenLinks at all, but there is still broken links integration which checks if there is any problem with any template (bad tileset link or image) and allows opening the template in the dock where we can carry on with the fixes.

If a tileset document is already opened then and we open it through the templates dock to fix the image, a new tab is opened for the same tileset document, I think the shared tileset pointers from the opened document and the tileset inside the template are not the same, so the document manager will open two instances of the same tileset document which won't be connected internally.

Testing and feedback on the UI and the flow are welcome.