### PR TITLE
Jsonformat

### DIFF
--- a/docs/reference/json-map-format.rst
+++ b/docs/reference/json-map-format.rst
@@ -29,7 +29,7 @@ Map
 | orientation       | string   | ``orthogonal``, ``isometric``, ``staggered`` or          |
 |                   |          | ``hexagonal``                                            |
 +-------------------+----------+----------------------------------------------------------+
-| properties        | object   | String key-value pairs                                   |
+| properties        | array    | A list of properties (name, value, type).                |
 +-------------------+----------+----------------------------------------------------------+
 | renderorder       | string   | Rendering direction (orthogonal maps only)               |
 +-------------------+----------+----------------------------------------------------------+
@@ -59,11 +59,17 @@ Map Example
       "layers":[ ],
       "nextobjectid":1,
       "orientation":"orthogonal",
-      "properties":
-      {
-        "mapProperty1":"one",
-        "mapProperty2":"two"
-      },
+      "properties":[
+        {
+          "name":"mapProperty1",
+          "type":"one",
+          "value":"string"
+        },
+        {
+          "name":"mapProperty2",
+          "type":"two",
+          "value":"string"
+        }],
       "renderorder":"right-down",
       "tileheight":32,
       "tilesets":[ ],
@@ -95,7 +101,7 @@ Layer
 +--------------+----------+---------------------------------------------------------------+
 | opacity      | float    | Value between 0 and 1                                         |
 +--------------+----------+---------------------------------------------------------------+
-| properties   | object   | string key-value pairs.                                       |
+| properties   | array    | A list of properties (name, value, type).                     |
 +--------------+----------+---------------------------------------------------------------+
 | type         | string   | ``tilelayer``, ``objectgroup``, ``imagelayer`` or ``group``   |
 +--------------+----------+---------------------------------------------------------------+
@@ -118,10 +124,12 @@ Tile Layer Example
       "height":4,
       "name":"ground",
       "opacity":1,
-      "properties":
-         {
-          "tileLayerProp":"1"
-         },
+      "properties":[
+        {
+          "name":"tileLayerProp",
+          "type":"int",
+          "value":1
+        }],
       "type":"tilelayer",
       "visible":true,
       "width":4,
@@ -140,10 +148,12 @@ Object Layer Example
       "name":"people",
       "objects":[ ],
       "opacity":1,
-      "properties":
-      {
-        "layerProp1": "someStringValue"
-      },
+      "properties":[
+        {
+          "name":"layerProp1",
+          "type":"string",
+          "value":"someStringValue"
+        }],
       "type":"objectgroup",
       "visible":true,
       "width":0,
@@ -175,7 +185,7 @@ Object
 +--------------+----------+----------------------------------------------+
 | polyline     | array    | A list of x,y coordinates in pixels          |
 +--------------+----------+----------------------------------------------+
-| properties   | object   | String key-value pairs                       |
+| properties   | array    | A list of properties (name, value, type).    |
 +--------------+----------+----------------------------------------------+
 | rotation     | float    | Angle in degrees clockwise                   |
 +--------------+----------+----------------------------------------------+
@@ -202,10 +212,12 @@ Object Example
       "height":0,
       "id":1,
       "name":"villager",
-      "properties":
-      {
-        "hp":"12"
-      },
+      "properties":[
+        {
+          "name":"hp",
+          "type":"int",
+          "value":12
+        }],
       "rotation":0,
       "type":"npc",
       "visible":true,
@@ -393,9 +405,7 @@ Tileset
 +------------------+----------+-----------------------------------------------------+
 | name             | string   | Name given to this tileset                          |
 +------------------+----------+-----------------------------------------------------+
-| properties       | object   | String key-value pairs                              |
-+------------------+----------+-----------------------------------------------------+
-| propertytypes    | object   | String key-value pairs                              |
+| properties       | array    | A list of properties (name, value, type).           |
 +------------------+----------+-----------------------------------------------------+
 | spacing          | int      | Spacing between adjacent tiles in image (pixels)    |
 +------------------+----------+-----------------------------------------------------+
@@ -407,10 +417,7 @@ Tileset
 +------------------+----------+-----------------------------------------------------+
 | tileoffset       | object   | See :ref:`tmx-tileoffset` (optional)                |
 +------------------+----------+-----------------------------------------------------+
-| tileproperties   | object   | Per-tile properties, indexed by gid as string       |
-+------------------+----------+-----------------------------------------------------+
-| tiles            | object   | Mapping from tile ID to :ref:`tile <json-tile>`     |
-|                  |          | (optional)                                          |
+| tiles            | array    | List of :ref:`tile <json-tile>` (optional)          |
 +------------------+----------+-----------------------------------------------------+
 | tilewidth        | int      | Maximum width of tiles in this set                  |
 +------------------+----------+-----------------------------------------------------+
