### PR TITLE
Fix #91 object tile position, to be same as other objects

### DIFF
--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -96,7 +96,7 @@ QRectF OrthogonalRenderer::boundingRect(const MapObject *object) const
 
         const QPointF bottomLeft = bounds.topLeft();
         boundingRect = QRectF(bottomLeft.x() + (tileOffset.x() * scale.width()),
-                              bottomLeft.y() + (tileOffset.y() * scale.height()) - objectSize.height(),
+                              bottomLeft.y() + (tileOffset.y() * scale.height()),
                               objectSize.width(),
                               objectSize.height()).adjusted(-1, -1, 1, 1);
     } else {
@@ -366,7 +366,7 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
 
     if (!cell.isEmpty()) {
         const QSizeF size = object->size();
-        CellRenderer(painter).render(cell, QPointF(), size,
+        CellRenderer(painter).render(cell, QPointF(0, size.height()), size,
                                      CellRenderer::BottomLeft);
 
         if (testFlag(ShowTileObjectOutlines)) {
@@ -388,7 +388,8 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
             painter->setPen(pen);
             painter->drawRect(rect);
         }
-    } else {
+    }
+    else {
         const qreal lineWidth = objectLineWidth();
         const qreal scale = painterScale();
         const qreal shadowDist = (lineWidth == 0 ? 1 : lineWidth) / scale;

--- a/src/tiled/createtileobjecttool.cpp
+++ b/src/tiled/createtileobjecttool.cpp
@@ -46,7 +46,7 @@ void CreateTileObjectTool::mouseMovedWhileCreatingObject(const QPointF &pos, Qt:
     const MapRenderer *renderer = mapDocument()->renderer();
 
     const QSize imgSize = mNewMapObjectItem->mapObject()->cell().tile()->size();
-    const QPointF diff(-imgSize.width() / 2, imgSize.height() / 2);
+    const QPointF diff(-imgSize.width() / 2, -imgSize.height() / 2);
     QPointF pixelCoords = renderer->screenToPixelCoords(pos + diff);
 
     SnapHelper(renderer, modifiers).snap(pixelCoords);

--- a/src/tiled/objectselectionitem.cpp
+++ b/src/tiled/objectselectionitem.cpp
@@ -80,10 +80,12 @@ static QRectF objectBounds(const MapObject *object,
         // Tile objects can have a tile offset, which is scaled along with the image
         QSizeF imgSize;
         QPoint tileOffset;
+        qreal moveDown = 0;
 
         if (const Tile *tile = object->cell().tile()) {
             imgSize = tile->size();
             tileOffset = tile->offset();
+            moveDown = imgSize.height();
         } else {
             imgSize = object->size();
         }
@@ -94,7 +96,7 @@ static QRectF objectBounds(const MapObject *object,
         const qreal scaleY = imgSize.height() > 0 ? objectSize.height() / imgSize.height() : 0;
 
         QRectF bounds(position.x() + (tileOffset.x() * scaleX),
-                      position.y() + (tileOffset.y() * scaleY),
+                      position.y() + ((tileOffset.y()+ moveDown) * scaleY),
                       objectSize.width(),
                       objectSize.height());
 
@@ -275,6 +277,7 @@ void MapObjectLabel::syncWithMapObject(MapRenderer *renderer)
     transform.rotate(mObject->rotation());
     transform.translate(-pixelPos.x(), -pixelPos.y());
     bounds = transform.mapRect(bounds);
+
 
     // Center the object name on the object bounding box
     QPointF pos((bounds.left() + bounds.right()) / 2, bounds.top());

--- a/src/tiled/objectselectiontool.cpp
+++ b/src/tiled/objectselectiontool.cpp
@@ -820,10 +820,11 @@ static QRectF objectBounds(const MapObject *object,
         // Tile objects can have a tile offset, which is scaled along with the image
         QSizeF imgSize;
         QPoint tileOffset;
-
+        qreal moveDown = 0;
         if (const Tile *tile = object->cell().tile()) {
             imgSize = tile->size();
             tileOffset = tile->offset();
+            moveDown = imgSize.height();
         } else {
             imgSize = object->size();
         }
@@ -834,7 +835,7 @@ static QRectF objectBounds(const MapObject *object,
         const qreal scaleY = imgSize.height() > 0 ? objectSize.height() / imgSize.height() : 0;
 
         QRectF bounds(position.x() + (tileOffset.x() * scaleX),
-                      position.y() + (tileOffset.y() * scaleY),
+                      position.y() + ((tileOffset.y() + moveDown) * scaleY),
                       objectSize.width(),
                       objectSize.height());
 


### PR DESCRIPTION
Maybe You can improve - but that fixes issues when You create tile in objecLayer, so now it will be offset by height in tiled Prieview  same as other objects - so as result parsing tiles-objecsts can be done same as other objects.. #91 

* Btw im total newbie in C++/QT, but that bug just make me mad..