### PR TITLE
Fix return in Tileset::orientationToString

### DIFF
--- a/src/libtiled/tileset.cpp
+++ b/src/libtiled/tileset.cpp
@@ -786,6 +786,7 @@ QString Tileset::orientationToString(Tileset::Orientation orientation)
     case Tileset::Isometric:
         return QLatin1String("isometric");
     }
+    return QString();
 }
 
 Tileset::Orientation Tileset::orientationFromString(const QString &string)


### PR DESCRIPTION
This part should not be reached in theory.
Let's return an empty QString anyways to be on the save side and to make
the compiler happy.

Fixes 'Program returns random data in a function'.