@@ -430,14 +437,12 @@ Tileset Example
              "imagewidth":640,
              "margin":3,
              "name":"",
-             "properties":
+             "properties":[
                {
-                 "myProperty1":"myProperty1_value"
-               },
-             "propertytypes":
-               {
-                 "myProperty1":"string"
-               },
+                 "name":"myProperty1",
+                 "type":"string",
+                 "value":"myProperty1_value"
+               }],
              "spacing":1,
              "tilecount":266,
              "tileheight":32,
@@ -449,11 +454,13 @@ Tileset Example
 Tile (Definition)
 ~~~~~~~~~~~~~~~~~
 
-+-----------+---------+--------------------------------------------+
-| Field     | Type    | Description                                |
-+===========+=========+============================================+
-| terrain   | array   | index of terrain for each corner of tile   |
-+-----------+---------+--------------------------------------------+
++------------+---------+--------------------------------------------+
+| Field      | Type    | Description                                |
++============+=========+============================================+
+| terrain    | array   | index of terrain for each corner of tile   |
++------------+---------+--------------------------------------------+
+| properties | array   | A list of properties (name, value, type).  |
++------------+---------+--------------------------------------------+
 
 A tileset that associates information with each tile, like its image
 path or terrain type, may include a "tiles" JSON object. Each key
@@ -470,17 +477,35 @@ Example:
 
     "tiles":
     {
-      "0":
       {
-        "terrain":[0, 0, 0, 0]
+        "terrain":[0, 0, 0, 0],
+        "properties":[
+          {
+            "name":"myProperty1",
+            "type":"string",
+            "value":"myProperty1_value"
+          }],
+        "tile":0
       },
-      "11":
       {
-        "terrain":[0, 1, 0, 1]
+        "terrain":[0, 1, 0, 1],
+        "properties":[
+          {
+            "name":"myProperty2",
+            "type":"string",
+            "value":"myProperty2_value"
+          }],
+        "tile":11
       },
-      "12":
       {
-        "terrain":[1, 1, 1, 1]
+        "terrain":[1, 1, 1, 1],
+        "properties":[
+          {
+            "name":"myProperty3",
+            "type":"string",
+            "value":"myProperty3_value"
+          }],
+        "tile":12
       }
     }
 
