### PR TITLE
Add --export-tileset command line argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,3 @@ util/java/libtiled-java/target
 
 # Linux perf/debugging
 gmon.out
-
-# Vim swap files
-*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ util/java/libtiled-java/target
 
 # Linux perf/debugging
 gmon.out
+
+# Vim swap files
+*.swp


### PR DESCRIPTION
@bjorn Please review.  Adding an --export-tileset command line arg has been quite useful to me.  Also, please make sure to see the comments at L385.  I believe tileset export was recently broken  (the "Export..." menu item has the same behavior).  Here's a sample tsx to json export to illustrate:

```
{ "source":"mytileset.tsx",
 "version":1.2
}
```