@@ -504,7 +529,7 @@ Example:
     "terrains":[
     {
       "name":"ground",
-        "tile":0
+      "tile":0
     },
     {
       "name":"chasm",

--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -232,7 +232,7 @@ QVariant MapToVariantConverter::toVariant(const Tileset &tileset,
         }
 
         if (!tileVariant.empty()) {
-            tileVariant[QLatin1String("tile")] = tile->id();
+            tileVariant[QLatin1String("id")] = tile->id();
             tilesVariant << tileVariant;
         }
     }

--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -582,7 +582,7 @@ void MapToVariantConverter::addProperties(QVariantMap &variantMap,
     if (properties.isEmpty())
         return;
 
-    QVariantList propertyListVariant;
+    QVariantList propertiesVariantList;
 
     Properties::const_iterator it = properties.constBegin();
     Properties::const_iterator it_end = properties.constEnd();
@@ -590,12 +590,12 @@ void MapToVariantConverter::addProperties(QVariantMap &variantMap,
         int type = it.value().userType();
         const QVariant value = toExportValue(it.value(), mMapDir);
 
-        QVariantMap propertyTypeVariantMap;
-        propertyTypeVariantMap[QLatin1String("name")] = it.key();
-        propertyTypeVariantMap[QLatin1String("value")] = value;
-        propertyTypeVariantMap[QLatin1String("type")] = typeToName(type);
-        propertyListVariant << propertyTypeVariantMap;
+        QVariantMap propertyVariantMap;
+        propertyVariantMap[QLatin1String("name")] = it.key();
+        propertyVariantMap[QLatin1String("value")] = value;
+        propertyVariantMap[QLatin1String("type")] = typeToName(type);
+        propertiesVariantList << propertyVariantMap;
     }
 
-    variantMap[QLatin1String("properties")] = propertyListVariant;
+    variantMap[QLatin1String("properties")] = propertiesVariantList;
 }

--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -195,9 +195,7 @@ QVariant MapToVariantConverter::toVariant(const Tileset &tileset,
         const Properties properties = tile->properties();
         QVariantMap tileVariant;
 
-        if (!properties.isEmpty()) {
-            tileVariant[QLatin1String("properties")] = toVariant(properties);
-        }
+        addProperties(tileVariant, properties);
 
         if (!tile->type().isEmpty())
             tileVariant[QLatin1String("type")] = tile->type();
@@ -256,24 +254,6 @@ QVariant MapToVariantConverter::toVariant(const Tileset &tileset,
     }
 
     return tilesetVariant;
-}
-
-QVariant MapToVariantConverter::toVariant(const Properties &properties) const
-{
-    QVariantList propertyListVariant;
-
-    Properties::const_iterator it = properties.constBegin();
-    Properties::const_iterator it_end = properties.constEnd();
-    for (; it != it_end; ++it) {
-        QVariantMap propertyTypeVariantMap;
-        propertyTypeVariantMap[QLatin1String("name")] = it.key();
-        const QVariant value = toExportValue(it.value(), mMapDir);
-        propertyTypeVariantMap[QLatin1String("value")] = value;
-        propertyTypeVariantMap[QLatin1String("type")] = typeToName(it.value().userType());
-        propertyListVariant << propertyTypeVariantMap;
-    }
-
-    return propertyListVariant;
 }
 
 QVariant MapToVariantConverter::toVariant(const QList<Layer *> &layers,
@@ -601,8 +581,7 @@ void MapToVariantConverter::addProperties(QVariantMap &variantMap,
     if (properties.isEmpty())
         return;
 
-    QVariantMap propertiesMap;
-    QVariantMap propertyTypesMap;
+    QVariantList propertyListVariant;
 
     Properties::const_iterator it = properties.constBegin();
     Properties::const_iterator it_end = properties.constEnd();
@@ -610,10 +589,12 @@ void MapToVariantConverter::addProperties(QVariantMap &variantMap,
         int type = it.value().userType();
         const QVariant value = toExportValue(it.value(), mMapDir);
 
-        propertiesMap[it.key()] = value;
-        propertyTypesMap[it.key()] = typeToName(type);
+        QVariantMap propertyTypeVariantMap;
+        propertyTypeVariantMap[QLatin1String("name")] = it.key();
+        propertyTypeVariantMap[QLatin1String("value")] = value;
+        propertyTypeVariantMap[QLatin1String("type")] = typeToName(type);
+        propertyListVariant << propertyTypeVariantMap;
     }
 
-    variantMap[QLatin1String("properties")] = propertiesMap;
-    variantMap[QLatin1String("propertytypes")] = propertyTypesMap;
+    variantMap[QLatin1String("properties")] = propertyListVariant;
 }

--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -126,9 +126,10 @@ QVariant MapToVariantConverter::toVariant(const Tileset &tileset,
 {
     QVariantMap tilesetVariant;
 
-    tilesetVariant[QLatin1String("version")] = 1.2;
     if (firstGid > 0)
         tilesetVariant[QLatin1String("firstgid")] = firstGid;
+    else
+        tilesetVariant[QLatin1String("version")] = 1.2; // external tileset
 
     const QString &fileName = tileset.fileName();
     if (!fileName.isEmpty()) {

--- a/src/libtiled/maptovariantconverter.h
+++ b/src/libtiled/maptovariantconverter.h
@@ -56,8 +56,8 @@ public:
 
 private:
     QVariant toVariant(const Tileset &tileset, int firstGid) const;
-    QVariant toVariant(const Properties &properties) const;
-    QVariant propertyTypesToVariant(const Properties &properties) const;
+    QVariant toVariant(const int tileid, const Properties &properties) const;
+    QVariant propertyTypesToVariant(const int tileid, const Properties &properties) const;
     QVariant toVariant(const QList<Layer*> &layers, Map::LayerDataFormat format) const;
     QVariant toVariant(const TileLayer &tileLayer, Map::LayerDataFormat format) const;
     QVariant toVariant(const ObjectGroup &objectGroup) const;

--- a/src/libtiled/maptovariantconverter.h
+++ b/src/libtiled/maptovariantconverter.h
@@ -56,7 +56,6 @@ public:
 
 private:
     QVariant toVariant(const Tileset &tileset, int firstGid) const;
-    QVariant toVariant(const Properties &properties) const;
     QVariant toVariant(const QList<Layer*> &layers, Map::LayerDataFormat format) const;
     QVariant toVariant(const TileLayer &tileLayer, Map::LayerDataFormat format) const;
     QVariant toVariant(const ObjectGroup &objectGroup) const;

--- a/src/libtiled/maptovariantconverter.h
+++ b/src/libtiled/maptovariantconverter.h
@@ -56,8 +56,7 @@ public:
 
 private:
     QVariant toVariant(const Tileset &tileset, int firstGid) const;
-    QVariant toVariant(const int tileid, const Properties &properties) const;
-    QVariant propertyTypesToVariant(const int tileid, const Properties &properties) const;
+    QVariant toVariant(const Properties &properties) const;
     QVariant toVariant(const QList<Layer*> &layers, Map::LayerDataFormat format) const;
     QVariant toVariant(const TileLayer &tileLayer, Map::LayerDataFormat format) const;
     QVariant toVariant(const ObjectGroup &objectGroup) const;

--- a/src/libtiled/varianttomapconverter.cpp
+++ b/src/libtiled/varianttomapconverter.cpp
@@ -144,6 +144,15 @@ ObjectTemplate *VariantToMapConverter::toObjectTemplate(const QVariant &variant,
     return toObjectTemplate(variant);
 }
 
+QVariant VariantToMapConverter::toType(const QVariant &propertyType, const QVariant &propertyValue)
+{
+    int type = nameToType(propertyType.toString());
+    if (type == QVariant::Invalid)
+        type = QVariant::String;
+    const QVariant value = fromExportValue(propertyValue, type, mMapDir);
+    return value;
+}
+
 Properties VariantToMapConverter::toProperties(const QVariant &propertiesVariant,
                                                const QVariant &propertyTypesVariant) const
 {
@@ -200,6 +209,7 @@ SharedTileset VariantToMapConverter::toTileset(const QVariant &variant)
     const int tileOffsetY = tileOffset[QLatin1String("y")].toInt();
     const int columns = variantMap[QLatin1String("columns")].toInt();
     const QString bgColor = variantMap[QLatin1String("backgroundcolor")].toString();
+    const QString version = variantMap[QLatin1String("version")].toString();
 
     if (tileWidth <= 0 || tileHeight <= 0 ||
             (firstGid == 0 && !mReadingExternalTileset)) {
@@ -255,72 +265,142 @@ SharedTileset VariantToMapConverter::toTileset(const QVariant &variant)
         terrain->setProperties(extractProperties(terrainMap));
     }
 
-    // Read tiles (everything except their properties)
-    const QVariantMap tilesVariantMap = variantMap[QLatin1String("tiles")].toMap();
-    QVariantMap::const_iterator it = tilesVariantMap.constBegin();
-    for (; it != tilesVariantMap.end(); ++it) {
-        bool ok;
-        const int tileId = it.key().toInt();
-        if (tileId < 0) {
-            mError = tr("Invalid (negative) tile id: %1").arg(tileId);
-            return SharedTileset();
-        }
+    if(version.length() == 0)
+    {
+        // Read tiles (everything except their properties)
+        const QVariantMap tilesVariantMap = variantMap[QLatin1String("tiles")].toMap();
+        QVariantMap::const_iterator it = tilesVariantMap.constBegin();
+        for (; it != tilesVariantMap.end(); ++it) {
+            bool ok;
+            const int tileId = it.key().toInt();
+            if (tileId < 0) {
+                mError = tr("Invalid (negative) tile id: %1").arg(tileId);
+                return SharedTileset();
+            }
 
-        Tile *tile = tileset->findOrCreateTile(tileId);
+            Tile *tile = tileset->findOrCreateTile(tileId);
 
-        const QVariantMap tileVar = it.value().toMap();
+            const QVariantMap tileVar = it.value().toMap();
 
-        tile->setType(tileVar[QLatin1String("type")].toString());
+            tile->setType(tileVar[QLatin1String("type")].toString());
 
-        QList<QVariant> terrains = tileVar[QLatin1String("terrain")].toList();
-        if (terrains.count() == 4) {
-            for (int i = 0; i < 4; ++i) {
-                int terrainId = terrains.at(i).toInt(&ok);
-                if (ok && terrainId >= 0 && terrainId < tileset->terrainCount())
-                    tile->setCornerTerrainId(i, terrainId);
+            QList<QVariant> terrains = tileVar[QLatin1String("terrain")].toList();
+            if (terrains.count() == 4) {
+                for (int i = 0; i < 4; ++i) {
+                    int terrainId = terrains.at(i).toInt(&ok);
+                    if (ok && terrainId >= 0 && terrainId < tileset->terrainCount())
+                        tile->setCornerTerrainId(i, terrainId);
+                }
+            }
+
+            qreal probability = tileVar[QLatin1String("probability")].toDouble(&ok);
+            if (ok)
+                tile->setProbability(probability);
+
+            imageVariant = tileVar[QLatin1String("image")];
+            if (!imageVariant.isNull()) {
+                const QUrl imagePath = toUrl(imageVariant.toString(), mMapDir);
+                tileset->setTileImage(tile, QPixmap(imagePath.toLocalFile()), imagePath);
+            }
+
+            QVariantMap objectGroupVariant = tileVar[QLatin1String("objectgroup")].toMap();
+            if (!objectGroupVariant.isEmpty()) {
+                ObjectGroup *objectGroup = toObjectGroup(objectGroupVariant);
+                if (objectGroup)
+                    objectGroup->setProperties(extractProperties(objectGroupVariant));
+                tile->setObjectGroup(objectGroup);
+            }
+
+            QVariantList frameList = tileVar[QLatin1String("animation")].toList();
+            if (!frameList.isEmpty()) {
+                QVector<Frame> frames(frameList.size());
+                for (int i = frameList.size() - 1; i >= 0; --i) {
+                    const QVariantMap frameVariantMap = frameList[i].toMap();
+                    Frame &frame = frames[i];
+                    frame.tileId = frameVariantMap[QLatin1String("tileid")].toInt();
+                    frame.duration = frameVariantMap[QLatin1String("duration")].toInt();
+                }
+                tile->setFrames(frames);
             }
         }
 
-        qreal probability = tileVar[QLatin1String("probability")].toDouble(&ok);
-        if (ok)
-            tile->setProbability(probability);
-
-        imageVariant = tileVar[QLatin1String("image")];
-        if (!imageVariant.isNull()) {
-            const QUrl imagePath = toUrl(imageVariant.toString(), mMapDir);
-            tileset->setTileImage(tile, QPixmap(imagePath.toLocalFile()), imagePath);
-        }
-
-        QVariantMap objectGroupVariant = tileVar[QLatin1String("objectgroup")].toMap();
-        if (!objectGroupVariant.isEmpty()) {
-            ObjectGroup *objectGroup = toObjectGroup(objectGroupVariant);
-            if (objectGroup)
-                objectGroup->setProperties(extractProperties(objectGroupVariant));
-            tile->setObjectGroup(objectGroup);
-        }
-
-        QVariantList frameList = tileVar[QLatin1String("animation")].toList();
-        if (!frameList.isEmpty()) {
-            QVector<Frame> frames(frameList.size());
-            for (int i = frameList.size() - 1; i >= 0; --i) {
-                const QVariantMap frameVariantMap = frameList[i].toMap();
-                Frame &frame = frames[i];
-                frame.tileId = frameVariantMap[QLatin1String("tileid")].toInt();
-                frame.duration = frameVariantMap[QLatin1String("duration")].toInt();
-            }
-            tile->setFrames(frames);
+        // Read tile properties
+        QVariantMap propertiesVariantMap = variantMap[QLatin1String("tileproperties")].toMap();
+        QVariantMap propertyTypesVariantMap = variantMap[QLatin1String("tilepropertytypes")].toMap();
+        for (it = propertiesVariantMap.constBegin(); it != propertiesVariantMap.constEnd(); ++it) {
+            const int tileId = it.key().toInt();
+            const QVariant propertiesVar = it.value();
+            const QVariant propertyTypesVar = propertyTypesVariantMap.value(it.key());
+            const Properties properties = toProperties(propertiesVar, propertyTypesVar);
+            tileset->findOrCreateTile(tileId)->setProperties(properties);
         }
     }
+    else if(version.compare(QLatin1String("1.2")) == 0)
+    {
+        // Read tiles (everything including their properties)
+        const QVariantList tilesVariantList = variantMap[QLatin1String("tiles")].toList();
+        for (int i = 0; i < tilesVariantList.count(); ++i) {
+            const QVariantMap tileVar = tilesVariantList[i].toMap();
+            const int tileId  = tileVar[QLatin1String("tile")].toInt();
+            if (tileId < 0) {
+                mError = tr("Invalid (negative) tile id: %1").arg(tileId);
+                return SharedTileset();
+            }
+            Tile *tile = tileset->findOrCreateTile(tileId);
+            tile->setType(tileVar[QLatin1String("type")].toString());
 
-    // Read tile properties
-    QVariantMap propertiesVariantMap = variantMap[QLatin1String("tileproperties")].toMap();
-    QVariantMap propertyTypesVariantMap = variantMap[QLatin1String("tilepropertytypes")].toMap();
-    for (it = propertiesVariantMap.constBegin(); it != propertiesVariantMap.constEnd(); ++it) {
-        const int tileId = it.key().toInt();
-        const QVariant propertiesVar = it.value();
-        const QVariant propertyTypesVar = propertyTypesVariantMap.value(it.key());
-        const Properties properties = toProperties(propertiesVar, propertyTypesVar);
-        tileset->findOrCreateTile(tileId)->setProperties(properties);
+            Properties properties;
+            QVariantList propertiesVariantList = tileVar[QLatin1String("properties")].toList();
+            if (!propertiesVariantList.isEmpty()) {
+                for (int j = 0; j < propertiesVariantList.count(); ++j) {
+                    const QVariantMap propertyVariantMap = propertiesVariantList[j].toMap();
+                    const QVariant propertyName = propertyVariantMap[QLatin1String("name")].toString();
+                    const QVariant propertyType = propertyVariantMap[QLatin1String("type")].toString();
+                    const QVariant propertyValue = propertyVariantMap[QLatin1String("value")];
+                    properties[propertyName.toString()] = toType(propertyType, propertyValue);
+                }
+                tile->setProperties(properties);
+            }
+            bool ok;
+            QList<QVariant> terrains = tileVar[QLatin1String("terrain")].toList();
+            if (terrains.count() == 4) {
+                for (int j = 0; j < 4; ++j) {
+                    int terrainId = terrains.at(j).toInt(&ok);
+                    if (ok && terrainId >= 0 && terrainId < tileset->terrainCount())
+                        tile->setCornerTerrainId(j, terrainId);
+                }
+            }
+
+            qreal probability = tileVar[QLatin1String("probability")].toDouble(&ok);
+            if (ok)
+                tile->setProbability(probability);
+
+            imageVariant = tileVar[QLatin1String("image")];
+            if (!imageVariant.isNull()) {
+                const QUrl imagePath = toUrl(imageVariant.toString(), mMapDir);
+                tileset->setTileImage(tile, QPixmap(imagePath.toLocalFile()), imagePath);
+            }
+
+            QVariantMap objectGroupVariant = tileVar[QLatin1String("objectgroup")].toMap();
+            if (!objectGroupVariant.isEmpty()) {
+                ObjectGroup *objectGroup = toObjectGroup(objectGroupVariant);
+                if (objectGroup)
+                    objectGroup->setProperties(extractProperties(objectGroupVariant));
+                tile->setObjectGroup(objectGroup);
+            }
+
+            QVariantList frameList = tileVar[QLatin1String("animation")].toList();
+            if (!frameList.isEmpty()) {
+                QVector<Frame> frames(frameList.size());
+                for (int i = frameList.size() - 1; i >= 0; --i) {
+                    const QVariantMap frameVariantMap = frameList[i].toMap();
+                    Frame &frame = frames[i];
+                    frame.tileId = frameVariantMap[QLatin1String("tileid")].toInt();
+                    frame.duration = frameVariantMap[QLatin1String("duration")].toInt();
+                }
+                tile->setFrames(frames);
+            }
+        }
     }
 
     if (!mReadingExternalTileset)

--- a/src/libtiled/varianttomapconverter.cpp
+++ b/src/libtiled/varianttomapconverter.cpp
@@ -144,15 +144,6 @@ ObjectTemplate *VariantToMapConverter::toObjectTemplate(const QVariant &variant,
     return toObjectTemplate(variant);
 }
 
-QVariant VariantToMapConverter::toType(const QVariant &propertyType, const QVariant &propertyValue)
-{
-    int type = nameToType(propertyType.toString());
-    if (type == QVariant::Invalid)
-        type = QVariant::String;
-    const QVariant value = fromExportValue(propertyValue, type, mMapDir);
-    return value;
-}
-
 Properties VariantToMapConverter::toProperties(const QVariant &propertiesVariant,
                                                const QVariant &propertyTypesVariant) const
 {

--- a/src/libtiled/varianttomapconverter.cpp
+++ b/src/libtiled/varianttomapconverter.cpp
@@ -346,7 +346,7 @@ SharedTileset VariantToMapConverter::toTileset(const QVariant &variant)
     const QVariantList tilesVariantList = tilesVariant.toList();
     for (int i = 0; i < tilesVariantList.count(); ++i) {
         const QVariantMap tileVar = tilesVariantList[i].toMap();
-        const int tileId  = tileVar[QLatin1String("tile")].toInt();
+        const int tileId  = tileVar[QLatin1String("id")].toInt();
         if (tileId < 0) {
             mError = tr("Invalid (negative) tile id: %1").arg(tileId);
             return SharedTileset();

--- a/src/libtiled/varianttomapconverter.cpp
+++ b/src/libtiled/varianttomapconverter.cpp
@@ -147,12 +147,11 @@ ObjectTemplate *VariantToMapConverter::toObjectTemplate(const QVariant &variant,
 Properties VariantToMapConverter::toProperties(const QVariant &propertiesVariant,
                                                const QVariant &propertyTypesVariant) const
 {
-    const QVariantMap propertiesMap = propertiesVariant.toMap();
-    const QVariantMap propertyTypesMap = propertyTypesVariant.toMap();
-
     Properties properties;
 
-    // original format
+    // read object-based format (1.0)
+    const QVariantMap propertiesMap = propertiesVariant.toMap();
+    const QVariantMap propertyTypesMap = propertyTypesVariant.toMap();
     QVariantMap::const_iterator it = propertiesMap.constBegin();
     QVariantMap::const_iterator it_end = propertiesMap.constEnd();
     for (; it != it_end; ++it) {
@@ -164,10 +163,10 @@ Properties VariantToMapConverter::toProperties(const QVariant &propertiesVariant
         properties[it.key()] = value;
     }
 
-    // version 1.2 format
-    QVariantList propertiesVariantList = propertiesVariant.toList();
-    for (int i = 0; i < propertiesVariantList.count(); ++i) {
-        const QVariantMap propertyVariantMap = propertiesVariantList[i].toMap();
+    // read array-based format (1.2)
+    const QVariantList propertiesList = propertiesVariant.toList();
+    for (const QVariant &propertyVariant : propertiesList) {
+        const QVariantMap propertyVariantMap = propertyVariant.toMap();
         const QString propertyName = propertyVariantMap[QLatin1String("name")].toString();
         const QString propertyType = propertyVariantMap[QLatin1String("type")].toString();
         const QVariant propertyValue = propertyVariantMap[QLatin1String("value")];
@@ -269,20 +268,9 @@ SharedTileset VariantToMapConverter::toTileset(const QVariant &variant)
         terrain->setProperties(extractProperties(terrainMap));
     }
 
-    // Read tiles (everything except their properties)
-    const QVariantMap tilesVariantMap = variantMap[QLatin1String("tiles")].toMap();
-    QVariantMap::const_iterator it = tilesVariantMap.constBegin();
-    for (; it != tilesVariantMap.end(); ++it) {
+    // Reads tile information (everything except the properties)
+    auto readTile = [&](Tile *tile, const QVariantMap &tileVar) {
         bool ok;
-        const int tileId = it.key().toInt();
-        if (tileId < 0) {
-            mError = tr("Invalid (negative) tile id: %1").arg(tileId);
-            return SharedTileset();
-        }
-
-        Tile *tile = tileset->findOrCreateTile(tileId);
-
-        const QVariantMap tileVar = it.value().toMap();
 
         tile->setType(tileVar[QLatin1String("type")].toString());
 
@@ -299,7 +287,7 @@ SharedTileset VariantToMapConverter::toTileset(const QVariant &variant)
         if (ok)
             tile->setProbability(probability);
 
-        imageVariant = tileVar[QLatin1String("image")];
+        QVariant imageVariant = tileVar[QLatin1String("image")];
         if (!imageVariant.isNull()) {
             const QUrl imagePath = toUrl(imageVariant.toString(), mMapDir);
             tileset->setTileImage(tile, QPixmap(imagePath.toLocalFile()), imagePath);
@@ -324,9 +312,26 @@ SharedTileset VariantToMapConverter::toTileset(const QVariant &variant)
             }
             tile->setFrames(frames);
         }
+    };
+
+    // Read tiles (1.0 format)
+    const QVariant tilesVariant = variantMap[QLatin1String("tiles")];
+    const QVariantMap tilesVariantMap = tilesVariant.toMap();
+    QVariantMap::const_iterator it = tilesVariantMap.constBegin();
+    for (; it != tilesVariantMap.end(); ++it) {
+        const int tileId = it.key().toInt();
+        if (tileId < 0) {
+            mError = tr("Invalid (negative) tile id: %1").arg(tileId);
+            return SharedTileset();
+        }
+
+        Tile *tile = tileset->findOrCreateTile(tileId);
+
+        const QVariantMap tileVar = it.value().toMap();
+        readTile(tile, tileVar);
     }
 
-    // Read tile properties
+    // Read tile properties (1.0 format)
     QVariantMap propertiesVariantMap = variantMap[QLatin1String("tileproperties")].toMap();
     QVariantMap propertyTypesVariantMap = variantMap[QLatin1String("tilepropertytypes")].toMap();
     for (it = propertiesVariantMap.constBegin(); it != propertiesVariantMap.constEnd(); ++it) {
@@ -337,8 +342,8 @@ SharedTileset VariantToMapConverter::toTileset(const QVariant &variant)
         tileset->findOrCreateTile(tileId)->setProperties(properties);
     }
 
-    // Read the tiles in the new format (list instead of map)
-    const QVariantList tilesVariantList = variantMap[QLatin1String("tiles")].toList();
+    // Read the tiles saved as a list (1.2 format)
+    const QVariantList tilesVariantList = tilesVariant.toList();
     for (int i = 0; i < tilesVariantList.count(); ++i) {
         const QVariantMap tileVar = tilesVariantList[i].toMap();
         const int tileId  = tileVar[QLatin1String("tile")].toInt();
@@ -347,49 +352,8 @@ SharedTileset VariantToMapConverter::toTileset(const QVariant &variant)
             return SharedTileset();
         }
         Tile *tile = tileset->findOrCreateTile(tileId);
-        tile->setType(tileVar[QLatin1String("type")].toString());
-
+        readTile(tile, tileVar);
         tile->setProperties(extractProperties(tileVar));
-
-        bool ok;
-        QList<QVariant> terrains = tileVar[QLatin1String("terrain")].toList();
-        if (terrains.count() == 4) {
-            for (int j = 0; j < 4; ++j) {
-                int terrainId = terrains.at(j).toInt(&ok);
-                if (ok && terrainId >= 0 && terrainId < tileset->terrainCount())
-                    tile->setCornerTerrainId(j, terrainId);
-            }
-        }
-
-        qreal probability = tileVar[QLatin1String("probability")].toDouble(&ok);
-        if (ok)
-            tile->setProbability(probability);
-
-        imageVariant = tileVar[QLatin1String("image")];
-        if (!imageVariant.isNull()) {
-            const QUrl imagePath = toUrl(imageVariant.toString(), mMapDir);
-            tileset->setTileImage(tile, QPixmap(imagePath.toLocalFile()), imagePath);
-        }
-
-        QVariantMap objectGroupVariant = tileVar[QLatin1String("objectgroup")].toMap();
-        if (!objectGroupVariant.isEmpty()) {
-            ObjectGroup *objectGroup = toObjectGroup(objectGroupVariant);
-            if (objectGroup)
-                objectGroup->setProperties(extractProperties(objectGroupVariant));
-            tile->setObjectGroup(objectGroup);
-        }
-
-        QVariantList frameList = tileVar[QLatin1String("animation")].toList();
-        if (!frameList.isEmpty()) {
-            QVector<Frame> frames(frameList.size());
-            for (int i = frameList.size() - 1; i >= 0; --i) {
-                const QVariantMap frameVariantMap = frameList[i].toMap();
-                Frame &frame = frames[i];
-                frame.tileId = frameVariantMap[QLatin1String("tileid")].toInt();
-                frame.duration = frameVariantMap[QLatin1String("duration")].toInt();
-            }
-            tile->setFrames(frames);
-        }
     }
 
     if (!mReadingExternalTileset)

--- a/src/libtiled/varianttomapconverter.h
+++ b/src/libtiled/varianttomapconverter.h
@@ -85,6 +85,7 @@ public:
     QString errorString() const { return mError; }
 
 private:
+    QVariant toType(const QVariant &type, const QVariant &value);
     Properties toProperties(const QVariant &propertiesVariant,
                             const QVariant &propertyTypesVariant) const;
     SharedTileset toTileset(const QVariant &variant);

--- a/src/libtiled/varianttomapconverter.h
+++ b/src/libtiled/varianttomapconverter.h
@@ -85,7 +85,6 @@ public:
     QString errorString() const { return mError; }
 
 private:
-    QVariant toType(const QVariant &type, const QVariant &value);
     Properties toProperties(const QVariant &propertiesVariant,
                             const QVariant &propertyTypesVariant) const;
     SharedTileset toTileset(const QVariant &variant);


### PR DESCRIPTION
Addresses issue https://github.com/bjorn/tiled/issues/1585

This introduces a new json revision (version: 1.2) that is much easier to serialize and de-serialize.  For an example of de-serializing the new format in Unity3d, see https://github.com/saeedakhter/TiledJsonUnity3d

**Problem:**
Tiles were serialized as a map with the tile ID as the key:
```
"tiles":
    {
     "0": { "image":"necro3_0\/5.png", "imageheight":32, "imagewidth":32 },
     "1": { "image":"necro3_0\/4.png", "imageheight":32, "imagewidth":32 }
    }
```
In Unity3d, this makes it difficult (impossible?) to use Unity3d's JSON deserialization:
https://docs.unity3d.com/Manual/JSONSerialization.html 

**Solution (this pull request):**
Serialize tiles and properties as a list.  If an ID is required, put it inside the list object.  Example:
```
 "tiles":[
        {
         "terrain":[0, 2, 2, 2],
         "tile":0
        }, 
        {
         "properties":[
                {
                 "name":"Prefrab",
                 "type":"string",
                 "value":"Floor*"
                }, 
                {
                 "name":"SortingLayer",
                 "type":"string",
                 "value":"Floor"
                }],
         "terrain":[0, 0, 0, 0],
         "tile":1
        }, 
```
