### PR TITLE
python3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: cpp
 sudo: required
 dist: trusty
+python: 3.6
 
 env:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,13 +6,16 @@ environment:
     secure: +3IhWT10lCSC4GE4gGfWt8WiZdIXuMUfaImgvQUullg=
   matrix:
     - QTDIR: C:\Qt\5.10.1\msvc2013_64
+      PYTHONHOME: C:\Python36-x64
       PUSH_RELEASE: true
       TILED_ITCH_CHANNEL: windows-64bit
     - QTDIR: C:\Qt\5.10.1\mingw53_32
+      PYTHONHOME: C:\Python36
       MINGW: C:\Qt\Tools\mingw530_32
       PUSH_RELEASE: true
       TILED_ITCH_CHANNEL: windows-32bit
     - QTDIR: C:\Qt\5.6\mingw49_32
+      PYTHONHOME: C:\Python36
       MINGW: C:\Qt\Tools\mingw492_32
       PUSH_RELEASE: false
       TILED_ITCH_CHANNEL: winxp-32bit

--- a/dist/win/installer.qbs
+++ b/dist/win/installer.qbs
@@ -2,6 +2,7 @@ import qbs
 import qbs.FileInfo
 import qbs.File
 import qbs.TextFile
+import qbs.Environment
 
 WindowsInstallerPackage {
     builtByDefault: false
@@ -41,16 +42,19 @@ WindowsInstallerPackage {
 
         if (qbs.toolchain.contains("mingw"))
             defs.push("MingwDir=" + FileInfo.joinPaths(cpp.toolchainInstallPath, ".."));
-        else if (qbs.toolchain.contains("msvc"))
-            defs.push("VcInstallDir=" + FileInfo.joinPaths(cpp.toolchainInstallPath, "../.."));
+        else if (qbs.toolchain.contains("msvc")) {
+            if (cpp.compilerVersionMajor >= 19) {
+                defs.push("VcUniversalCRT=true");
+                defs.push("VcInstallDir=" + cpp.toolchainInstallPath);
+            } else {
+                defs.push("VcInstallDir=" + FileInfo.joinPaths(cpp.toolchainInstallPath, "../.."));
+            }
+        }
 
         if (project.sparkleEnabled)
             defs.push("Sparkle");
 
-        // A bit of a hack to exclude the Python plugin when it isn't built
-        if (File.exists("C:/Python27") &&
-                qbs.toolchain.contains("mingw") &&
-                !qbs.debugInformation) {
+        if (File.exists( Environment.getEnv("PYTHONHOME") )) {
             defs.push("Python");
         }
 

--- a/dist/win/installer.wxs
+++ b/dist/win/installer.wxs
@@ -94,8 +94,12 @@
             <File Id="libstdc___6_dll" Source="$(var.MingwDir)\bin\libstdc++-6.dll"/>
             <File Id="libwinpthread_1_dll" Source="$(var.MingwDir)\bin\libwinpthread-1.dll"/>
             <?else?>
-            <File Source="$(var.VcInstallDir)\redist\$(var.Platform)\Microsoft.VC120.CRT\msvcp120.dll"/>
-            <File Source="$(var.VcInstallDir)\redist\$(var.Platform)\Microsoft.VC120.CRT\msvcr120.dll"/>
+              <?ifdef VcUniversalCRT ?>
+              <File Source="$(var.VcInstallDir)\msvcp140.dll"/>
+              <?else?>
+              <File Source="$(var.VcInstallDir)\redist\$(var.Platform)\Microsoft.VC120.CRT\msvcp120.dll"/>
+              <File Source="$(var.VcInstallDir)\redist\$(var.Platform)\Microsoft.VC120.CRT\msvcr120.dll"/>
+              <?endif?>
             <?endif?>
 
             <?ifdef Sparkle ?>

--- a/qbs/imports/PythonProbe.qbs
+++ b/qbs/imports/PythonProbe.qbs
@@ -1,0 +1,60 @@
+import qbs
+import qbs.Environment
+import qbs.File
+import qbs.FileInfo
+import qbs.Process
+import qbs.Utilities
+
+Probe {
+    id: pythonDllProbe
+    property string pythonDir: pythonInstallDir // Input
+    property string buildVariant: qbs.buildVariant // Input
+    property string fileNamePrefix // Output
+
+    configure: {
+        function printWarning(msg) {
+            console.warn(msg + " The python dumpers for cdb will not be available.");
+        }
+
+        if (!pythonDir) {
+            printWarning("PYTHON_INSTALL_DIR not set.");
+            return;
+        }
+        if (!File.exists(pythonDir)) {
+            printWarning("The provided python installation directory '" + pythonDir
+                         + "' does not exist.");
+            return;
+        }
+        var p = new Process();
+        try {
+            var pythonFilePath = FileInfo.joinPaths(pythonDir, "python.exe");
+            p.exec(pythonFilePath, ["--version"], true);
+            var output = p.readStdOut().trim();
+            var magicPrefix = "Python ";
+            if (!output.startsWith(magicPrefix)) {
+                printWarning("Unexpected python output when checking for version: '"
+                             + output + "'");
+                return;
+            }
+            var versionNumberString = output.slice(magicPrefix.length);
+            var versionNumbers = versionNumberString.split('.');
+            if (versionNumbers.length < 2) {
+                printWarning("Unexpected python output when checking for version: '"
+                        + output + "'");
+                return;
+            }
+            if (Utilities.versionCompare(versionNumberString, "3.5") < 0) {
+                printWarning("The python installation at '" + pythonDir
+                             + "' has version " + versionNumberString + ", but 3.5 or higher "
+                             + "is required.");
+                return;
+            }
+            found = true;
+            fileNamePrefix = "python" + versionNumbers[0] + versionNumbers[1];
+            if (buildVariant === "debug")
+                fileNamePrefix += "_d"
+        } finally {
+            p.close();
+        }
+    }
+}

--- a/src/plugins/python/find_python.pri
+++ b/src/plugins/python/find_python.pri
@@ -1,14 +1,9 @@
 !contains(DISABLE_PYTHON_PLUGIN, yes) {
     unix {
-        packagesExist(python-2.7) {
+        packagesExist(python3) {
             HAVE_PYTHON = yes
             CONFIG += link_pkgconfig
-            PKGCONFIG += python-2.7
-        } else:system(python-config --prefix) {
-            # currently here for reference, only 2.7 is tested
-            HAVE_PYTHON = yes
-            QMAKE_CXXFLAGS += `python-config --cflags`
-            QMAKE_LFLAGS += `python-config --ldflags`
+            PKGCONFIG += python3
         }
     }
 

--- a/src/plugins/python/python.qbs
+++ b/src/plugins/python/python.qbs
@@ -7,33 +7,53 @@ TiledPlugin {
     Depends { name: "Qt"; submodules: ["widgets"] }
 
     condition: {
-        if (qbs.targetOS.contains("windows")) {
-            return File.exists( Environment.getEnv("PYTHONHOME") );
-        }
+        if (qbs.targetOS.contains("windows"))
+            return File.exists(Environment.getEnv("PYTHONHOME"));
 
-        return pkgConfig.found;
+        return pkgConfigPython3.found ||
+               pkgConfigPython3_6.found ||
+               pkgConfigPython3_4.found;
     }
 
     Probes.PkgConfigProbe {
-        id: pkgConfig
-        // the default qbs.sysroot basically just messes up system defaults
-        sysroot: ''
-        packageNames: ["python3"]
+        id: pkgConfigPython3
+        name: "python3"
+    }
+    Probes.PkgConfigProbe {
+        id: pkgConfigPython3_6
+        name: "python-3.6"
+    }
+    Probes.PkgConfigProbe {
+        id: pkgConfigPython3_4
+        name: "python-3.4"
     }
 
     Properties {
-        condition: pkgConfig.found
-
-        cpp.cxxFlags: pkgConfig.cflags
-        cpp.linkerFlags: pkgConfig.libs
-        // was ldflags broken for some py2 pkgconfigs? seems to work with py3
-        //cpp.dynamicLibraries: ["python3"]
+        condition: pkgConfigPython3.found
+        cpp.cxxFlags: pkgConfigPython3.cflags
+        cpp.dynamicLibraries: pkgConfigPython3.libraries
+        cpp.libraryPaths: pkgConfigPython3.libraryPaths
+        cpp.linkerFlags: pkgConfigPython3.linkerFlags
+    }
+    Properties {
+        condition: !pkgConfigPython3.found && pkgConfigPython3_6.found
+        cpp.cxxFlags: pkgConfigPython3_6.cflags
+        cpp.dynamicLibraries: pkgConfigPython3_6.libraries
+        cpp.libraryPaths: pkgConfigPython3_6.libraryPaths
+        cpp.linkerFlags: pkgConfigPython3_6.linkerFlags
+    }
+    Properties {
+        condition: !pkgConfigPython3.found && !pkgConfigPython3_6.found && pkgConfigPython3_4.found
+        cpp.cxxFlags: pkgConfigPython3_4.cflags
+        cpp.dynamicLibraries: pkgConfigPython3_4.libraries
+        cpp.libraryPaths: pkgConfigPython3_4.libraryPaths
+        cpp.linkerFlags: pkgConfigPython3_4.linkerFlags
     }
 
     Properties {
         condition: qbs.targetOS.contains("windows")
-        cpp.includePaths: [Environment.getEnv("PYTHONHOME")+"/include"]
-        cpp.libraryPaths: [Environment.getEnv("PYTHONHOME")+"/libs"]
+        cpp.includePaths: [Environment.getEnv("PYTHONHOME") + "/include"]
+        cpp.libraryPaths: [Environment.getEnv("PYTHONHOME") + "/libs"]
         cpp.dynamicLibraries: ["python3"]
     }
 

--- a/src/plugins/python/python.qbs
+++ b/src/plugins/python/python.qbs
@@ -2,6 +2,7 @@ import qbs 1.0
 import qbs.Probes as Probes
 import qbs.File
 import qbs.Environment
+import qbs.FileInfo
 
 TiledPlugin {
     Depends { name: "Qt"; submodules: ["widgets"] }
@@ -10,22 +11,17 @@ TiledPlugin {
         if (qbs.targetOS.contains("windows"))
             return File.exists(Environment.getEnv("PYTHONHOME"));
 
-        return pkgConfigPython3.found ||
-               pkgConfigPython3_6.found ||
-               pkgConfigPython3_4.found;
+        return pkgConfigPython3.found;
     }
 
     Probes.PkgConfigProbe {
         id: pkgConfigPython3
         name: "python3"
     }
-    Probes.PkgConfigProbe {
-        id: pkgConfigPython3_6
-        name: "python-3.6"
-    }
-    Probes.PkgConfigProbe {
-        id: pkgConfigPython3_4
-        name: "python-3.4"
+
+    PythonProbe {
+        id: pythonDllProbe
+        pythonDir: Environment.getEnv("PYTHONHOME")
     }
 
     Properties {
@@ -35,26 +31,19 @@ TiledPlugin {
         cpp.libraryPaths: pkgConfigPython3.libraryPaths
         cpp.linkerFlags: pkgConfigPython3.linkerFlags
     }
-    Properties {
-        condition: !pkgConfigPython3.found && pkgConfigPython3_6.found
-        cpp.cxxFlags: pkgConfigPython3_6.cflags
-        cpp.dynamicLibraries: pkgConfigPython3_6.libraries
-        cpp.libraryPaths: pkgConfigPython3_6.libraryPaths
-        cpp.linkerFlags: pkgConfigPython3_6.linkerFlags
-    }
-    Properties {
-        condition: !pkgConfigPython3.found && !pkgConfigPython3_6.found && pkgConfigPython3_4.found
-        cpp.cxxFlags: pkgConfigPython3_4.cflags
-        cpp.dynamicLibraries: pkgConfigPython3_4.libraries
-        cpp.libraryPaths: pkgConfigPython3_4.libraryPaths
-        cpp.linkerFlags: pkgConfigPython3_4.linkerFlags
-    }
 
     Properties {
-        condition: qbs.targetOS.contains("windows")
+        condition: qbs.targetOS.contains("windows") && !qbs.toolchain.contains("mingw")
         cpp.includePaths: [Environment.getEnv("PYTHONHOME") + "/include"]
         cpp.libraryPaths: [Environment.getEnv("PYTHONHOME") + "/libs"]
         cpp.dynamicLibraries: ["python3"]
+    }
+
+    Properties {
+        condition: qbs.targetOS.contains("windows") && qbs.toolchain.contains("mingw")
+        cpp.includePaths: [Environment.getEnv("PYTHONHOME") + "/include"]
+        cpp.libraryPaths: [Environment.getEnv("PYTHONHOME") + "/libs"]
+        cpp.dynamicLibraries: [FileInfo.joinPaths(Environment.getEnv("PYTHONHOME"), pythonDllProbe.fileNamePrefix + ".dll")]
     }
 
     files: [

--- a/src/plugins/python/python.qbs
+++ b/src/plugins/python/python.qbs
@@ -1,56 +1,40 @@
 import qbs 1.0
 import qbs.Probes as Probes
 import qbs.File
+import qbs.Environment
 
 TiledPlugin {
     Depends { name: "Qt"; submodules: ["widgets"] }
 
     condition: {
-        if (qbs.targetOS.contains("linux")) {
-            return pkgConfig.found;
-        } else if (qbs.targetOS.contains("windows")) {
-            // On Windows, currently only the default install location of
-            // Python 2.7 is supported, and only when compiling with MinGW in
-            // release mode. Also, avoid Python 2.7.10, since it results in a
-            // linker error.
-            //
-            return File.exists("C:/Python27") &&
-                    qbs.toolchain.contains("mingw") &&
-                    !qbs.debugInformation;
-        } else if (qbs.targetOS.contains("darwin")) {
-            return true;
+        if (qbs.targetOS.contains("windows")) {
+            return File.exists( Environment.getEnv("PYTHONHOME") );
         }
 
-        return false;
+        return pkgConfig.found;
     }
 
     Probes.PkgConfigProbe {
         id: pkgConfig
-        name: "python-2.7"
+        // the default qbs.sysroot basically just messes up system defaults
+        sysroot: ''
+        packageNames: ["python3"]
     }
 
     Properties {
-        condition: qbs.targetOS.contains("linux")
+        condition: pkgConfig.found
 
         cpp.cxxFlags: pkgConfig.cflags
-        // This should be it, but it doesn't work because the -lpython2.7 ends
-        // up too early on the command line.
-        //cpp.linkerFlags: pkgConfig.libs
-        cpp.dynamicLibraries: ["python2.7"]
+        cpp.linkerFlags: pkgConfig.libs
+        // was ldflags broken for some py2 pkgconfigs? seems to work with py3
+        //cpp.dynamicLibraries: ["python3"]
     }
 
     Properties {
         condition: qbs.targetOS.contains("windows")
-        cpp.includePaths: ["C:/Python27/include"]
-        cpp.libraryPaths: ["C:/Python27/libs"]
-        cpp.dynamicLibraries: ["python27"]
-    }
-
-    Properties {
-        condition: qbs.targetOS.contains("darwin")
-        cpp.includePaths: ["/System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7"]
-        cpp.libraryPaths: ["/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/config"]
-        cpp.dynamicLibraries: ["python2.7"]
+        cpp.includePaths: [Environment.getEnv("PYTHONHOME")+"/include"]
+        cpp.libraryPaths: [Environment.getEnv("PYTHONHOME")+"/libs"]
+        cpp.dynamicLibraries: ["python3"]
     }
 
     files: [

--- a/src/plugins/python/pythonbind.cpp
+++ b/src/plugins/python/pythonbind.cpp
@@ -360,7 +360,9 @@ typedef struct {
 
 extern PyTypeObject PyTiledLoggingInterface_Type;
 
+#ifndef _MSC_VER
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
 
 int _wrap_convert_py2c__QRgb(PyObject *value, QRgb *address);
 

--- a/src/plugins/python/pythonbind.cpp
+++ b/src/plugins/python/pythonbind.cpp
@@ -9,51 +9,6 @@
 #include <stddef.h>
 
 
-#if PY_VERSION_HEX < 0x020400F0
-
-#define PyEval_ThreadsInitialized() 1
-
-#define Py_CLEAR(op)				\
-        do {                            	\
-                if (op) {			\
-                        PyObject *tmp = (PyObject *)(op);	\
-                        (op) = NULL;		\
-                        Py_DECREF(tmp);		\
-                }				\
-        } while (0)
-
-
-#define Py_VISIT(op)							\
-        do { 								\
-                if (op) {						\
-                        int vret = visit((PyObject *)(op), arg);	\
-                        if (vret)					\
-                                return vret;				\
-                }							\
-        } while (0)
-
-#endif
-
-
-
-#if PY_VERSION_HEX < 0x020500F0
-
-typedef int Py_ssize_t;
-# define PY_SSIZE_T_MAX INT_MAX
-# define PY_SSIZE_T_MIN INT_MIN
-typedef inquiry lenfunc;
-typedef intargfunc ssizeargfunc;
-typedef intobjargproc ssizeobjargproc;
-
-#endif
-
-
-#ifndef PyVarObject_HEAD_INIT
-#define PyVarObject_HEAD_INIT(type, size) \
-        PyObject_HEAD_INIT(type) size,
-#endif
-
-
 #if PY_VERSION_HEX >= 0x03000000
 #if PY_VERSION_HEX >= 0x03050000
 typedef PyAsyncMethods* cmpfunc;
@@ -393,30 +348,6 @@ _wrap_PyQPointF__tp_init(PyQPointF *self, PyObject *args, PyObject *kwargs)
 
 
 PyObject *
-_wrap_PyQPointF_y(PyQPointF *self)
-{
-    PyObject *py_retval;
-    int retval;
-
-    retval = self->obj->y();
-    py_retval = Py_BuildValue((char *) "i", retval);
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyQPointF_x(PyQPointF *self)
-{
-    PyObject *py_retval;
-    int retval;
-
-    retval = self->obj->x();
-    py_retval = Py_BuildValue((char *) "i", retval);
-    return py_retval;
-}
-
-
-PyObject *
 _wrap_PyQPointF_setX(PyQPointF *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
@@ -449,11 +380,35 @@ _wrap_PyQPointF_setY(PyQPointF *self, PyObject *args, PyObject *kwargs)
     return py_retval;
 }
 
+
+PyObject *
+_wrap_PyQPointF_x(PyQPointF *self)
+{
+    PyObject *py_retval;
+    int retval;
+
+    retval = self->obj->x();
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyQPointF_y(PyQPointF *self)
+{
+    PyObject *py_retval;
+    int retval;
+
+    retval = self->obj->y();
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
 static PyMethodDef PyQPointF_methods[] = {
-    {(char *) "y", (PyCFunction) _wrap_PyQPointF_y, METH_NOARGS, "y()\n\n" },
-    {(char *) "x", (PyCFunction) _wrap_PyQPointF_x, METH_NOARGS, "x()\n\n" },
     {(char *) "setX", (PyCFunction) _wrap_PyQPointF_setX, METH_KEYWORDS|METH_VARARGS, "setX(x)\n\ntype: x: int" },
     {(char *) "setY", (PyCFunction) _wrap_PyQPointF_setY, METH_KEYWORDS|METH_VARARGS, "setY(y)\n\ntype: y: int" },
+    {(char *) "x", (PyCFunction) _wrap_PyQPointF_x, METH_NOARGS, "x()\n\n" },
+    {(char *) "y", (PyCFunction) _wrap_PyQPointF_y, METH_NOARGS, "y()\n\n" },
     {NULL, NULL, 0, NULL}
 };
 
@@ -575,6 +530,18 @@ _wrap_PyQSizeF__tp_init(PyQSizeF *self, PyObject *args, PyObject *kwargs)
 
 
 PyObject *
+_wrap_PyQSizeF_height(PyQSizeF *self)
+{
+    PyObject *py_retval;
+    int retval;
+
+    retval = self->obj->height();
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
+
+PyObject *
 _wrap_PyQSizeF_setHeight(PyQSizeF *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
@@ -587,18 +554,6 @@ _wrap_PyQSizeF_setHeight(PyQSizeF *self, PyObject *args, PyObject *kwargs)
     self->obj->setHeight(h);
     Py_INCREF(Py_None);
     py_retval = Py_None;
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyQSizeF_width(PyQSizeF *self)
-{
-    PyObject *py_retval;
-    int retval;
-
-    retval = self->obj->width();
-    py_retval = Py_BuildValue((char *) "i", retval);
     return py_retval;
 }
 
@@ -621,21 +576,21 @@ _wrap_PyQSizeF_setWidth(PyQSizeF *self, PyObject *args, PyObject *kwargs)
 
 
 PyObject *
-_wrap_PyQSizeF_height(PyQSizeF *self)
+_wrap_PyQSizeF_width(PyQSizeF *self)
 {
     PyObject *py_retval;
     int retval;
 
-    retval = self->obj->height();
+    retval = self->obj->width();
     py_retval = Py_BuildValue((char *) "i", retval);
     return py_retval;
 }
 
 static PyMethodDef PyQSizeF_methods[] = {
-    {(char *) "setHeight", (PyCFunction) _wrap_PyQSizeF_setHeight, METH_KEYWORDS|METH_VARARGS, "setHeight(h)\n\ntype: h: int" },
-    {(char *) "width", (PyCFunction) _wrap_PyQSizeF_width, METH_NOARGS, "width()\n\n" },
-    {(char *) "setWidth", (PyCFunction) _wrap_PyQSizeF_setWidth, METH_KEYWORDS|METH_VARARGS, "setWidth(w)\n\ntype: w: int" },
     {(char *) "height", (PyCFunction) _wrap_PyQSizeF_height, METH_NOARGS, "height()\n\n" },
+    {(char *) "setHeight", (PyCFunction) _wrap_PyQSizeF_setHeight, METH_KEYWORDS|METH_VARARGS, "setHeight(h)\n\ntype: h: int" },
+    {(char *) "setWidth", (PyCFunction) _wrap_PyQSizeF_setWidth, METH_KEYWORDS|METH_VARARGS, "setWidth(w)\n\ntype: w: int" },
+    {(char *) "width", (PyCFunction) _wrap_PyQSizeF_width, METH_NOARGS, "width()\n\n" },
     {NULL, NULL, 0, NULL}
 };
 
@@ -1245,43 +1200,6 @@ int _wrap_PyQImage__tp_init(PyQImage *self, PyObject *args, PyObject *kwargs)
 
 
 PyObject *
-_wrap_PyQImage_load(PyQImage *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    bool retval;
-    const char *fileName;
-    Py_ssize_t fileName_len;
-    char *fmt;
-    const char *keywords[] = {"fileName", "fmt", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "s#s", (char **) keywords, &fileName, &fileName_len, &fmt)) {
-        return NULL;
-    }
-    retval = self->obj->load(QString::fromUtf8(fileName), fmt);
-    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyQImage_setColor(PyQImage *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    int i;
-    PyQRgb *c;
-    const char *keywords[] = {"i", "c", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "iO!", (char **) keywords, &i, &PyQRgb_Type, &c)) {
-        return NULL;
-    }
-    self->obj->setColor(i, *((PyQRgb *) c)->obj);
-    Py_INCREF(Py_None);
-    py_retval = Py_None;
-    return py_retval;
-}
-
-
-PyObject *
 _wrap_PyQImage_color(PyQImage *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
@@ -1297,6 +1215,69 @@ _wrap_PyQImage_color(PyQImage *self, PyObject *args, PyObject *kwargs)
     py_QRgb->flags = PYBINDGEN_WRAPPER_FLAG_NONE;
     py_QRgb->obj = new QRgb(retval);
     py_retval = Py_BuildValue((char *) "N", py_QRgb);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyQImage_colorTable(PyQImage *self)
+{
+    PyObject *py_retval;
+    QVector< QRgb > retval;
+    PyQVector__lt__QRgb__gt__ *py_QVector__lt__QRgb__gt__;
+
+    retval = self->obj->colorTable();
+    py_QVector__lt__QRgb__gt__ = PyObject_New(PyQVector__lt__QRgb__gt__, &PyQVector__lt__QRgb__gt___Type);
+    py_QVector__lt__QRgb__gt__->obj = new QVector<QRgb>(retval);
+    py_retval = Py_BuildValue((char *) "N", py_QVector__lt__QRgb__gt__);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyQImage_fill(PyQImage *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    int color;
+    const char *keywords[] = {"color", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "i", (char **) keywords, &color)) {
+        return NULL;
+    }
+    self->obj->fill(color);
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyQImage_height(PyQImage *self)
+{
+    PyObject *py_retval;
+    int retval;
+
+    retval = self->obj->height();
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyQImage_load(PyQImage *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    bool retval;
+    const char *fileName;
+    Py_ssize_t fileName_len;
+    char *fmt;
+    const char *keywords[] = {"fileName", "fmt", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "s#s", (char **) keywords, &fileName, &fileName_len, &fmt)) {
+        return NULL;
+    }
+    retval = self->obj->load(QString::fromUtf8(fileName), fmt);
+    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
     return py_retval;
 }
 
@@ -1327,13 +1308,36 @@ _wrap_PyQImage_mirrored(PyQImage *self, PyObject *args, PyObject *kwargs)
 
 
 PyObject *
-_wrap_PyQImage_height(PyQImage *self)
+_wrap_PyQImage_setColor(PyQImage *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
-    int retval;
+    int i;
+    PyQRgb *c;
+    const char *keywords[] = {"i", "c", NULL};
 
-    retval = self->obj->height();
-    py_retval = Py_BuildValue((char *) "i", retval);
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "iO!", (char **) keywords, &i, &PyQRgb_Type, &c)) {
+        return NULL;
+    }
+    self->obj->setColor(i, *((PyQRgb *) c)->obj);
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyQImage_setColorTable(PyQImage *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    QVector<QRgb> colors_value;
+    const char *keywords[] = {"colors", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O&", (char **) keywords, _wrap_convert_py2c__QVector__lt___QRgb___gt__, &colors_value)) {
+        return NULL;
+    }
+    self->obj->setColorTable(colors_value);
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
     return py_retval;
 }
 
@@ -1424,55 +1428,6 @@ _wrap_PyQImage_width(PyQImage *self)
 }
 
 
-PyObject *
-_wrap_PyQImage_colorTable(PyQImage *self)
-{
-    PyObject *py_retval;
-    QVector< QRgb > retval;
-    PyQVector__lt__QRgb__gt__ *py_QVector__lt__QRgb__gt__;
-
-    retval = self->obj->colorTable();
-    py_QVector__lt__QRgb__gt__ = PyObject_New(PyQVector__lt__QRgb__gt__, &PyQVector__lt__QRgb__gt___Type);
-    py_QVector__lt__QRgb__gt__->obj = new QVector<QRgb>(retval);
-    py_retval = Py_BuildValue((char *) "N", py_QVector__lt__QRgb__gt__);
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyQImage_setColorTable(PyQImage *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    QVector<QRgb> colors_value;
-    const char *keywords[] = {"colors", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O&", (char **) keywords, _wrap_convert_py2c__QVector__lt___QRgb___gt__, &colors_value)) {
-        return NULL;
-    }
-    self->obj->setColorTable(colors_value);
-    Py_INCREF(Py_None);
-    py_retval = Py_None;
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyQImage_fill(PyQImage *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    int color;
-    const char *keywords[] = {"color", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "i", (char **) keywords, &color)) {
-        return NULL;
-    }
-    self->obj->fill(color);
-    Py_INCREF(Py_None);
-    py_retval = Py_None;
-    return py_retval;
-}
-
-
 static PyObject*
 _wrap_PyQImage__copy__(PyQImage *self)
 {
@@ -1485,16 +1440,16 @@ _wrap_PyQImage__copy__(PyQImage *self)
 }
 
 static PyMethodDef PyQImage_methods[] = {
-    {(char *) "load", (PyCFunction) _wrap_PyQImage_load, METH_KEYWORDS|METH_VARARGS, "load(fileName, fmt)\n\ntype: fileName: QString const\ntype: fmt: char *" },
-    {(char *) "setColor", (PyCFunction) _wrap_PyQImage_setColor, METH_KEYWORDS|METH_VARARGS, "setColor(i, c)\n\ntype: i: int\ntype: c: QRgb" },
     {(char *) "color", (PyCFunction) _wrap_PyQImage_color, METH_KEYWORDS|METH_VARARGS, "color(i)\n\ntype: i: int" },
-    {(char *) "mirrored", (PyCFunction) _wrap_PyQImage_mirrored, METH_KEYWORDS|METH_VARARGS, "mirrored(horiz, vert)\n\ntype: horiz: bool\ntype: vert: bool" },
+    {(char *) "colorTable", (PyCFunction) _wrap_PyQImage_colorTable, METH_NOARGS, "colorTable()\n\n" },
+    {(char *) "fill", (PyCFunction) _wrap_PyQImage_fill, METH_KEYWORDS|METH_VARARGS, "fill(color)\n\ntype: color: int" },
     {(char *) "height", (PyCFunction) _wrap_PyQImage_height, METH_NOARGS, "height()\n\n" },
+    {(char *) "load", (PyCFunction) _wrap_PyQImage_load, METH_KEYWORDS|METH_VARARGS, "load(fileName, fmt)\n\ntype: fileName: QString const\ntype: fmt: char *" },
+    {(char *) "mirrored", (PyCFunction) _wrap_PyQImage_mirrored, METH_KEYWORDS|METH_VARARGS, "mirrored(horiz, vert)\n\ntype: horiz: bool\ntype: vert: bool" },
+    {(char *) "setColor", (PyCFunction) _wrap_PyQImage_setColor, METH_KEYWORDS|METH_VARARGS, "setColor(i, c)\n\ntype: i: int\ntype: c: QRgb" },
+    {(char *) "setColorTable", (PyCFunction) _wrap_PyQImage_setColorTable, METH_KEYWORDS|METH_VARARGS, "setColorTable(colors)\n\ntype: colors: QVector< QRgb >" },
     {(char *) "setPixel", (PyCFunction) _wrap_PyQImage_setPixel, METH_KEYWORDS|METH_VARARGS, NULL },
     {(char *) "width", (PyCFunction) _wrap_PyQImage_width, METH_NOARGS, "width()\n\n" },
-    {(char *) "colorTable", (PyCFunction) _wrap_PyQImage_colorTable, METH_NOARGS, "colorTable()\n\n" },
-    {(char *) "setColorTable", (PyCFunction) _wrap_PyQImage_setColorTable, METH_KEYWORDS|METH_VARARGS, "setColorTable(colors)\n\ntype: colors: QVector< QRgb >" },
-    {(char *) "fill", (PyCFunction) _wrap_PyQImage_fill, METH_KEYWORDS|METH_VARARGS, "fill(color)\n\ntype: color: int" },
     {(char *) "__copy__", (PyCFunction) _wrap_PyQImage__copy__, METH_NOARGS, NULL},
     {NULL, NULL, 0, NULL}
 };
@@ -1633,33 +1588,6 @@ _wrap_PyQPixmap_convertFromImage(PyQPixmap *self, PyObject *args, PyObject *kwar
 
 
 PyObject *
-_wrap_PyQPixmap_width(PyQPixmap *self)
-{
-    PyObject *py_retval;
-    int retval;
-
-    retval = self->obj->width();
-    py_retval = Py_BuildValue((char *) "i", retval);
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyQPixmap_toImage(PyQPixmap *self)
-{
-    PyObject *py_retval;
-    PyQImage *py_QImage;
-
-    QImage const & retval = self->obj->toImage();
-    py_QImage = PyObject_New(PyQImage, &PyQImage_Type);
-    py_QImage->flags = PYBINDGEN_WRAPPER_FLAG_NONE;
-    py_QImage->obj = new QImage(retval);
-    py_retval = Py_BuildValue((char *) "N", py_QImage);
-    return py_retval;
-}
-
-
-PyObject *
 _wrap_PyQPixmap_fromImage(PyQPixmap *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
@@ -1688,6 +1616,33 @@ _wrap_PyQPixmap_height(PyQPixmap *self)
 }
 
 
+PyObject *
+_wrap_PyQPixmap_toImage(PyQPixmap *self)
+{
+    PyObject *py_retval;
+    PyQImage *py_QImage;
+
+    QImage const & retval = self->obj->toImage();
+    py_QImage = PyObject_New(PyQImage, &PyQImage_Type);
+    py_QImage->flags = PYBINDGEN_WRAPPER_FLAG_NONE;
+    py_QImage->obj = new QImage(retval);
+    py_retval = Py_BuildValue((char *) "N", py_QImage);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyQPixmap_width(PyQPixmap *self)
+{
+    PyObject *py_retval;
+    int retval;
+
+    retval = self->obj->width();
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
+
 static PyObject*
 _wrap_PyQPixmap__copy__(PyQPixmap *self)
 {
@@ -1701,10 +1656,10 @@ _wrap_PyQPixmap__copy__(PyQPixmap *self)
 
 static PyMethodDef PyQPixmap_methods[] = {
     {(char *) "convertFromImage", (PyCFunction) _wrap_PyQPixmap_convertFromImage, METH_KEYWORDS|METH_VARARGS, "convertFromImage(image)\n\ntype: image: QImage const &" },
-    {(char *) "width", (PyCFunction) _wrap_PyQPixmap_width, METH_NOARGS, "width()\n\n" },
-    {(char *) "toImage", (PyCFunction) _wrap_PyQPixmap_toImage, METH_NOARGS, "toImage()\n\n" },
     {(char *) "fromImage", (PyCFunction) _wrap_PyQPixmap_fromImage, METH_KEYWORDS|METH_VARARGS, "fromImage(image)\n\ntype: image: QImage const &" },
     {(char *) "height", (PyCFunction) _wrap_PyQPixmap_height, METH_NOARGS, "height()\n\n" },
+    {(char *) "toImage", (PyCFunction) _wrap_PyQPixmap_toImage, METH_NOARGS, "toImage()\n\n" },
+    {(char *) "width", (PyCFunction) _wrap_PyQPixmap_width, METH_NOARGS, "width()\n\n" },
     {(char *) "__copy__", (PyCFunction) _wrap_PyQPixmap__copy__, METH_NOARGS, NULL},
     {NULL, NULL, 0, NULL}
 };
@@ -2943,21 +2898,16 @@ _wrap_PyTiledObject__tp_init(void)
 
 
 PyObject *
-_wrap_PyTiledObject_setProperty(PyTiledObject *self, PyObject *args, PyObject *kwargs)
+_wrap_PyTiledObject_properties(PyTiledObject *self)
 {
     PyObject *py_retval;
-    const char *prop;
-    Py_ssize_t prop_len;
-    const char *val;
-    Py_ssize_t val_len;
-    const char *keywords[] = {"prop", "val", NULL};
+    PyTiledProperties *py_Properties;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "s#s#", (char **) keywords, &prop, &prop_len, &val, &val_len)) {
-        return NULL;
-    }
-    self->obj->setProperty(QString::fromUtf8(prop), QString::fromUtf8(val));
-    Py_INCREF(Py_None);
-    py_retval = Py_None;
+    Tiled::Properties const retval = self->obj->properties();
+    py_Properties = PyObject_New(PyTiledProperties, &PyTiledProperties_Type);
+    py_Properties->flags = PYBINDGEN_WRAPPER_FLAG_NONE;
+    py_Properties->obj = new Tiled::Properties(retval);
+    py_retval = Py_BuildValue((char *) "N", py_Properties);
     return py_retval;
 }
 
@@ -2981,23 +2931,28 @@ _wrap_PyTiledObject_propertyAsString(PyTiledObject *self, PyObject *args, PyObje
 
 
 PyObject *
-_wrap_PyTiledObject_properties(PyTiledObject *self)
+_wrap_PyTiledObject_setProperty(PyTiledObject *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
-    PyTiledProperties *py_Properties;
+    const char *prop;
+    Py_ssize_t prop_len;
+    const char *val;
+    Py_ssize_t val_len;
+    const char *keywords[] = {"prop", "val", NULL};
 
-    Tiled::Properties const retval = self->obj->properties();
-    py_Properties = PyObject_New(PyTiledProperties, &PyTiledProperties_Type);
-    py_Properties->flags = PYBINDGEN_WRAPPER_FLAG_NONE;
-    py_Properties->obj = new Tiled::Properties(retval);
-    py_retval = Py_BuildValue((char *) "N", py_Properties);
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "s#s#", (char **) keywords, &prop, &prop_len, &val, &val_len)) {
+        return NULL;
+    }
+    self->obj->setProperty(QString::fromUtf8(prop), QString::fromUtf8(val));
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
     return py_retval;
 }
 
 static PyMethodDef PyTiledObject_methods[] = {
-    {(char *) "setProperty", (PyCFunction) _wrap_PyTiledObject_setProperty, METH_KEYWORDS|METH_VARARGS, "setProperty(prop, val)\n\ntype: prop: QString\ntype: val: QString" },
-    {(char *) "propertyAsString", (PyCFunction) _wrap_PyTiledObject_propertyAsString, METH_KEYWORDS|METH_VARARGS, "propertyAsString(prop)\n\ntype: prop: QString" },
     {(char *) "properties", (PyCFunction) _wrap_PyTiledObject_properties, METH_NOARGS, "properties()\n\n" },
+    {(char *) "propertyAsString", (PyCFunction) _wrap_PyTiledObject_propertyAsString, METH_KEYWORDS|METH_VARARGS, "propertyAsString(prop)\n\ntype: prop: QString" },
+    {(char *) "setProperty", (PyCFunction) _wrap_PyTiledObject_setProperty, METH_KEYWORDS|METH_VARARGS, "setProperty(prop, val)\n\ntype: prop: QString\ntype: val: QString" },
     {NULL, NULL, 0, NULL}
 };
 
@@ -3122,21 +3077,40 @@ _wrap_PyTiledTile__tp_init(PyTiledTile *self, PyObject *args, PyObject *kwargs)
 
 
 PyObject *
-_wrap_PyTiledTile_tileset(PyTiledTile *self)
+_wrap_PyTiledTile_height(PyTiledTile *self)
 {
     PyObject *py_retval;
-    Tiled::Tileset *retval;
-    PyTiledTileset *py_Tileset;
+    int retval;
 
-    retval = self->obj->tileset();
-    if (!(retval)) {
-        Py_INCREF(Py_None);
-        return Py_None;
-    }
-    py_Tileset = PyObject_New(PyTiledTileset, &PyTiledTileset_Type);
-    py_Tileset->obj = retval;
-    py_Tileset->flags = PYBINDGEN_WRAPPER_FLAG_OBJECT_NOT_OWNED;
-    py_retval = Py_BuildValue((char *) "N", py_Tileset);
+    retval = self->obj->height();
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledTile_id(PyTiledTile *self)
+{
+    PyObject *py_retval;
+    int retval;
+
+    retval = self->obj->id();
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledTile_image(PyTiledTile *self)
+{
+    PyObject *py_retval;
+    PyQPixmap *py_QPixmap;
+
+    QPixmap const & retval = self->obj->image();
+    py_QPixmap = PyObject_New(PyQPixmap, &PyQPixmap_Type);
+    py_QPixmap->flags = PYBINDGEN_WRAPPER_FLAG_NONE;
+    py_QPixmap->obj = new QPixmap(retval);
+    py_retval = Py_BuildValue((char *) "N", py_QPixmap);
     return py_retval;
 }
 
@@ -3159,28 +3133,21 @@ _wrap_PyTiledTile_setImage(PyTiledTile *self, PyObject *args, PyObject *kwargs)
 
 
 PyObject *
-_wrap_PyTiledTile_image(PyTiledTile *self)
+_wrap_PyTiledTile_tileset(PyTiledTile *self)
 {
     PyObject *py_retval;
-    PyQPixmap *py_QPixmap;
+    Tiled::Tileset *retval;
+    PyTiledTileset *py_Tileset;
 
-    QPixmap const & retval = self->obj->image();
-    py_QPixmap = PyObject_New(PyQPixmap, &PyQPixmap_Type);
-    py_QPixmap->flags = PYBINDGEN_WRAPPER_FLAG_NONE;
-    py_QPixmap->obj = new QPixmap(retval);
-    py_retval = Py_BuildValue((char *) "N", py_QPixmap);
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledTile_height(PyTiledTile *self)
-{
-    PyObject *py_retval;
-    int retval;
-
-    retval = self->obj->height();
-    py_retval = Py_BuildValue((char *) "i", retval);
+    retval = self->obj->tileset();
+    if (!(retval)) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+    py_Tileset = PyObject_New(PyTiledTileset, &PyTiledTileset_Type);
+    py_Tileset->obj = retval;
+    py_Tileset->flags = PYBINDGEN_WRAPPER_FLAG_OBJECT_NOT_OWNED;
+    py_retval = Py_BuildValue((char *) "N", py_Tileset);
     return py_retval;
 }
 
@@ -3196,25 +3163,13 @@ _wrap_PyTiledTile_width(PyTiledTile *self)
     return py_retval;
 }
 
-
-PyObject *
-_wrap_PyTiledTile_id(PyTiledTile *self)
-{
-    PyObject *py_retval;
-    int retval;
-
-    retval = self->obj->id();
-    py_retval = Py_BuildValue((char *) "i", retval);
-    return py_retval;
-}
-
 static PyMethodDef PyTiledTile_methods[] = {
-    {(char *) "tileset", (PyCFunction) _wrap_PyTiledTile_tileset, METH_NOARGS, "tileset()\n\n" },
-    {(char *) "setImage", (PyCFunction) _wrap_PyTiledTile_setImage, METH_KEYWORDS|METH_VARARGS, "setImage(image)\n\ntype: image: QPixmap const &" },
-    {(char *) "image", (PyCFunction) _wrap_PyTiledTile_image, METH_NOARGS, "image()\n\n" },
     {(char *) "height", (PyCFunction) _wrap_PyTiledTile_height, METH_NOARGS, "height()\n\n" },
-    {(char *) "width", (PyCFunction) _wrap_PyTiledTile_width, METH_NOARGS, "width()\n\n" },
     {(char *) "id", (PyCFunction) _wrap_PyTiledTile_id, METH_NOARGS, "id()\n\n" },
+    {(char *) "image", (PyCFunction) _wrap_PyTiledTile_image, METH_NOARGS, "image()\n\n" },
+    {(char *) "setImage", (PyCFunction) _wrap_PyTiledTile_setImage, METH_KEYWORDS|METH_VARARGS, "setImage(image)\n\ntype: image: QPixmap const &" },
+    {(char *) "tileset", (PyCFunction) _wrap_PyTiledTile_tileset, METH_NOARGS, "tileset()\n\n" },
+    {(char *) "width", (PyCFunction) _wrap_PyTiledTile_width, METH_NOARGS, "width()\n\n" },
     {NULL, NULL, 0, NULL}
 };
 
@@ -3340,91 +3295,6 @@ _wrap_PyTiledTileset_columnCount(PyTiledTileset *self)
 
 
 PyObject *
-_wrap_PyTiledTileset_loadFromImage(PyTiledTileset *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    bool retval;
-    PyQImage *img;
-    const char *file;
-    Py_ssize_t file_len;
-    const char *keywords[] = {"img", "file", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!s#", (char **) keywords, &PyQImage_Type, &img, &file, &file_len)) {
-        return NULL;
-    }
-    retval = self->obj->loadFromImage(*((PyQImage *) img)->obj, QString::fromUtf8(file));
-    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledTileset_tileSpacing(PyTiledTileset *self)
-{
-    PyObject *py_retval;
-    int retval;
-
-    retval = self->obj->tileSpacing();
-    py_retval = Py_BuildValue((char *) "i", retval);
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledTileset_name(PyTiledTileset *self)
-{
-    PyObject *py_retval;
-    QString retval;
-
-    retval = self->obj->name();
-    py_retval = Py_BuildValue((char *) "s", retval.toUtf8().data());
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledTileset_setName(PyTiledTileset *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    const char *name;
-    Py_ssize_t name_len;
-    const char *keywords[] = {"name", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "s#", (char **) keywords, &name, &name_len)) {
-        return NULL;
-    }
-    self->obj->setName(QString::fromUtf8(name));
-    Py_INCREF(Py_None);
-    py_retval = Py_None;
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledTileset_tileHeight(PyTiledTileset *self)
-{
-    PyObject *py_retval;
-    int retval;
-
-    retval = self->obj->tileHeight();
-    py_retval = Py_BuildValue((char *) "i", retval);
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledTileset_tileWidth(PyTiledTileset *self)
-{
-    PyObject *py_retval;
-    int retval;
-
-    retval = self->obj->tileWidth();
-    py_retval = Py_BuildValue((char *) "i", retval);
-    return py_retval;
-}
-
-
-PyObject *
 _wrap_PyTiledTileset_create(PyTiledTileset *PYBINDGEN_UNUSED(dummy), PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
@@ -3450,16 +3320,92 @@ _wrap_PyTiledTileset_create(PyTiledTileset *PYBINDGEN_UNUSED(dummy), PyObject *a
 
 
 PyObject *
-_wrap_PyTiledTileset_transparentColor(PyTiledTileset *self)
+_wrap_PyTiledTileset_fileName(PyTiledTileset *self)
 {
     PyObject *py_retval;
-    PyQColor *py_QColor;
+    QString retval;
 
-    QColor retval = self->obj->transparentColor();
-    py_QColor = PyObject_New(PyQColor, &PyQColor_Type);
-    py_QColor->flags = PYBINDGEN_WRAPPER_FLAG_NONE;
-    py_QColor->obj = new QColor(retval);
-    py_retval = Py_BuildValue((char *) "N", py_QColor);
+    retval = self->obj->fileName();
+    py_retval = Py_BuildValue((char *) "s", retval.toUtf8().data());
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledTileset_imageHeight(PyTiledTileset *self)
+{
+    PyObject *py_retval;
+    int retval;
+
+    retval = self->obj->imageHeight();
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledTileset_imageWidth(PyTiledTileset *self)
+{
+    PyObject *py_retval;
+    int retval;
+
+    retval = self->obj->imageWidth();
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledTileset_isExternal(PyTiledTileset *self)
+{
+    PyObject *py_retval;
+    bool retval;
+
+    retval = self->obj->isExternal();
+    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledTileset_loadFromImage(PyTiledTileset *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    bool retval;
+    PyQImage *img;
+    const char *file;
+    Py_ssize_t file_len;
+    const char *keywords[] = {"img", "file", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!s#", (char **) keywords, &PyQImage_Type, &img, &file, &file_len)) {
+        return NULL;
+    }
+    retval = self->obj->loadFromImage(*((PyQImage *) img)->obj, QString::fromUtf8(file));
+    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledTileset_margin(PyTiledTileset *self)
+{
+    PyObject *py_retval;
+    int retval;
+
+    retval = self->obj->margin();
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledTileset_name(PyTiledTileset *self)
+{
+    PyObject *py_retval;
+    QString retval;
+
+    retval = self->obj->name();
+    py_retval = Py_BuildValue((char *) "s", retval.toUtf8().data());
     return py_retval;
 }
 
@@ -3476,6 +3422,41 @@ _wrap_PyTiledTileset_setFileName(PyTiledTileset *self, PyObject *args, PyObject 
         return NULL;
     }
     self->obj->setFileName(QString::fromUtf8(name));
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledTileset_setName(PyTiledTileset *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    const char *name;
+    Py_ssize_t name_len;
+    const char *keywords[] = {"name", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "s#", (char **) keywords, &name, &name_len)) {
+        return NULL;
+    }
+    self->obj->setName(QString::fromUtf8(name));
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledTileset_setTransparentColor(PyTiledTileset *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    PyQColor *col;
+    const char *keywords[] = {"col", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!", (char **) keywords, &PyQColor_Type, &col)) {
+        return NULL;
+    }
+    self->obj->setTransparentColor(*((PyQColor *) col)->obj);
     Py_INCREF(Py_None);
     py_retval = Py_None;
     return py_retval;
@@ -3508,18 +3489,6 @@ _wrap_PyTiledTileset_tileAt(PyTiledTileset *self, PyObject *args, PyObject *kwar
 
 
 PyObject *
-_wrap_PyTiledTileset_fileName(PyTiledTileset *self)
-{
-    PyObject *py_retval;
-    QString retval;
-
-    retval = self->obj->fileName();
-    py_retval = Py_BuildValue((char *) "s", retval.toUtf8().data());
-    return py_retval;
-}
-
-
-PyObject *
 _wrap_PyTiledTileset_tileCount(PyTiledTileset *self)
 {
     PyObject *py_retval;
@@ -3532,88 +3501,74 @@ _wrap_PyTiledTileset_tileCount(PyTiledTileset *self)
 
 
 PyObject *
-_wrap_PyTiledTileset_imageHeight(PyTiledTileset *self)
+_wrap_PyTiledTileset_tileHeight(PyTiledTileset *self)
 {
     PyObject *py_retval;
     int retval;
 
-    retval = self->obj->imageHeight();
+    retval = self->obj->tileHeight();
     py_retval = Py_BuildValue((char *) "i", retval);
     return py_retval;
 }
 
 
 PyObject *
-_wrap_PyTiledTileset_imageWidth(PyTiledTileset *self)
+_wrap_PyTiledTileset_tileSpacing(PyTiledTileset *self)
 {
     PyObject *py_retval;
     int retval;
 
-    retval = self->obj->imageWidth();
+    retval = self->obj->tileSpacing();
     py_retval = Py_BuildValue((char *) "i", retval);
     return py_retval;
 }
 
 
 PyObject *
-_wrap_PyTiledTileset_setTransparentColor(PyTiledTileset *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    PyQColor *col;
-    const char *keywords[] = {"col", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!", (char **) keywords, &PyQColor_Type, &col)) {
-        return NULL;
-    }
-    self->obj->setTransparentColor(*((PyQColor *) col)->obj);
-    Py_INCREF(Py_None);
-    py_retval = Py_None;
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledTileset_margin(PyTiledTileset *self)
+_wrap_PyTiledTileset_tileWidth(PyTiledTileset *self)
 {
     PyObject *py_retval;
     int retval;
 
-    retval = self->obj->margin();
+    retval = self->obj->tileWidth();
     py_retval = Py_BuildValue((char *) "i", retval);
     return py_retval;
 }
 
 
 PyObject *
-_wrap_PyTiledTileset_isExternal(PyTiledTileset *self)
+_wrap_PyTiledTileset_transparentColor(PyTiledTileset *self)
 {
     PyObject *py_retval;
-    bool retval;
+    PyQColor *py_QColor;
 
-    retval = self->obj->isExternal();
-    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
+    QColor retval = self->obj->transparentColor();
+    py_QColor = PyObject_New(PyQColor, &PyQColor_Type);
+    py_QColor->flags = PYBINDGEN_WRAPPER_FLAG_NONE;
+    py_QColor->obj = new QColor(retval);
+    py_retval = Py_BuildValue((char *) "N", py_QColor);
     return py_retval;
 }
 
 static PyMethodDef PyTiledTileset_methods[] = {
     {(char *) "columnCount", (PyCFunction) _wrap_PyTiledTileset_columnCount, METH_NOARGS, "columnCount()\n\n" },
-    {(char *) "loadFromImage", (PyCFunction) _wrap_PyTiledTileset_loadFromImage, METH_KEYWORDS|METH_VARARGS, "loadFromImage(img, file)\n\ntype: img: QImage const &\ntype: file: QString" },
-    {(char *) "tileSpacing", (PyCFunction) _wrap_PyTiledTileset_tileSpacing, METH_NOARGS, "tileSpacing()\n\n" },
-    {(char *) "name", (PyCFunction) _wrap_PyTiledTileset_name, METH_NOARGS, "name()\n\n" },
-    {(char *) "setName", (PyCFunction) _wrap_PyTiledTileset_setName, METH_KEYWORDS|METH_VARARGS, "setName(name)\n\ntype: name: QString" },
-    {(char *) "tileHeight", (PyCFunction) _wrap_PyTiledTileset_tileHeight, METH_NOARGS, "tileHeight()\n\n" },
-    {(char *) "tileWidth", (PyCFunction) _wrap_PyTiledTileset_tileWidth, METH_NOARGS, "tileWidth()\n\n" },
     {(char *) "create", (PyCFunction) _wrap_PyTiledTileset_create, METH_KEYWORDS|METH_VARARGS|METH_STATIC, "create(name, tileWidth, tileHeight, tileSpacing, margin)\n\ntype: name: QString\ntype: tileWidth: int\ntype: tileHeight: int\ntype: tileSpacing: int\ntype: margin: int" },
-    {(char *) "transparentColor", (PyCFunction) _wrap_PyTiledTileset_transparentColor, METH_NOARGS, "transparentColor()\n\n" },
-    {(char *) "setFileName", (PyCFunction) _wrap_PyTiledTileset_setFileName, METH_KEYWORDS|METH_VARARGS, "setFileName(name)\n\ntype: name: QString" },
-    {(char *) "tileAt", (PyCFunction) _wrap_PyTiledTileset_tileAt, METH_KEYWORDS|METH_VARARGS, "tileAt(id)\n\ntype: id: int" },
     {(char *) "fileName", (PyCFunction) _wrap_PyTiledTileset_fileName, METH_NOARGS, "fileName()\n\n" },
-    {(char *) "tileCount", (PyCFunction) _wrap_PyTiledTileset_tileCount, METH_NOARGS, "tileCount()\n\n" },
     {(char *) "imageHeight", (PyCFunction) _wrap_PyTiledTileset_imageHeight, METH_NOARGS, "imageHeight()\n\n" },
     {(char *) "imageWidth", (PyCFunction) _wrap_PyTiledTileset_imageWidth, METH_NOARGS, "imageWidth()\n\n" },
-    {(char *) "setTransparentColor", (PyCFunction) _wrap_PyTiledTileset_setTransparentColor, METH_KEYWORDS|METH_VARARGS, "setTransparentColor(col)\n\ntype: col: QColor" },
-    {(char *) "margin", (PyCFunction) _wrap_PyTiledTileset_margin, METH_NOARGS, "margin()\n\n" },
     {(char *) "isExternal", (PyCFunction) _wrap_PyTiledTileset_isExternal, METH_NOARGS, "isExternal()\n\n" },
+    {(char *) "loadFromImage", (PyCFunction) _wrap_PyTiledTileset_loadFromImage, METH_KEYWORDS|METH_VARARGS, "loadFromImage(img, file)\n\ntype: img: QImage const &\ntype: file: QString" },
+    {(char *) "margin", (PyCFunction) _wrap_PyTiledTileset_margin, METH_NOARGS, "margin()\n\n" },
+    {(char *) "name", (PyCFunction) _wrap_PyTiledTileset_name, METH_NOARGS, "name()\n\n" },
+    {(char *) "setFileName", (PyCFunction) _wrap_PyTiledTileset_setFileName, METH_KEYWORDS|METH_VARARGS, "setFileName(name)\n\ntype: name: QString" },
+    {(char *) "setName", (PyCFunction) _wrap_PyTiledTileset_setName, METH_KEYWORDS|METH_VARARGS, "setName(name)\n\ntype: name: QString" },
+    {(char *) "setTransparentColor", (PyCFunction) _wrap_PyTiledTileset_setTransparentColor, METH_KEYWORDS|METH_VARARGS, "setTransparentColor(col)\n\ntype: col: QColor" },
+    {(char *) "tileAt", (PyCFunction) _wrap_PyTiledTileset_tileAt, METH_KEYWORDS|METH_VARARGS, "tileAt(id)\n\ntype: id: int" },
+    {(char *) "tileCount", (PyCFunction) _wrap_PyTiledTileset_tileCount, METH_NOARGS, "tileCount()\n\n" },
+    {(char *) "tileHeight", (PyCFunction) _wrap_PyTiledTileset_tileHeight, METH_NOARGS, "tileHeight()\n\n" },
+    {(char *) "tileSpacing", (PyCFunction) _wrap_PyTiledTileset_tileSpacing, METH_NOARGS, "tileSpacing()\n\n" },
+    {(char *) "tileWidth", (PyCFunction) _wrap_PyTiledTileset_tileWidth, METH_NOARGS, "tileWidth()\n\n" },
+    {(char *) "transparentColor", (PyCFunction) _wrap_PyTiledTileset_transparentColor, METH_NOARGS, "transparentColor()\n\n" },
     {NULL, NULL, 0, NULL}
 };
 
@@ -3880,33 +3835,21 @@ _wrap_PyTiledLayer__tp_init(void)
 
 
 PyObject *
-_wrap_PyTiledLayer_opacity(PyTiledLayer *self)
+_wrap_PyTiledLayer_asObjectGroup(PyTiledLayer *self)
 {
     PyObject *py_retval;
-    double retval;
+    Tiled::ObjectGroup *retval;
+    PyTiledObjectGroup *py_ObjectGroup;
 
-    retval = self->obj->opacity();
-    py_retval = Py_BuildValue((char *) "d", retval);
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledLayer_map(PyTiledLayer *self)
-{
-    PyObject *py_retval;
-    Tiled::Map *retval;
-    PyTiledMap *py_Map;
-
-    retval = self->obj->map();
+    retval = self->obj->asObjectGroup();
     if (!(retval)) {
         Py_INCREF(Py_None);
         return Py_None;
     }
-    py_Map = PyObject_New(PyTiledMap, &PyTiledMap_Type);
-    py_Map->obj = retval;
-    py_Map->flags = PYBINDGEN_WRAPPER_FLAG_OBJECT_NOT_OWNED;
-    py_retval = Py_BuildValue((char *) "N", py_Map);
+    py_ObjectGroup = PyObject_New(PyTiledObjectGroup, &PyTiledObjectGroup_Type);
+    py_ObjectGroup->obj = retval;
+    py_ObjectGroup->flags = PYBINDGEN_WRAPPER_FLAG_OBJECT_NOT_OWNED;
+    py_retval = Py_BuildValue((char *) "N", py_ObjectGroup);
     return py_retval;
 }
 
@@ -3932,6 +3875,38 @@ _wrap_PyTiledLayer_asTileLayer(PyTiledLayer *self)
 
 
 PyObject *
+_wrap_PyTiledLayer_isVisible(PyTiledLayer *self)
+{
+    PyObject *py_retval;
+    bool retval;
+
+    retval = self->obj->isVisible();
+    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledLayer_map(PyTiledLayer *self)
+{
+    PyObject *py_retval;
+    Tiled::Map *retval;
+    PyTiledMap *py_Map;
+
+    retval = self->obj->map();
+    if (!(retval)) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+    py_Map = PyObject_New(PyTiledMap, &PyTiledMap_Type);
+    py_Map->obj = retval;
+    py_Map->flags = PYBINDGEN_WRAPPER_FLAG_OBJECT_NOT_OWNED;
+    py_retval = Py_BuildValue((char *) "N", py_Map);
+    return py_retval;
+}
+
+
+PyObject *
 _wrap_PyTiledLayer_name(PyTiledLayer *self)
 {
     PyObject *py_retval;
@@ -3939,6 +3914,18 @@ _wrap_PyTiledLayer_name(PyTiledLayer *self)
 
     retval = self->obj->name();
     py_retval = Py_BuildValue((char *) "s", retval.toUtf8().data());
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledLayer_opacity(PyTiledLayer *self)
+{
+    PyObject *py_retval;
+    double retval;
+
+    retval = self->obj->opacity();
+    py_retval = Py_BuildValue((char *) "d", retval);
     return py_retval;
 }
 
@@ -3962,43 +3949,6 @@ _wrap_PyTiledLayer_setName(PyTiledLayer *self, PyObject *args, PyObject *kwargs)
 
 
 PyObject *
-_wrap_PyTiledLayer_setX(PyTiledLayer *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    int x;
-    const char *keywords[] = {"x", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "i", (char **) keywords, &x)) {
-        return NULL;
-    }
-    self->obj->setX(x);
-    Py_INCREF(Py_None);
-    py_retval = Py_None;
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledLayer_asObjectGroup(PyTiledLayer *self)
-{
-    PyObject *py_retval;
-    Tiled::ObjectGroup *retval;
-    PyTiledObjectGroup *py_ObjectGroup;
-
-    retval = self->obj->asObjectGroup();
-    if (!(retval)) {
-        Py_INCREF(Py_None);
-        return Py_None;
-    }
-    py_ObjectGroup = PyObject_New(PyTiledObjectGroup, &PyTiledObjectGroup_Type);
-    py_ObjectGroup->obj = retval;
-    py_ObjectGroup->flags = PYBINDGEN_WRAPPER_FLAG_OBJECT_NOT_OWNED;
-    py_retval = Py_BuildValue((char *) "N", py_ObjectGroup);
-    return py_retval;
-}
-
-
-PyObject *
 _wrap_PyTiledLayer_setOpacity(PyTiledLayer *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
@@ -4011,42 +3961,6 @@ _wrap_PyTiledLayer_setOpacity(PyTiledLayer *self, PyObject *args, PyObject *kwar
     self->obj->setOpacity(opacity);
     Py_INCREF(Py_None);
     py_retval = Py_None;
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledLayer_isVisible(PyTiledLayer *self)
-{
-    PyObject *py_retval;
-    bool retval;
-
-    retval = self->obj->isVisible();
-    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledLayer_y(PyTiledLayer *self)
-{
-    PyObject *py_retval;
-    int retval;
-
-    retval = self->obj->y();
-    py_retval = Py_BuildValue((char *) "i", retval);
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledLayer_x(PyTiledLayer *self)
-{
-    PyObject *py_retval;
-    int retval;
-
-    retval = self->obj->x();
-    py_retval = Py_BuildValue((char *) "i", retval);
     return py_retval;
 }
 
@@ -4089,6 +4003,23 @@ _wrap_PyTiledLayer_setVisible(PyTiledLayer *self, PyObject *args, PyObject *kwar
 
 
 PyObject *
+_wrap_PyTiledLayer_setX(PyTiledLayer *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    int x;
+    const char *keywords[] = {"x", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "i", (char **) keywords, &x)) {
+        return NULL;
+    }
+    self->obj->setX(x);
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
+    return py_retval;
+}
+
+
+PyObject *
 _wrap_PyTiledLayer_setY(PyTiledLayer *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
@@ -4104,21 +4035,45 @@ _wrap_PyTiledLayer_setY(PyTiledLayer *self, PyObject *args, PyObject *kwargs)
     return py_retval;
 }
 
+
+PyObject *
+_wrap_PyTiledLayer_x(PyTiledLayer *self)
+{
+    PyObject *py_retval;
+    int retval;
+
+    retval = self->obj->x();
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledLayer_y(PyTiledLayer *self)
+{
+    PyObject *py_retval;
+    int retval;
+
+    retval = self->obj->y();
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
 static PyMethodDef PyTiledLayer_methods[] = {
-    {(char *) "opacity", (PyCFunction) _wrap_PyTiledLayer_opacity, METH_NOARGS, "opacity()\n\n" },
-    {(char *) "map", (PyCFunction) _wrap_PyTiledLayer_map, METH_NOARGS, "map()\n\n" },
-    {(char *) "asTileLayer", (PyCFunction) _wrap_PyTiledLayer_asTileLayer, METH_NOARGS, "asTileLayer()\n\n" },
-    {(char *) "name", (PyCFunction) _wrap_PyTiledLayer_name, METH_NOARGS, "name()\n\n" },
-    {(char *) "setName", (PyCFunction) _wrap_PyTiledLayer_setName, METH_KEYWORDS|METH_VARARGS, "setName(name)\n\ntype: name: QString" },
-    {(char *) "setX", (PyCFunction) _wrap_PyTiledLayer_setX, METH_KEYWORDS|METH_VARARGS, "setX(x)\n\ntype: x: int" },
     {(char *) "asObjectGroup", (PyCFunction) _wrap_PyTiledLayer_asObjectGroup, METH_NOARGS, "asObjectGroup()\n\n" },
-    {(char *) "setOpacity", (PyCFunction) _wrap_PyTiledLayer_setOpacity, METH_KEYWORDS|METH_VARARGS, "setOpacity(opacity)\n\ntype: opacity: double" },
+    {(char *) "asTileLayer", (PyCFunction) _wrap_PyTiledLayer_asTileLayer, METH_NOARGS, "asTileLayer()\n\n" },
     {(char *) "isVisible", (PyCFunction) _wrap_PyTiledLayer_isVisible, METH_NOARGS, "isVisible()\n\n" },
-    {(char *) "y", (PyCFunction) _wrap_PyTiledLayer_y, METH_NOARGS, "y()\n\n" },
-    {(char *) "x", (PyCFunction) _wrap_PyTiledLayer_x, METH_NOARGS, "x()\n\n" },
+    {(char *) "map", (PyCFunction) _wrap_PyTiledLayer_map, METH_NOARGS, "map()\n\n" },
+    {(char *) "name", (PyCFunction) _wrap_PyTiledLayer_name, METH_NOARGS, "name()\n\n" },
+    {(char *) "opacity", (PyCFunction) _wrap_PyTiledLayer_opacity, METH_NOARGS, "opacity()\n\n" },
+    {(char *) "setName", (PyCFunction) _wrap_PyTiledLayer_setName, METH_KEYWORDS|METH_VARARGS, "setName(name)\n\ntype: name: QString" },
+    {(char *) "setOpacity", (PyCFunction) _wrap_PyTiledLayer_setOpacity, METH_KEYWORDS|METH_VARARGS, "setOpacity(opacity)\n\ntype: opacity: double" },
     {(char *) "setPosition", (PyCFunction) _wrap_PyTiledLayer_setPosition, METH_KEYWORDS|METH_VARARGS, "setPosition(x, y)\n\ntype: x: int\ntype: y: int" },
     {(char *) "setVisible", (PyCFunction) _wrap_PyTiledLayer_setVisible, METH_KEYWORDS|METH_VARARGS, "setVisible(visible)\n\ntype: visible: bool" },
+    {(char *) "setX", (PyCFunction) _wrap_PyTiledLayer_setX, METH_KEYWORDS|METH_VARARGS, "setX(x)\n\ntype: x: int" },
     {(char *) "setY", (PyCFunction) _wrap_PyTiledLayer_setY, METH_KEYWORDS|METH_VARARGS, "setY(y)\n\ntype: y: int" },
+    {(char *) "x", (PyCFunction) _wrap_PyTiledLayer_x, METH_NOARGS, "x()\n\n" },
+    {(char *) "y", (PyCFunction) _wrap_PyTiledLayer_y, METH_NOARGS, "y()\n\n" },
     {NULL, NULL, 0, NULL}
 };
 
@@ -4293,255 +4248,6 @@ int _wrap_PyTiledMap__tp_init(PyTiledMap *self, PyObject *args, PyObject *kwargs
 }
 
 
-PyObject *
-_wrap_PyTiledMap_setOrientation(PyTiledMap *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    Tiled::Map::Orientation o;
-    const char *keywords[] = {"o", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "i", (char **) keywords, &o)) {
-        return NULL;
-    }
-    self->obj->setOrientation(o);
-    Py_INCREF(Py_None);
-    py_retval = Py_None;
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMap_setHeight(PyTiledMap *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    int h;
-    const char *keywords[] = {"h", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "i", (char **) keywords, &h)) {
-        return NULL;
-    }
-    self->obj->setHeight(h);
-    Py_INCREF(Py_None);
-    py_retval = Py_None;
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMap_isTilesetUsed(PyTiledMap *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    bool retval;
-    PyTiledTileset *tileset;
-    Tiled::Tileset *tileset_ptr;
-    const char *keywords[] = {"tileset", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!", (char **) keywords, &PyTiledTileset_Type, &tileset)) {
-        return NULL;
-    }
-    tileset_ptr = (tileset ? tileset->obj : NULL);
-    retval = self->obj->isTilesetUsed(tileset_ptr);
-    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMap_layerAt(PyTiledMap *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    Tiled::Layer *retval;
-    int idx;
-    const char *keywords[] = {"idx", NULL};
-    PyTiledLayer *py_Layer;
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "i", (char **) keywords, &idx)) {
-        return NULL;
-    }
-    retval = self->obj->layerAt(idx);
-    if (!(retval)) {
-        Py_INCREF(Py_None);
-        return Py_None;
-    }
-    py_Layer = PyObject_New(PyTiledLayer, &PyTiledLayer_Type);
-    py_Layer->obj = retval;
-    py_Layer->flags = PYBINDGEN_WRAPPER_FLAG_OBJECT_NOT_OWNED;
-    py_retval = Py_BuildValue((char *) "N", py_Layer);
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMap_removeTilesetAt(PyTiledMap *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    int pos;
-    const char *keywords[] = {"pos", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "i", (char **) keywords, &pos)) {
-        return NULL;
-    }
-    self->obj->removeTilesetAt(pos);
-    Py_INCREF(Py_None);
-    py_retval = Py_None;
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMap_orientation(PyTiledMap *self)
-{
-    PyObject *py_retval;
-    Tiled::Map::Orientation retval;
-
-    retval = self->obj->orientation();
-    py_retval = Py_BuildValue((char *) "i", retval);
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMap_tileLayerCount(PyTiledMap *self)
-{
-    PyObject *py_retval;
-    int retval;
-
-    retval = self->obj->tileLayerCount();
-    py_retval = Py_BuildValue((char *) "i", retval);
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMap_tileHeight(PyTiledMap *self)
-{
-    PyObject *py_retval;
-    int retval;
-
-    retval = self->obj->tileHeight();
-    py_retval = Py_BuildValue((char *) "i", retval);
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMap_insertTileset(PyTiledMap *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    int pos;
-    PyTiledSharedTileset *tileset;
-    const char *keywords[] = {"pos", "tileset", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "iO!", (char **) keywords, &pos, &PyTiledSharedTileset_Type, &tileset)) {
-        return NULL;
-    }
-    self->obj->insertTileset(pos, *((PyTiledSharedTileset *) tileset)->obj);
-    Py_INCREF(Py_None);
-    py_retval = Py_None;
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMap_tileWidth(PyTiledMap *self)
-{
-    PyObject *py_retval;
-    int retval;
-
-    retval = self->obj->tileWidth();
-    py_retval = Py_BuildValue((char *) "i", retval);
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMap_height(PyTiledMap *self)
-{
-    PyObject *py_retval;
-    int retval;
-
-    retval = self->obj->height();
-    py_retval = Py_BuildValue((char *) "i", retval);
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMap_width(PyTiledMap *self)
-{
-    PyObject *py_retval;
-    int retval;
-
-    retval = self->obj->width();
-    py_retval = Py_BuildValue((char *) "i", retval);
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMap_replaceTileset(PyTiledMap *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    PyTiledSharedTileset *oldTileset;
-    PyTiledSharedTileset *newTileset;
-    const char *keywords[] = {"oldTileset", "newTileset", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!O!", (char **) keywords, &PyTiledSharedTileset_Type, &oldTileset, &PyTiledSharedTileset_Type, &newTileset)) {
-        return NULL;
-    }
-    self->obj->replaceTileset(*((PyTiledSharedTileset *) oldTileset)->obj, *((PyTiledSharedTileset *) newTileset)->obj);
-    Py_INCREF(Py_None);
-    py_retval = Py_None;
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMap_indexOfTileset(PyTiledMap *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    int retval;
-    PyTiledSharedTileset *tileset;
-    const char *keywords[] = {"tileset", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!", (char **) keywords, &PyTiledSharedTileset_Type, &tileset)) {
-        return NULL;
-    }
-    retval = self->obj->indexOfTileset(*((PyTiledSharedTileset *) tileset)->obj);
-    py_retval = Py_BuildValue((char *) "i", retval);
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMap_addTileset(PyTiledMap *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    PyTiledSharedTileset *tileset;
-    const char *keywords[] = {"tileset", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!", (char **) keywords, &PyTiledSharedTileset_Type, &tileset)) {
-        return NULL;
-    }
-    self->obj->addTileset(*((PyTiledSharedTileset *) tileset)->obj);
-    Py_INCREF(Py_None);
-    py_retval = Py_None;
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMap_layerCount(PyTiledMap *self)
-{
-    PyObject *py_retval;
-    int retval;
-
-    retval = self->obj->layerCount();
-    py_retval = Py_BuildValue((char *) "i", retval);
-    return py_retval;
-}
-
-
 
 PyObject *
 _wrap_PyTiledMap_addLayer__0(PyTiledMap *self, PyObject *args, PyObject *kwargs, PyObject **return_exception)
@@ -4658,21 +4364,121 @@ PyObject * _wrap_PyTiledMap_addLayer(PyTiledMap *self, PyObject *args, PyObject 
 
 
 PyObject *
-_wrap_PyTiledMap_tilesetAt(PyTiledMap *self, PyObject *args, PyObject *kwargs)
+_wrap_PyTiledMap_addTileset(PyTiledMap *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
+    PyTiledSharedTileset *tileset;
+    const char *keywords[] = {"tileset", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!", (char **) keywords, &PyTiledSharedTileset_Type, &tileset)) {
+        return NULL;
+    }
+    self->obj->addTileset(*((PyTiledSharedTileset *) tileset)->obj);
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMap_height(PyTiledMap *self)
+{
+    PyObject *py_retval;
+    int retval;
+
+    retval = self->obj->height();
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMap_indexOfTileset(PyTiledMap *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    int retval;
+    PyTiledSharedTileset *tileset;
+    const char *keywords[] = {"tileset", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!", (char **) keywords, &PyTiledSharedTileset_Type, &tileset)) {
+        return NULL;
+    }
+    retval = self->obj->indexOfTileset(*((PyTiledSharedTileset *) tileset)->obj);
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMap_insertTileset(PyTiledMap *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    int pos;
+    PyTiledSharedTileset *tileset;
+    const char *keywords[] = {"pos", "tileset", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "iO!", (char **) keywords, &pos, &PyTiledSharedTileset_Type, &tileset)) {
+        return NULL;
+    }
+    self->obj->insertTileset(pos, *((PyTiledSharedTileset *) tileset)->obj);
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMap_isTilesetUsed(PyTiledMap *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    bool retval;
+    PyTiledTileset *tileset;
+    Tiled::Tileset *tileset_ptr;
+    const char *keywords[] = {"tileset", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!", (char **) keywords, &PyTiledTileset_Type, &tileset)) {
+        return NULL;
+    }
+    tileset_ptr = (tileset ? tileset->obj : NULL);
+    retval = self->obj->isTilesetUsed(tileset_ptr);
+    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMap_layerAt(PyTiledMap *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    Tiled::Layer *retval;
     int idx;
     const char *keywords[] = {"idx", NULL};
-    PyTiledSharedTileset *py_SharedTileset;
+    PyTiledLayer *py_Layer;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "i", (char **) keywords, &idx)) {
         return NULL;
     }
-    Tiled::SharedTileset retval = self->obj->tilesetAt(idx);
-    py_SharedTileset = PyObject_New(PyTiledSharedTileset, &PyTiledSharedTileset_Type);
-    py_SharedTileset->flags = PYBINDGEN_WRAPPER_FLAG_NONE;
-    py_SharedTileset->obj = new Tiled::SharedTileset(retval);
-    py_retval = Py_BuildValue((char *) "N", py_SharedTileset);
+    retval = self->obj->layerAt(idx);
+    if (!(retval)) {
+        Py_INCREF(Py_None);
+        return Py_None;
+    }
+    py_Layer = PyObject_New(PyTiledLayer, &PyTiledLayer_Type);
+    py_Layer->obj = retval;
+    py_Layer->flags = PYBINDGEN_WRAPPER_FLAG_OBJECT_NOT_OWNED;
+    py_retval = Py_BuildValue((char *) "N", py_Layer);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMap_layerCount(PyTiledMap *self)
+{
+    PyObject *py_retval;
+    int retval;
+
+    retval = self->obj->layerCount();
+    py_retval = Py_BuildValue((char *) "i", retval);
     return py_retval;
 }
 
@@ -4685,6 +4491,87 @@ _wrap_PyTiledMap_objectGroupCount(PyTiledMap *self)
 
     retval = self->obj->objectGroupCount();
     py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMap_orientation(PyTiledMap *self)
+{
+    PyObject *py_retval;
+    Tiled::Map::Orientation retval;
+
+    retval = self->obj->orientation();
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMap_removeTilesetAt(PyTiledMap *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    int pos;
+    const char *keywords[] = {"pos", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "i", (char **) keywords, &pos)) {
+        return NULL;
+    }
+    self->obj->removeTilesetAt(pos);
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMap_replaceTileset(PyTiledMap *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    PyTiledSharedTileset *oldTileset;
+    PyTiledSharedTileset *newTileset;
+    const char *keywords[] = {"oldTileset", "newTileset", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!O!", (char **) keywords, &PyTiledSharedTileset_Type, &oldTileset, &PyTiledSharedTileset_Type, &newTileset)) {
+        return NULL;
+    }
+    self->obj->replaceTileset(*((PyTiledSharedTileset *) oldTileset)->obj, *((PyTiledSharedTileset *) newTileset)->obj);
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMap_setHeight(PyTiledMap *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    int h;
+    const char *keywords[] = {"h", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "i", (char **) keywords, &h)) {
+        return NULL;
+    }
+    self->obj->setHeight(h);
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMap_setOrientation(PyTiledMap *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    Tiled::Map::Orientation o;
+    const char *keywords[] = {"o", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "i", (char **) keywords, &o)) {
+        return NULL;
+    }
+    self->obj->setOrientation(o);
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
     return py_retval;
 }
 
@@ -4707,12 +4594,80 @@ _wrap_PyTiledMap_setWidth(PyTiledMap *self, PyObject *args, PyObject *kwargs)
 
 
 PyObject *
+_wrap_PyTiledMap_tileHeight(PyTiledMap *self)
+{
+    PyObject *py_retval;
+    int retval;
+
+    retval = self->obj->tileHeight();
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMap_tileLayerCount(PyTiledMap *self)
+{
+    PyObject *py_retval;
+    int retval;
+
+    retval = self->obj->tileLayerCount();
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMap_tileWidth(PyTiledMap *self)
+{
+    PyObject *py_retval;
+    int retval;
+
+    retval = self->obj->tileWidth();
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMap_tilesetAt(PyTiledMap *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    int idx;
+    const char *keywords[] = {"idx", NULL};
+    PyTiledSharedTileset *py_SharedTileset;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "i", (char **) keywords, &idx)) {
+        return NULL;
+    }
+    Tiled::SharedTileset retval = self->obj->tilesetAt(idx);
+    py_SharedTileset = PyObject_New(PyTiledSharedTileset, &PyTiledSharedTileset_Type);
+    py_SharedTileset->flags = PYBINDGEN_WRAPPER_FLAG_NONE;
+    py_SharedTileset->obj = new Tiled::SharedTileset(retval);
+    py_retval = Py_BuildValue((char *) "N", py_SharedTileset);
+    return py_retval;
+}
+
+
+PyObject *
 _wrap_PyTiledMap_tilesetCount(PyTiledMap *self)
 {
     PyObject *py_retval;
     int retval;
 
     retval = self->obj->tilesetCount();
+    py_retval = Py_BuildValue((char *) "i", retval);
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMap_width(PyTiledMap *self)
+{
+    PyObject *py_retval;
+    int retval;
+
+    retval = self->obj->width();
     py_retval = Py_BuildValue((char *) "i", retval);
     return py_retval;
 }
@@ -4730,27 +4685,27 @@ _wrap_PyTiledMap__copy__(PyTiledMap *self)
 }
 
 static PyMethodDef PyTiledMap_methods[] = {
-    {(char *) "setOrientation", (PyCFunction) _wrap_PyTiledMap_setOrientation, METH_KEYWORDS|METH_VARARGS, "setOrientation(o)\n\ntype: o: Tiled::Map::Orientation" },
-    {(char *) "setHeight", (PyCFunction) _wrap_PyTiledMap_setHeight, METH_KEYWORDS|METH_VARARGS, "setHeight(h)\n\ntype: h: int" },
+    {(char *) "addLayer", (PyCFunction) _wrap_PyTiledMap_addLayer, METH_KEYWORDS|METH_VARARGS, NULL },
+    {(char *) "addTileset", (PyCFunction) _wrap_PyTiledMap_addTileset, METH_KEYWORDS|METH_VARARGS, "addTileset(tileset)\n\ntype: tileset: SharedTileset" },
+    {(char *) "height", (PyCFunction) _wrap_PyTiledMap_height, METH_NOARGS, "height()\n\n" },
+    {(char *) "indexOfTileset", (PyCFunction) _wrap_PyTiledMap_indexOfTileset, METH_KEYWORDS|METH_VARARGS, "indexOfTileset(tileset)\n\ntype: tileset: SharedTileset const &" },
+    {(char *) "insertTileset", (PyCFunction) _wrap_PyTiledMap_insertTileset, METH_KEYWORDS|METH_VARARGS, "insertTileset(pos, tileset)\n\ntype: pos: int\ntype: tileset: SharedTileset" },
     {(char *) "isTilesetUsed", (PyCFunction) _wrap_PyTiledMap_isTilesetUsed, METH_KEYWORDS|METH_VARARGS, "isTilesetUsed(tileset)\n\ntype: tileset: Tileset const *" },
     {(char *) "layerAt", (PyCFunction) _wrap_PyTiledMap_layerAt, METH_KEYWORDS|METH_VARARGS, "layerAt(idx)\n\ntype: idx: int" },
-    {(char *) "removeTilesetAt", (PyCFunction) _wrap_PyTiledMap_removeTilesetAt, METH_KEYWORDS|METH_VARARGS, "removeTilesetAt(pos)\n\ntype: pos: int" },
-    {(char *) "orientation", (PyCFunction) _wrap_PyTiledMap_orientation, METH_NOARGS, "orientation()\n\n" },
-    {(char *) "tileLayerCount", (PyCFunction) _wrap_PyTiledMap_tileLayerCount, METH_NOARGS, "tileLayerCount()\n\n" },
-    {(char *) "tileHeight", (PyCFunction) _wrap_PyTiledMap_tileHeight, METH_NOARGS, "tileHeight()\n\n" },
-    {(char *) "insertTileset", (PyCFunction) _wrap_PyTiledMap_insertTileset, METH_KEYWORDS|METH_VARARGS, "insertTileset(pos, tileset)\n\ntype: pos: int\ntype: tileset: SharedTileset" },
-    {(char *) "tileWidth", (PyCFunction) _wrap_PyTiledMap_tileWidth, METH_NOARGS, "tileWidth()\n\n" },
-    {(char *) "height", (PyCFunction) _wrap_PyTiledMap_height, METH_NOARGS, "height()\n\n" },
-    {(char *) "width", (PyCFunction) _wrap_PyTiledMap_width, METH_NOARGS, "width()\n\n" },
-    {(char *) "replaceTileset", (PyCFunction) _wrap_PyTiledMap_replaceTileset, METH_KEYWORDS|METH_VARARGS, "replaceTileset(oldTileset, newTileset)\n\ntype: oldTileset: SharedTileset\ntype: newTileset: SharedTileset" },
-    {(char *) "indexOfTileset", (PyCFunction) _wrap_PyTiledMap_indexOfTileset, METH_KEYWORDS|METH_VARARGS, "indexOfTileset(tileset)\n\ntype: tileset: SharedTileset const &" },
-    {(char *) "addTileset", (PyCFunction) _wrap_PyTiledMap_addTileset, METH_KEYWORDS|METH_VARARGS, "addTileset(tileset)\n\ntype: tileset: SharedTileset" },
     {(char *) "layerCount", (PyCFunction) _wrap_PyTiledMap_layerCount, METH_NOARGS, "layerCount()\n\n" },
-    {(char *) "addLayer", (PyCFunction) _wrap_PyTiledMap_addLayer, METH_KEYWORDS|METH_VARARGS, NULL },
-    {(char *) "tilesetAt", (PyCFunction) _wrap_PyTiledMap_tilesetAt, METH_KEYWORDS|METH_VARARGS, "tilesetAt(idx)\n\ntype: idx: int" },
     {(char *) "objectGroupCount", (PyCFunction) _wrap_PyTiledMap_objectGroupCount, METH_NOARGS, "objectGroupCount()\n\n" },
+    {(char *) "orientation", (PyCFunction) _wrap_PyTiledMap_orientation, METH_NOARGS, "orientation()\n\n" },
+    {(char *) "removeTilesetAt", (PyCFunction) _wrap_PyTiledMap_removeTilesetAt, METH_KEYWORDS|METH_VARARGS, "removeTilesetAt(pos)\n\ntype: pos: int" },
+    {(char *) "replaceTileset", (PyCFunction) _wrap_PyTiledMap_replaceTileset, METH_KEYWORDS|METH_VARARGS, "replaceTileset(oldTileset, newTileset)\n\ntype: oldTileset: SharedTileset\ntype: newTileset: SharedTileset" },
+    {(char *) "setHeight", (PyCFunction) _wrap_PyTiledMap_setHeight, METH_KEYWORDS|METH_VARARGS, "setHeight(h)\n\ntype: h: int" },
+    {(char *) "setOrientation", (PyCFunction) _wrap_PyTiledMap_setOrientation, METH_KEYWORDS|METH_VARARGS, "setOrientation(o)\n\ntype: o: Tiled::Map::Orientation" },
     {(char *) "setWidth", (PyCFunction) _wrap_PyTiledMap_setWidth, METH_KEYWORDS|METH_VARARGS, "setWidth(w)\n\ntype: w: int" },
+    {(char *) "tileHeight", (PyCFunction) _wrap_PyTiledMap_tileHeight, METH_NOARGS, "tileHeight()\n\n" },
+    {(char *) "tileLayerCount", (PyCFunction) _wrap_PyTiledMap_tileLayerCount, METH_NOARGS, "tileLayerCount()\n\n" },
+    {(char *) "tileWidth", (PyCFunction) _wrap_PyTiledMap_tileWidth, METH_NOARGS, "tileWidth()\n\n" },
+    {(char *) "tilesetAt", (PyCFunction) _wrap_PyTiledMap_tilesetAt, METH_KEYWORDS|METH_VARARGS, "tilesetAt(idx)\n\ntype: idx: int" },
     {(char *) "tilesetCount", (PyCFunction) _wrap_PyTiledMap_tilesetCount, METH_NOARGS, "tilesetCount()\n\n" },
+    {(char *) "width", (PyCFunction) _wrap_PyTiledMap_width, METH_NOARGS, "width()\n\n" },
     {(char *) "__copy__", (PyCFunction) _wrap_PyTiledMap__copy__, METH_NOARGS, NULL},
     {NULL, NULL, 0, NULL}
 };
@@ -4925,6 +4880,18 @@ int _wrap_PyTiledCell__tp_init(PyTiledCell *self, PyObject *args, PyObject *kwar
 
 
 PyObject *
+_wrap_PyTiledCell_isEmpty(PyTiledCell *self)
+{
+    PyObject *py_retval;
+    bool retval;
+
+    retval = self->obj->isEmpty();
+    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
+    return py_retval;
+}
+
+
+PyObject *
 _wrap_PyTiledCell_tile(PyTiledCell *self)
 {
     PyObject *py_retval;
@@ -4944,18 +4911,6 @@ _wrap_PyTiledCell_tile(PyTiledCell *self)
 }
 
 
-PyObject *
-_wrap_PyTiledCell_isEmpty(PyTiledCell *self)
-{
-    PyObject *py_retval;
-    bool retval;
-
-    retval = self->obj->isEmpty();
-    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
-    return py_retval;
-}
-
-
 static PyObject*
 _wrap_PyTiledCell__copy__(PyTiledCell *self)
 {
@@ -4968,8 +4923,8 @@ _wrap_PyTiledCell__copy__(PyTiledCell *self)
 }
 
 static PyMethodDef PyTiledCell_methods[] = {
-    {(char *) "tile", (PyCFunction) _wrap_PyTiledCell_tile, METH_NOARGS, "tile()\n\n" },
     {(char *) "isEmpty", (PyCFunction) _wrap_PyTiledCell_isEmpty, METH_NOARGS, "isEmpty()\n\n" },
+    {(char *) "tile", (PyCFunction) _wrap_PyTiledCell_tile, METH_NOARGS, "tile()\n\n" },
     {(char *) "__copy__", (PyCFunction) _wrap_PyTiledCell__copy__, METH_NOARGS, NULL},
     {NULL, NULL, 0, NULL}
 };
@@ -5096,25 +5051,6 @@ _wrap_PyTiledTileLayer__tp_init(PyTiledTileLayer *self, PyObject *args, PyObject
 
 
 PyObject *
-_wrap_PyTiledTileLayer_referencesTileset(PyTiledTileLayer *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    bool retval;
-    PyTiledTileset *ts;
-    Tiled::Tileset *ts_ptr;
-    const char *keywords[] = {"ts", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!", (char **) keywords, &PyTiledTileset_Type, &ts)) {
-        return NULL;
-    }
-    ts_ptr = (ts ? ts->obj : NULL);
-    retval = self->obj->referencesTileset(ts_ptr);
-    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
-    return py_retval;
-}
-
-
-PyObject *
 _wrap_PyTiledTileLayer_cellAt(PyTiledTileLayer *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
@@ -5148,13 +5084,32 @@ _wrap_PyTiledTileLayer_height(PyTiledTileLayer *self)
 
 
 PyObject *
-_wrap_PyTiledTileLayer_width(PyTiledTileLayer *self)
+_wrap_PyTiledTileLayer_isEmpty(PyTiledTileLayer *self)
 {
     PyObject *py_retval;
-    int retval;
+    bool retval;
 
-    retval = self->obj->width();
-    py_retval = Py_BuildValue((char *) "i", retval);
+    retval = self->obj->isEmpty();
+    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledTileLayer_referencesTileset(PyTiledTileLayer *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    bool retval;
+    PyTiledTileset *ts;
+    Tiled::Tileset *ts_ptr;
+    const char *keywords[] = {"ts", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!", (char **) keywords, &PyTiledTileset_Type, &ts)) {
+        return NULL;
+    }
+    ts_ptr = (ts ? ts->obj : NULL);
+    retval = self->obj->referencesTileset(ts_ptr);
+    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
     return py_retval;
 }
 
@@ -5179,23 +5134,23 @@ _wrap_PyTiledTileLayer_setCell(PyTiledTileLayer *self, PyObject *args, PyObject 
 
 
 PyObject *
-_wrap_PyTiledTileLayer_isEmpty(PyTiledTileLayer *self)
+_wrap_PyTiledTileLayer_width(PyTiledTileLayer *self)
 {
     PyObject *py_retval;
-    bool retval;
+    int retval;
 
-    retval = self->obj->isEmpty();
-    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
+    retval = self->obj->width();
+    py_retval = Py_BuildValue((char *) "i", retval);
     return py_retval;
 }
 
 static PyMethodDef PyTiledTileLayer_methods[] = {
-    {(char *) "referencesTileset", (PyCFunction) _wrap_PyTiledTileLayer_referencesTileset, METH_KEYWORDS|METH_VARARGS, "referencesTileset(ts)\n\ntype: ts: Tileset *" },
     {(char *) "cellAt", (PyCFunction) _wrap_PyTiledTileLayer_cellAt, METH_KEYWORDS|METH_VARARGS, "cellAt(x, y)\n\ntype: x: int\ntype: y: int" },
     {(char *) "height", (PyCFunction) _wrap_PyTiledTileLayer_height, METH_NOARGS, "height()\n\n" },
-    {(char *) "width", (PyCFunction) _wrap_PyTiledTileLayer_width, METH_NOARGS, "width()\n\n" },
-    {(char *) "setCell", (PyCFunction) _wrap_PyTiledTileLayer_setCell, METH_KEYWORDS|METH_VARARGS, "setCell(x, y, c)\n\ntype: x: int\ntype: y: int\ntype: c: Cell" },
     {(char *) "isEmpty", (PyCFunction) _wrap_PyTiledTileLayer_isEmpty, METH_NOARGS, "isEmpty()\n\n" },
+    {(char *) "referencesTileset", (PyCFunction) _wrap_PyTiledTileLayer_referencesTileset, METH_KEYWORDS|METH_VARARGS, "referencesTileset(ts)\n\ntype: ts: Tileset *" },
+    {(char *) "setCell", (PyCFunction) _wrap_PyTiledTileLayer_setCell, METH_KEYWORDS|METH_VARARGS, "setCell(x, y, c)\n\ntype: x: int\ntype: y: int\ntype: c: Cell" },
+    {(char *) "width", (PyCFunction) _wrap_PyTiledTileLayer_width, METH_NOARGS, "width()\n\n" },
     {NULL, NULL, 0, NULL}
 };
 
@@ -5547,6 +5502,21 @@ int _wrap_PyTiledMapObject__tp_init(PyTiledMapObject *self, PyObject *args, PyOb
 
 
 PyObject *
+_wrap_PyTiledMapObject_cell(PyTiledMapObject *self)
+{
+    PyObject *py_retval;
+    PyTiledCell *py_Cell;
+
+    Tiled::Cell const retval = self->obj->cell();
+    py_Cell = PyObject_New(PyTiledCell, &PyTiledCell_Type);
+    py_Cell->flags = PYBINDGEN_WRAPPER_FLAG_NONE;
+    py_Cell->obj = new Tiled::Cell(retval);
+    py_retval = Py_BuildValue((char *) "N", py_Cell);
+    return py_retval;
+}
+
+
+PyObject *
 _wrap_PyTiledMapObject_height(PyTiledMapObject *self)
 {
     PyObject *py_retval;
@@ -5559,13 +5529,37 @@ _wrap_PyTiledMapObject_height(PyTiledMapObject *self)
 
 
 PyObject *
-_wrap_PyTiledMapObject_shape(PyTiledMapObject *self)
+_wrap_PyTiledMapObject_isVisible(PyTiledMapObject *self)
 {
     PyObject *py_retval;
-    Tiled::MapObject::Shape retval;
+    bool retval;
 
-    retval = self->obj->shape();
-    py_retval = Py_BuildValue((char *) "i", retval);
+    retval = self->obj->isVisible();
+    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMapObject_name(PyTiledMapObject *self)
+{
+    PyObject *py_retval;
+    QString retval;
+
+    retval = self->obj->name();
+    py_retval = Py_BuildValue((char *) "s", retval.toUtf8().data());
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMapObject_rotation(PyTiledMapObject *self)
+{
+    PyObject *py_retval;
+    double retval;
+
+    retval = self->obj->rotation();
+    py_retval = Py_BuildValue((char *) "d", retval);
     return py_retval;
 }
 
@@ -5588,16 +5582,34 @@ _wrap_PyTiledMapObject_setCell(PyTiledMapObject *self, PyObject *args, PyObject 
 
 
 PyObject *
-_wrap_PyTiledMapObject_setWidth(PyTiledMapObject *self, PyObject *args, PyObject *kwargs)
+_wrap_PyTiledMapObject_setHeight(PyTiledMapObject *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
-    double w;
-    const char *keywords[] = {"w", NULL};
+    double h;
+    const char *keywords[] = {"h", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "d", (char **) keywords, &w)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "d", (char **) keywords, &h)) {
         return NULL;
     }
-    self->obj->setWidth(w);
+    self->obj->setHeight(h);
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMapObject_setName(PyTiledMapObject *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    const char *n;
+    Py_ssize_t n_len;
+    const char *keywords[] = {"n", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "s#", (char **) keywords, &n, &n_len)) {
+        return NULL;
+    }
+    self->obj->setName(QString::fromUtf8(n));
     Py_INCREF(Py_None);
     py_retval = Py_None;
     return py_retval;
@@ -5615,6 +5627,57 @@ _wrap_PyTiledMapObject_setPosition(PyTiledMapObject *self, PyObject *args, PyObj
         return NULL;
     }
     self->obj->setPosition(*((PyQPointF *) pos)->obj);
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMapObject_setRotation(PyTiledMapObject *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    double r;
+    const char *keywords[] = {"r", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "d", (char **) keywords, &r)) {
+        return NULL;
+    }
+    self->obj->setRotation(r);
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMapObject_setShape(PyTiledMapObject *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    Tiled::MapObject::Shape s;
+    const char *keywords[] = {"s", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "i", (char **) keywords, &s)) {
+        return NULL;
+    }
+    self->obj->setShape(s);
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
+    return py_retval;
+}
+
+
+PyObject *
+_wrap_PyTiledMapObject_setSize(PyTiledMapObject *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    PyQSizeF *size;
+    const char *keywords[] = {"size", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!", (char **) keywords, &PyQSizeF_Type, &size)) {
+        return NULL;
+    }
+    self->obj->setSize(*((PyQSizeF *) size)->obj);
     Py_INCREF(Py_None);
     py_retval = Py_None;
     return py_retval;
@@ -5640,43 +5703,18 @@ _wrap_PyTiledMapObject_setType(PyTiledMapObject *self, PyObject *args, PyObject 
 
 
 PyObject *
-_wrap_PyTiledMapObject_cell(PyTiledMapObject *self)
+_wrap_PyTiledMapObject_setVisible(PyTiledMapObject *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
-    PyTiledCell *py_Cell;
+    bool v;
+    PyObject *py_v;
+    const char *keywords[] = {"v", NULL};
 
-    Tiled::Cell const retval = self->obj->cell();
-    py_Cell = PyObject_New(PyTiledCell, &PyTiledCell_Type);
-    py_Cell->flags = PYBINDGEN_WRAPPER_FLAG_NONE;
-    py_Cell->obj = new Tiled::Cell(retval);
-    py_retval = Py_BuildValue((char *) "N", py_Cell);
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMapObject_width(PyTiledMapObject *self)
-{
-    PyObject *py_retval;
-    double retval;
-
-    retval = self->obj->width();
-    py_retval = Py_BuildValue((char *) "d", retval);
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMapObject_setRotation(PyTiledMapObject *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    double r;
-    const char *keywords[] = {"r", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "d", (char **) keywords, &r)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O", (char **) keywords, &py_v)) {
         return NULL;
     }
-    self->obj->setRotation(r);
+    v = (bool) PyObject_IsTrue(py_v);
+    self->obj->setVisible(v);
     Py_INCREF(Py_None);
     py_retval = Py_None;
     return py_retval;
@@ -5684,43 +5722,18 @@ _wrap_PyTiledMapObject_setRotation(PyTiledMapObject *self, PyObject *args, PyObj
 
 
 PyObject *
-_wrap_PyTiledMapObject_type(PyTiledMapObject *self)
+_wrap_PyTiledMapObject_setWidth(PyTiledMapObject *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
-    QString retval;
+    double w;
+    const char *keywords[] = {"w", NULL};
 
-    retval = self->obj->type();
-    py_retval = Py_BuildValue((char *) "s", retval.toUtf8().data());
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMapObject_setName(PyTiledMapObject *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    const char *n;
-    Py_ssize_t n_len;
-    const char *keywords[] = {"n", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "s#", (char **) keywords, &n, &n_len)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "d", (char **) keywords, &w)) {
         return NULL;
     }
-    self->obj->setName(QString::fromUtf8(n));
+    self->obj->setWidth(w);
     Py_INCREF(Py_None);
     py_retval = Py_None;
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMapObject_rotation(PyTiledMapObject *self)
-{
-    PyObject *py_retval;
-    double retval;
-
-    retval = self->obj->rotation();
-    py_retval = Py_BuildValue((char *) "d", retval);
     return py_retval;
 }
 
@@ -5760,70 +5773,36 @@ _wrap_PyTiledMapObject_setY(PyTiledMapObject *self, PyObject *args, PyObject *kw
 
 
 PyObject *
-_wrap_PyTiledMapObject_setHeight(PyTiledMapObject *self, PyObject *args, PyObject *kwargs)
+_wrap_PyTiledMapObject_shape(PyTiledMapObject *self)
 {
     PyObject *py_retval;
-    double h;
-    const char *keywords[] = {"h", NULL};
+    Tiled::MapObject::Shape retval;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "d", (char **) keywords, &h)) {
-        return NULL;
-    }
-    self->obj->setHeight(h);
-    Py_INCREF(Py_None);
-    py_retval = Py_None;
+    retval = self->obj->shape();
+    py_retval = Py_BuildValue((char *) "i", retval);
     return py_retval;
 }
 
 
 PyObject *
-_wrap_PyTiledMapObject_name(PyTiledMapObject *self)
+_wrap_PyTiledMapObject_type(PyTiledMapObject *self)
 {
     PyObject *py_retval;
     QString retval;
 
-    retval = self->obj->name();
+    retval = self->obj->type();
     py_retval = Py_BuildValue((char *) "s", retval.toUtf8().data());
     return py_retval;
 }
 
 
 PyObject *
-_wrap_PyTiledMapObject_setSize(PyTiledMapObject *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    PyQSizeF *size;
-    const char *keywords[] = {"size", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!", (char **) keywords, &PyQSizeF_Type, &size)) {
-        return NULL;
-    }
-    self->obj->setSize(*((PyQSizeF *) size)->obj);
-    Py_INCREF(Py_None);
-    py_retval = Py_None;
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMapObject_isVisible(PyTiledMapObject *self)
-{
-    PyObject *py_retval;
-    bool retval;
-
-    retval = self->obj->isVisible();
-    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMapObject_y(PyTiledMapObject *self)
+_wrap_PyTiledMapObject_width(PyTiledMapObject *self)
 {
     PyObject *py_retval;
     double retval;
 
-    retval = self->obj->y();
+    retval = self->obj->width();
     py_retval = Py_BuildValue((char *) "d", retval);
     return py_retval;
 }
@@ -5842,63 +5821,39 @@ _wrap_PyTiledMapObject_x(PyTiledMapObject *self)
 
 
 PyObject *
-_wrap_PyTiledMapObject_setVisible(PyTiledMapObject *self, PyObject *args, PyObject *kwargs)
+_wrap_PyTiledMapObject_y(PyTiledMapObject *self)
 {
     PyObject *py_retval;
-    bool v;
-    PyObject *py_v;
-    const char *keywords[] = {"v", NULL};
+    double retval;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O", (char **) keywords, &py_v)) {
-        return NULL;
-    }
-    v = (bool) PyObject_IsTrue(py_v);
-    self->obj->setVisible(v);
-    Py_INCREF(Py_None);
-    py_retval = Py_None;
-    return py_retval;
-}
-
-
-PyObject *
-_wrap_PyTiledMapObject_setShape(PyTiledMapObject *self, PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    Tiled::MapObject::Shape s;
-    const char *keywords[] = {"s", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "i", (char **) keywords, &s)) {
-        return NULL;
-    }
-    self->obj->setShape(s);
-    Py_INCREF(Py_None);
-    py_retval = Py_None;
+    retval = self->obj->y();
+    py_retval = Py_BuildValue((char *) "d", retval);
     return py_retval;
 }
 
 static PyMethodDef PyTiledMapObject_methods[] = {
-    {(char *) "height", (PyCFunction) _wrap_PyTiledMapObject_height, METH_NOARGS, "height()\n\n" },
-    {(char *) "shape", (PyCFunction) _wrap_PyTiledMapObject_shape, METH_NOARGS, "shape()\n\n" },
-    {(char *) "setCell", (PyCFunction) _wrap_PyTiledMapObject_setCell, METH_KEYWORDS|METH_VARARGS, "setCell(c)\n\ntype: c: Tiled::Cell const" },
-    {(char *) "setWidth", (PyCFunction) _wrap_PyTiledMapObject_setWidth, METH_KEYWORDS|METH_VARARGS, "setWidth(w)\n\ntype: w: double" },
-    {(char *) "setPosition", (PyCFunction) _wrap_PyTiledMapObject_setPosition, METH_KEYWORDS|METH_VARARGS, "setPosition(pos)\n\ntype: pos: QPointF" },
-    {(char *) "setType", (PyCFunction) _wrap_PyTiledMapObject_setType, METH_KEYWORDS|METH_VARARGS, "setType(n)\n\ntype: n: QString" },
     {(char *) "cell", (PyCFunction) _wrap_PyTiledMapObject_cell, METH_NOARGS, "cell()\n\n" },
-    {(char *) "width", (PyCFunction) _wrap_PyTiledMapObject_width, METH_NOARGS, "width()\n\n" },
-    {(char *) "setRotation", (PyCFunction) _wrap_PyTiledMapObject_setRotation, METH_KEYWORDS|METH_VARARGS, "setRotation(r)\n\ntype: r: double" },
-    {(char *) "type", (PyCFunction) _wrap_PyTiledMapObject_type, METH_NOARGS, "type()\n\n" },
-    {(char *) "setName", (PyCFunction) _wrap_PyTiledMapObject_setName, METH_KEYWORDS|METH_VARARGS, "setName(n)\n\ntype: n: QString" },
+    {(char *) "height", (PyCFunction) _wrap_PyTiledMapObject_height, METH_NOARGS, "height()\n\n" },
+    {(char *) "isVisible", (PyCFunction) _wrap_PyTiledMapObject_isVisible, METH_NOARGS, "isVisible()\n\n" },
+    {(char *) "name", (PyCFunction) _wrap_PyTiledMapObject_name, METH_NOARGS, "name()\n\n" },
     {(char *) "rotation", (PyCFunction) _wrap_PyTiledMapObject_rotation, METH_NOARGS, "rotation()\n\n" },
+    {(char *) "setCell", (PyCFunction) _wrap_PyTiledMapObject_setCell, METH_KEYWORDS|METH_VARARGS, "setCell(c)\n\ntype: c: Tiled::Cell const" },
+    {(char *) "setHeight", (PyCFunction) _wrap_PyTiledMapObject_setHeight, METH_KEYWORDS|METH_VARARGS, "setHeight(h)\n\ntype: h: double" },
+    {(char *) "setName", (PyCFunction) _wrap_PyTiledMapObject_setName, METH_KEYWORDS|METH_VARARGS, "setName(n)\n\ntype: n: QString" },
+    {(char *) "setPosition", (PyCFunction) _wrap_PyTiledMapObject_setPosition, METH_KEYWORDS|METH_VARARGS, "setPosition(pos)\n\ntype: pos: QPointF" },
+    {(char *) "setRotation", (PyCFunction) _wrap_PyTiledMapObject_setRotation, METH_KEYWORDS|METH_VARARGS, "setRotation(r)\n\ntype: r: double" },
+    {(char *) "setShape", (PyCFunction) _wrap_PyTiledMapObject_setShape, METH_KEYWORDS|METH_VARARGS, "setShape(s)\n\ntype: s: Tiled::MapObject::Shape" },
+    {(char *) "setSize", (PyCFunction) _wrap_PyTiledMapObject_setSize, METH_KEYWORDS|METH_VARARGS, "setSize(size)\n\ntype: size: QSizeF" },
+    {(char *) "setType", (PyCFunction) _wrap_PyTiledMapObject_setType, METH_KEYWORDS|METH_VARARGS, "setType(n)\n\ntype: n: QString" },
+    {(char *) "setVisible", (PyCFunction) _wrap_PyTiledMapObject_setVisible, METH_KEYWORDS|METH_VARARGS, "setVisible(v)\n\ntype: v: bool" },
+    {(char *) "setWidth", (PyCFunction) _wrap_PyTiledMapObject_setWidth, METH_KEYWORDS|METH_VARARGS, "setWidth(w)\n\ntype: w: double" },
     {(char *) "setX", (PyCFunction) _wrap_PyTiledMapObject_setX, METH_KEYWORDS|METH_VARARGS, "setX(x)\n\ntype: x: double" },
     {(char *) "setY", (PyCFunction) _wrap_PyTiledMapObject_setY, METH_KEYWORDS|METH_VARARGS, "setY(y)\n\ntype: y: double" },
-    {(char *) "setHeight", (PyCFunction) _wrap_PyTiledMapObject_setHeight, METH_KEYWORDS|METH_VARARGS, "setHeight(h)\n\ntype: h: double" },
-    {(char *) "name", (PyCFunction) _wrap_PyTiledMapObject_name, METH_NOARGS, "name()\n\n" },
-    {(char *) "setSize", (PyCFunction) _wrap_PyTiledMapObject_setSize, METH_KEYWORDS|METH_VARARGS, "setSize(size)\n\ntype: size: QSizeF" },
-    {(char *) "isVisible", (PyCFunction) _wrap_PyTiledMapObject_isVisible, METH_NOARGS, "isVisible()\n\n" },
-    {(char *) "y", (PyCFunction) _wrap_PyTiledMapObject_y, METH_NOARGS, "y()\n\n" },
+    {(char *) "shape", (PyCFunction) _wrap_PyTiledMapObject_shape, METH_NOARGS, "shape()\n\n" },
+    {(char *) "type", (PyCFunction) _wrap_PyTiledMapObject_type, METH_NOARGS, "type()\n\n" },
+    {(char *) "width", (PyCFunction) _wrap_PyTiledMapObject_width, METH_NOARGS, "width()\n\n" },
     {(char *) "x", (PyCFunction) _wrap_PyTiledMapObject_x, METH_NOARGS, "x()\n\n" },
-    {(char *) "setVisible", (PyCFunction) _wrap_PyTiledMapObject_setVisible, METH_KEYWORDS|METH_VARARGS, "setVisible(v)\n\ntype: v: bool" },
-    {(char *) "setShape", (PyCFunction) _wrap_PyTiledMapObject_setShape, METH_KEYWORDS|METH_VARARGS, "setShape(s)\n\ntype: s: Tiled::MapObject::Shape" },
+    {(char *) "y", (PyCFunction) _wrap_PyTiledMapObject_y, METH_NOARGS, "y()\n\n" },
     {NULL, NULL, 0, NULL}
 };
 
@@ -6044,20 +5999,21 @@ _wrap_PyTiledObjectGroup_addObject(PyTiledObjectGroup *self, PyObject *args, PyO
 
 
 PyObject *
-_wrap_PyTiledObjectGroup_referencesTileset(PyTiledObjectGroup *self, PyObject *args, PyObject *kwargs)
+_wrap_PyTiledObjectGroup_insertObject(PyTiledObjectGroup *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
-    bool retval;
-    PyTiledTileset *ts;
-    Tiled::Tileset *ts_ptr;
-    const char *keywords[] = {"ts", NULL};
+    int idx;
+    PyTiledMapObject *object;
+    Tiled::MapObject *object_ptr;
+    const char *keywords[] = {"idx", "object", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!", (char **) keywords, &PyTiledTileset_Type, &ts)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "iO!", (char **) keywords, &idx, &PyTiledMapObject_Type, &object)) {
         return NULL;
     }
-    ts_ptr = (ts ? ts->obj : NULL);
-    retval = self->obj->referencesTileset(ts_ptr);
-    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
+    object_ptr = (object ? object->obj : NULL);
+    self->obj->insertObject(idx, object_ptr);
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
     return py_retval;
 }
 
@@ -6100,21 +6056,20 @@ _wrap_PyTiledObjectGroup_objectCount(PyTiledObjectGroup *self)
 
 
 PyObject *
-_wrap_PyTiledObjectGroup_insertObject(PyTiledObjectGroup *self, PyObject *args, PyObject *kwargs)
+_wrap_PyTiledObjectGroup_referencesTileset(PyTiledObjectGroup *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
-    int idx;
-    PyTiledMapObject *object;
-    Tiled::MapObject *object_ptr;
-    const char *keywords[] = {"idx", "object", NULL};
+    bool retval;
+    PyTiledTileset *ts;
+    Tiled::Tileset *ts_ptr;
+    const char *keywords[] = {"ts", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "iO!", (char **) keywords, &idx, &PyTiledMapObject_Type, &object)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!", (char **) keywords, &PyTiledTileset_Type, &ts)) {
         return NULL;
     }
-    object_ptr = (object ? object->obj : NULL);
-    self->obj->insertObject(idx, object_ptr);
-    Py_INCREF(Py_None);
-    py_retval = Py_None;
+    ts_ptr = (ts ? ts->obj : NULL);
+    retval = self->obj->referencesTileset(ts_ptr);
+    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
     return py_retval;
 }
 
@@ -6139,10 +6094,10 @@ _wrap_PyTiledObjectGroup_removeObject(PyTiledObjectGroup *self, PyObject *args, 
 
 static PyMethodDef PyTiledObjectGroup_methods[] = {
     {(char *) "addObject", (PyCFunction) _wrap_PyTiledObjectGroup_addObject, METH_KEYWORDS|METH_VARARGS, "addObject(object)\n\ntype: object: MapObject *" },
-    {(char *) "referencesTileset", (PyCFunction) _wrap_PyTiledObjectGroup_referencesTileset, METH_KEYWORDS|METH_VARARGS, "referencesTileset(ts)\n\ntype: ts: Tileset *" },
+    {(char *) "insertObject", (PyCFunction) _wrap_PyTiledObjectGroup_insertObject, METH_KEYWORDS|METH_VARARGS, "insertObject(idx, object)\n\ntype: idx: int\ntype: object: MapObject *" },
     {(char *) "objectAt", (PyCFunction) _wrap_PyTiledObjectGroup_objectAt, METH_KEYWORDS|METH_VARARGS, "objectAt(index)\n\ntype: index: int" },
     {(char *) "objectCount", (PyCFunction) _wrap_PyTiledObjectGroup_objectCount, METH_NOARGS, "objectCount()\n\n" },
-    {(char *) "insertObject", (PyCFunction) _wrap_PyTiledObjectGroup_insertObject, METH_KEYWORDS|METH_VARARGS, "insertObject(idx, object)\n\ntype: idx: int\ntype: object: MapObject *" },
+    {(char *) "referencesTileset", (PyCFunction) _wrap_PyTiledObjectGroup_referencesTileset, METH_KEYWORDS|METH_VARARGS, "referencesTileset(ts)\n\ntype: ts: Tileset *" },
     {(char *) "removeObject", (PyCFunction) _wrap_PyTiledObjectGroup_removeObject, METH_KEYWORDS|METH_VARARGS, "removeObject(object)\n\ntype: object: MapObject *" },
     {NULL, NULL, 0, NULL}
 };
@@ -6525,6 +6480,27 @@ inittiled_Tiled(void)
 
 
 PyObject *
+_wrap_tiled_isObjectGroupAt(PyObject * PYBINDGEN_UNUSED(dummy), PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    bool retval;
+    PyTiledMap *map;
+    Tiled::Map *map_ptr;
+    int idx;
+    const char *keywords[] = {"map", "idx", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!i", (char **) keywords, &PyTiledMap_Type, &map, &idx)) {
+        return NULL;
+    }
+    map_ptr = (map ? map->obj : NULL);
+    retval = isObjectGroupAt(map_ptr, idx);
+    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
+    return py_retval;
+}
+PyObject * _wrap_tiled_isObjectGroupAt(PyObject * PYBINDGEN_UNUSED(dummy), PyObject *args, PyObject *kwargs);
+
+
+PyObject *
 _wrap_tiled_isTileLayerAt(PyObject * PYBINDGEN_UNUSED(dummy), PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
@@ -6597,27 +6573,6 @@ PyObject * _wrap_tiled_objectGroupAt(PyObject * PYBINDGEN_UNUSED(dummy), PyObjec
 
 
 PyObject *
-_wrap_tiled_isObjectGroupAt(PyObject * PYBINDGEN_UNUSED(dummy), PyObject *args, PyObject *kwargs)
-{
-    PyObject *py_retval;
-    bool retval;
-    PyTiledMap *map;
-    Tiled::Map *map_ptr;
-    int idx;
-    const char *keywords[] = {"map", "idx", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!i", (char **) keywords, &PyTiledMap_Type, &map, &idx)) {
-        return NULL;
-    }
-    map_ptr = (map ? map->obj : NULL);
-    retval = isObjectGroupAt(map_ptr, idx);
-    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
-    return py_retval;
-}
-PyObject * _wrap_tiled_isObjectGroupAt(PyObject * PYBINDGEN_UNUSED(dummy), PyObject *args, PyObject *kwargs);
-
-
-PyObject *
 _wrap_tiled_tileLayerAt(PyObject * PYBINDGEN_UNUSED(dummy), PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
@@ -6646,10 +6601,10 @@ _wrap_tiled_tileLayerAt(PyObject * PYBINDGEN_UNUSED(dummy), PyObject *args, PyOb
 PyObject * _wrap_tiled_tileLayerAt(PyObject * PYBINDGEN_UNUSED(dummy), PyObject *args, PyObject *kwargs);
 
 static PyMethodDef tiled_functions[] = {
+    {(char *) "isObjectGroupAt", (PyCFunction) _wrap_tiled_isObjectGroupAt, METH_KEYWORDS|METH_VARARGS, "isObjectGroupAt(map, idx)\n\ntype: map: Tiled::Map *\ntype: idx: int" },
     {(char *) "isTileLayerAt", (PyCFunction) _wrap_tiled_isTileLayerAt, METH_KEYWORDS|METH_VARARGS, "isTileLayerAt(map, idx)\n\ntype: map: Tiled::Map *\ntype: idx: int" },
     {(char *) "loadTilesetFromFile", (PyCFunction) _wrap_tiled_loadTilesetFromFile, METH_KEYWORDS|METH_VARARGS, "loadTilesetFromFile(ts, file)\n\ntype: ts: Tileset *\ntype: file: QString" },
     {(char *) "objectGroupAt", (PyCFunction) _wrap_tiled_objectGroupAt, METH_KEYWORDS|METH_VARARGS, "objectGroupAt(map, idx)\n\ntype: map: Tiled::Map *\ntype: idx: int" },
-    {(char *) "isObjectGroupAt", (PyCFunction) _wrap_tiled_isObjectGroupAt, METH_KEYWORDS|METH_VARARGS, "isObjectGroupAt(map, idx)\n\ntype: map: Tiled::Map *\ntype: idx: int" },
     {(char *) "tileLayerAt", (PyCFunction) _wrap_tiled_tileLayerAt, METH_KEYWORDS|METH_VARARGS, "tileLayerAt(map, idx)\n\ntype: map: Tiled::Map *\ntype: idx: int" },
     {NULL, NULL, 0, NULL}
 };

--- a/src/plugins/python/pythonplugin.cpp
+++ b/src/plugins/python/pythonplugin.cpp
@@ -71,15 +71,10 @@ void PythonPlugin::initialize()
         Py_NoSiteFlag = 1;
         Py_NoUserSiteDirectory = 1;
 
-        #if PY_VERSION_HEX >= 0x03000000
         PyImport_AppendInittab("tiled", PyInit_tiled);
         PyImport_AppendInittab("tiled.qt", PyInit_tiled);
         PyImport_AppendInittab("tiled.Tiled", PyInit_tiled);
         Py_Initialize();
-        #else
-        Py_Initialize();
-        inittiled();
-        #endif
 
         PyObject *pmod = PyImport_ImportModule("tiled");
 

--- a/src/plugins/python/pythonplugin.h
+++ b/src/plugins/python/pythonplugin.h
@@ -133,7 +133,11 @@ private:
 
 } // namespace Python
 
+#if PY_VERSION_HEX >= 0x03000000
+PyMODINIT_FUNC PyInit_tiled(void);
+#else
 PyMODINIT_FUNC inittiled(void);
+#endif
 extern int _wrap_convert_py2c__Tiled__Map___star__(PyObject *obj, Tiled::Map * *address);
 extern PyObject* _wrap_convert_c2py__Tiled__Map_const(Tiled::Map const *cvalue);
 extern PyObject* _wrap_convert_c2py__Tiled__LoggingInterface(Tiled::LoggingInterface *cvalue);

--- a/src/plugins/python/pythonplugin.h
+++ b/src/plugins/python/pythonplugin.h
@@ -133,11 +133,7 @@ private:
 
 } // namespace Python
 
-#if PY_VERSION_HEX >= 0x03000000
 PyMODINIT_FUNC PyInit_tiled(void);
-#else
-PyMODINIT_FUNC inittiled(void);
-#endif
 extern int _wrap_convert_py2c__Tiled__Map___star__(PyObject *obj, Tiled::Map * *address);
 extern PyObject* _wrap_convert_c2py__Tiled__Map_const(Tiled::Map const *cvalue);
 extern PyObject* _wrap_convert_c2py__Tiled__LoggingInterface(Tiled::LoggingInterface *cvalue);

--- a/src/plugins/python/scripts/fotf.py
+++ b/src/plugins/python/scripts/fotf.py
@@ -4,10 +4,9 @@ Fury of the Furries level loader for Tiled
 """
 
 import sys, re
-from tiled import *
-from tiled.qt import *
+import tiled as T
 from os.path import dirname
-from lib import cpystruct, lbm
+from lib import cpystruct, lbm, utils
 from struct import pack,unpack
 from collections import namedtuple
 
@@ -19,31 +18,32 @@ MetaData = namedtuple(
   'fin1X, fin1Y, u1, fin2X, fin2Y, lvl'
   )
 
-class Fury(Plugin):
+class Fury(T.Plugin):
   @classmethod
   def nameFilter(cls):
     return "Fury of the Furries (*.bin)"
 
   @classmethod
   def supportsFile(cls, f):
-    return open(f).read(4) == 'byt4'
+    return open(f,'rb').read(4) == b'byt4'
 
   @classmethod
   def read(cls, f):
-    print 'Loading map at',f
+    print('Loading map at',f)
     fr = Fury(f)
 
-    m = Tiled.Map(Tiled.Map.Orthogonal, fr.w, fr.h, 16, 16)
+    m = T.Tiled.Map(T.Tiled.Map.Orthogonal, fr.w, fr.h, 16, 16)
     maps[f] = m
 
     # probably defined explicitly somewhere in the data
     decs = [1,3,4,2,8,6,7,9,10,5]
     decnum = (int(re.findall('[0-9]+', f).pop())-1)/10
     if decnum >= len(decs): decnum %= len(decs)
-    gfxf = dirname(f)+'/../DEC/DECOR%02i.LBM' % decs[decnum]
-    t = Tiled.Tileset.create('DECOR', 16,16, 0, 0)
+    gfxf = 'DEC/DECOR%02i.LBM' % decs[int(decnum)]
+    gfxf = utils.find_sensitive_path(dirname(f)+'/../', gfxf)
+    t = T.Tiled.Tileset.create('DECOR', 16,16, 0, 0)
     t.data().loadFromImage(fr.readtilegfx(gfxf), '')
-    l = Tiled.TileLayer('Tiles',0,0, fr.w, fr.h)
+    l = T.Tiled.TileLayer('Tiles',0,0, fr.w, fr.h)
     fr.populatetiles(l, t.data())
     # have to pass ownership so can't add tileset before populating layer
     m.addTileset(t)
@@ -51,16 +51,16 @@ class Fury(Plugin):
 
     #if not f.endswith('DATA19.BIN'):
     #  del fr.lvl[:21*2] # skip some zeros, todo: more deterministic
-    print len(fr.lvl), unpack('<40h', str(fr.lvl[:80]))
-    print MetaData(*unpack('<9h', str(fr.lvl[:18])))
+    print( len(fr.lvl), unpack('<40h', fr.lvl[:80]) )
+    print( MetaData(*unpack('<9h', fr.lvl[:18])) )
 
     return m
 
   @classmethod
   def write(cls, m, fn):
-    print "-- script doesn't support writing yet"
+    print("-- script doesn't support writing yet")
     fn += '.testing'
-    print ".. map(%i,%i) to" % (m.width(),m.height()), fn
+    print(".. map(%i,%i) to" % (m.width(),m.height()), fn)
     lvl = []
 
     with open(fn, 'w') as fh:
@@ -69,7 +69,7 @@ class Fury(Plugin):
         l = 0
         if isTileLayerAt(m, i):
           l = tileLayerAt(m, i)
-          print l
+          print(l)
         elif isObjectGroupAt(m, i):
           #l = objectGroupAt(m, i)
           continue
@@ -78,7 +78,7 @@ class Fury(Plugin):
           for y in range(l.height()):
             tiles.append( l.cellAt(x, y).tile.id() )
 
-        print >>fh, tiles
+        print(tiles, file=fh)
 
     return False
 
@@ -94,16 +94,16 @@ class Fury(Plugin):
         dat.extend(ldata.d)
         dat.extend([rdata.val for i in range(rdata.rep)])
 
-    print 'le',len(dat)
-    self.w, self.h = unpack("<2H", str(dat[:4]))
+    print('le',len(dat))
+    self.w, self.h = unpack("<2H", dat[:4])
     del dat[:4]
     self.lvl = dat
 
   def readtilegfx(self, fn):
     lc = dict(lbm.parselbm(fn))
-    #print lc['BMHD']
+    #print(lc['BMHD'])
     bd = list(lbm.readbody(lc['BODY'], lc['BMHD']))
-    img = QImage(lc['BMHD'].sz.w, lc['BMHD'].sz.h, QImage.Format_Indexed8)
+    img = T.qt.QImage(lc['BMHD'].sz.w, lc['BMHD'].sz.h, T.qt.QImage.Format_Indexed8)
     img.setColorTable(lc['CMAP'])
 
     # there should be a faster alternative
@@ -121,7 +121,7 @@ class Fury(Plugin):
         if tpos < t.tileCount():
           ti = t.tileAt(tpos)
           if ti != None:
-            l.setCell(x, y, Tiled.Cell(ti))
+            l.setCell(x, y, T.Tiled.Cell(ti))
         i += 2
       if self.w < 78: # padded to width of 78 tiles
         i += (78-self.w)*2

--- a/src/plugins/python/scripts/lib/lbm.py
+++ b/src/plugins/python/scripts/lib/lbm.py
@@ -15,8 +15,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-from tiled.qt import *
-from cpystruct import *
+import tiled as T
+from .cpystruct import *
 #from PyQt4.Qt import QColor  # to test outside tiled
 import struct
 
@@ -57,28 +57,29 @@ class CMAP(CpyStruct("BYTE color[3];", True)):
   def parse(cls, dat):
     c = CMAP()
     sz = struct.calcsize(getattr(cls, '__fstr'))
-    for i in range(len(dat)/sz):
+    for i in range(int(len(dat)/sz)):
       c.unpack(dat[i*sz:i*sz+sz])
-      yield QColor(c.color[0],c.color[1],c.color[2]).rgb()
+      yield T.qt.QColor(c.color[0],c.color[1],c.color[2]).rgb()
 
 def uncomp(dat):
   i = 0
   ret = bytearray()
   while i < len(dat):
-    v = struct.unpack('b', dat[i])[0]
+    #v = struct.unpack('b', dat[i:i+1])[0]
+    v = (256-dat[i])*-1 if dat[i] > 127 else dat[i]
     i += 1
     if v >= 0:
       for n in range(v+1):
-        ret += dat[i]
+        ret += dat[i:i+1]
         i += 1
     elif v != -128:
       for n in range(v-1,0,1):
-        ret += dat[i]
+        ret += dat[i:i+1]
       i += 1
   return ret
 
 def readbody(bd, ch):
-  bj = [0,(ch.sz.w+15) / 16 * 2]
+  bj = [0,int((ch.sz.w+15) / 16) * 2]
   for p in range(2,ch.planes):
     bj.append(bj[1] * p)
 
@@ -114,5 +115,5 @@ def parselbm(f):
 
 if __name__ == "__main__":
   import sys
-  print list(parselbm(sys.argv[1]))
+  print( list(parselbm(sys.argv[1])) )
 

--- a/src/plugins/python/scripts/lib/lbm.py
+++ b/src/plugins/python/scripts/lib/lbm.py
@@ -65,8 +65,7 @@ def uncomp(dat):
   i = 0
   ret = bytearray()
   while i < len(dat):
-    #v = struct.unpack('b', dat[i:i+1])[0]
-    v = (256-dat[i])*-1 if dat[i] > 127 else dat[i]
+    v = struct.unpack('b', dat[i:i+1])[0]
     i += 1
     if v >= 0:
       for n in range(v+1):

--- a/src/plugins/python/scripts/lib/mappy_types.py
+++ b/src/plugins/python/scripts/lib/mappy_types.py
@@ -1,5 +1,5 @@
 
-from cpystruct import *
+from .cpystruct import *
 
 """
 #define AN_END -1     /* Animation types, AN_END = end of anims */

--- a/src/plugins/python/scripts/lib/utils.py
+++ b/src/plugins/python/scripts/lib/utils.py
@@ -1,0 +1,17 @@
+import os.path
+
+
+def find_sensitive_path(dir, insensitive_path):
+    insensitive_path = insensitive_path.strip(os.path.sep)
+
+    parts = insensitive_path.split(os.path.sep)
+    next_name = parts[0]
+    for name in os.listdir(dir):
+        if next_name.lower() == name.lower():
+            improved_path = os.path.join(dir, name)
+            if len(parts) == 1:
+                return improved_path
+            else:
+                return find_sensitive_path(improved_path, os.path.sep.join(parts[1:]))
+    return None
+

--- a/src/plugins/python/scripts/mappy.py
+++ b/src/plugins/python/scripts/mappy.py
@@ -2,14 +2,19 @@
 Mappy support for Tiled
 2012-2013, <samuli@tuomola.net>
 """
-from tiled import *
-from tiled.qt import *
-import os, sys, struct
-from lib.mappy_types import BLKSTR, MPHD, fmpchunk
-import pickle
-from StringIO import StringIO
-from collections import OrderedDict
 from base64 import b64encode, b64decode
+from collections import OrderedDict
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+import os, sys, struct
+import pickle
+
+import tiled as T
+from lib.mappy_types import BLKSTR, MPHD, fmpchunk
+
 
 class FMPPicklerMixin:
 
@@ -23,12 +28,12 @@ class FMPPicklerMixin:
       frm.data = fh.read(4)
       filelen = frm.len - 16
       chunks[frm.id] = frm
-      print frm
+      print(frm)
 
       while fh.tell() < filelen:
         fc = fmpchunk()
         if not fc.unpack(fh): break
-        print fh.tell(), fc
+        print(fh.tell(), fc)
         fc.data = fh.read(fc.len)
         chunks[fc.id] = fc
 
@@ -39,7 +44,7 @@ class FMPPicklerMixin:
 
     with open(fn, 'wb') as fh:
       for k,v in chunks.items():
-        print k, len(v) + v.len # chunk header + data
+        print(k, len(v) + v.len) # chunk header + data
         fh.write(v.pack())
         fh.write(v.data)
 
@@ -48,17 +53,17 @@ class FMPPicklerMixin:
     src = StringIO()
     pi = pickle.Pickler(src, 2)
     pi.dump(chunks)
-    print "packlen", src.len
+    print("packlen", src.len)
     return b64encode(src.getvalue())
 
   @classmethod
   def unpicklechunks(cls, data):
     src = StringIO(b64decode(data))
-    print "unpacklen",src.len
+    print("unpacklen",src.len)
     return pickle.Unpickler(src).load()
 
 
-class Mappy(Plugin, FMPPicklerMixin):
+class Mappy(T.Plugin, FMPPicklerMixin):
 
   @classmethod
   def nameFilter(cls):
@@ -70,35 +75,35 @@ class Mappy(Plugin, FMPPicklerMixin):
 
   @classmethod
   def supportsFile(cls, f):
-    return open(f).read(4) == 'FORM'
+    return open(f,'rb').read(4) == b'FORM'
 
   @classmethod
   def read(cls, f):
 
-    print 'Loading map at',f
+    print('Loading map at',f)
     chunks = cls.unpackchunks(f)
     hd = MPHD()
     # perhaps cpystruct should only read as many bytes as it can handle?
     hd.unpack(chunks['MPHD'].data[:len(hd)])
 
-    m = Tiled.Map(Tiled.Map.Orthogonal, hd.mapwidth, hd.mapheight,
+    m = T.Tiled.Map(T.Tiled.Map.Orthogonal, hd.mapwidth, hd.mapheight,
                     hd.blockwidth, hd.blockheight)
     if hd.type == 2:
-      print 'Isometric maps not supported at the moment'
+      print('Isometric maps not supported at the moment')
       return m
 
-    m.setProperty('chunks', cls.picklechunks(chunks))
+    #TODO: m.setProperty('chunks', cls.picklechunks(chunks))
 
-    tset = Tiled.Tileset.create('Tiles', hd.blockwidth, hd.blockheight, 0, 0)
+    tset = T.Tiled.Tileset.create('Tiles', hd.blockwidth, hd.blockheight, 0, 0)
     cmap = list(FMPColormap.unpack(chunks['CMAP'].data))
     tset.data().loadFromImage(FMPTileGfx.unpack(hd, chunks['BGFX'].data, cmap), "")
 
     blks = FMPBlocks(chunks['BKDT'].data, hd).blocks
 
     for c in ['LYR'+str(i) for i in range(7,0,-1)]+['BODY']:
-      if not chunks.has_key(c): continue
-      print 'populating',c
-      lay = Tiled.TileLayer(c,0,0,hd.mapwidth, hd.mapheight)
+      if c not in chunks: continue
+      print('populating',c)
+      lay = T.Tiled.TileLayer(c,0,0,hd.mapwidth, hd.mapheight)
       lvl = list(FMPLayer.unpack(hd, chunks[c].data))
       FMPLayer.populate(lay, blks, tset.data(), hd, lvl)
       m.addLayer(lay)
@@ -111,14 +116,14 @@ class Mappy(Plugin, FMPPicklerMixin):
   @classmethod
   def write(cls, m, fn):
 
-    if m.orientation() != Tiled.Map.Orthogonal:
-      print 'Isometric maps not supported at the moment'
+    if m.orientation() != T.Tiled.Map.Orthogonal:
+      print('Isometric maps not supported at the moment')
       return False
     if not m.property('chunks'):
       raise Exception("Export depends on unparsed binary blobs from original "
                       +"fmp to be stored in the map property 'chunks'")
 
-    print 'Writing map at',fn
+    print('Writing map at',fn)
 
     chunks = cls.unpicklechunks(m.property('chunks'))
     hd = MPHD()
@@ -159,18 +164,18 @@ class FMPTileGfx:
   @classmethod
   def unpack(cls, hd, dat, cmap):
     n = 0
-    w,h = hd.blockwidth*10, hd.blockheight*hd.numblockgfx/10+hd.blockheight
-    fmt = QImage.Format_Indexed8 if hd.blockdepth==8 else QImage.Format_ARGB32
-    img = QImage(w, h, fmt)
+    w,h = hd.blockwidth*10, int(hd.blockheight*hd.numblockgfx/10+hd.blockheight)
+    fmt = T.qt.QImage.Format_Indexed8 if hd.blockdepth==8 else T.qt.QImage.Format_ARGB32
+    img = T.qt.QImage(w, h, fmt)
     img.setColorTable(cmap)
 
     for i in range(hd.numblockgfx):
-      col,row = i%10, i/10
+      col,row = int(i%10), int(i/10)
       tx,ty = col*hd.blockwidth, row*hd.blockheight
 
       for y in range(hd.blockheight):
         for x in range(hd.blockwidth):
-          c = struct.unpack('B', dat[n])[0]
+          c = struct.unpack('B', dat[n:n+1])[0]
           if hd.blockdepth==8:
             img.setPixel(tx+x, ty+y, c)
           else:
@@ -194,7 +199,7 @@ class FMPLayer:
   @classmethod
   def pack(cls, hd, blocks, layer, laynum):
     dat = StringIO()
-    print hd
+    print(hd)
     for y in range(layer.height()):
       for x in range(layer.width()):
         cell = layer.cellAt(x, y)
@@ -214,18 +219,18 @@ class FMPLayer:
 
       for y in range(hd.mapheight):
         for x in range(hd.mapwidth):
-          v = ldata[i]
+          v = int(ldata[i])
 
           if v >= len(blocks):
             pass#print 'unknown block at',i
           else:
-            n = blocks[ldata[i]].olay[fg]
+            n = int(blocks[v].olay[fg])
             if n != 0:
               ti = tileset.tileAt(n)
               if ti is None:
-                print 'invalid tile',n,'at',x,y
+                print('invalid tile',n,'at',x,y)
               else:
-                layer.setCell(x, y, Tiled.Cell(ti))
+                layer.setCell(x, y, T.Tiled.Cell(ti))
           i += 1
 
 
@@ -234,14 +239,14 @@ class FMPColormap:
   @classmethod
   def unpack(self, cmap):
     """cmap -- rgb bytearray"""
-    print 'got',len(cmap)
+    print('got',len(cmap))
     for i in range(0,len(cmap),3):
       r,g,b = struct.unpack('3B', cmap[i:i+3])
-      yield QColor(r,g,b).rgb()
+      yield T.qt.QColor(r,g,b).rgb()
 
   @classmethod
   def pack(self, cmap):
-    """cmap -- QImage.colorTable"""
+    """cmap -- T.qt.QImage.colorTable"""
     yield fmpchunk(id='CMAP', len=len(list(cmap))).pack()
     for c in cmap:
       yield struct.pack('3B', (c.qRed,c.qGreen,c.qBlue))

--- a/src/plugins/python/scripts/pk2.py
+++ b/src/plugins/python/scripts/pk2.py
@@ -5,17 +5,16 @@ Pekka Kana 2 map support for Tiled
 Notes:
 - should make PK2 classes mixins with Tiled ones
 """
-import os, sys, re, string
-from tiled import *
-from tiled.qt import *
 from lib import cpystruct
 from os.path import dirname, exists
 from struct import pack,unpack,Struct
 from base64 import b64encode, b64decode
+import os, sys, re, string
+import tiled as T
 
 maps = []
 
-class PK2(Plugin):
+class PK2(T.Plugin):
   @classmethod
   def nameFilter(cls):
     return "Pekka Kana 2 (*.map)"
@@ -26,7 +25,7 @@ class PK2(Plugin):
 
   @classmethod
   def supportsFile(cls, f):
-    return open(f, 'rb').read(4) == '1.3\0'
+    return open(f, 'rb').read(4) == b'1.3\0'
 
   @classmethod
   def read(cls, f):
@@ -38,42 +37,42 @@ class PK2(Plugin):
       lay1 = PK2MAPLAYER(fh)
       lay2 = PK2MAPLAYER(fh)
       lay3 = PK2MAPLAYER(fh)
-      print lvl
+      print(lvl)
 
     # -- tileset
-    img = QImage()
+    img = T.qt.QImage()
     imgfile = dirname(f)+'/../../gfx/tiles/'+str(lvl.tileFile)
     img.load(imgfile, 'BMP')
-    t = Tiled.Tileset.create('Tiles', 32,32, 0, 0)
-    t.data().setTransparentColor(QColor(img.color(255)))
+    t = T.Tiled.Tileset.create('Tiles', 32,32, 0, 0)
+    t.data().setTransparentColor(T.qt.QColor(img.color(255)))
     t.data().loadFromImage(img, imgfile)
 
     # find common bounding box for the layers
     bb = ['','',10,10]
     for l in [lay1,lay2,lay3]:
-      print l
+      print(l)
       bb[0] = min([bb[0], l.lx.num])
       bb[1] = min([bb[1], l.ly.num])
       bb[2] = max([bb[2], l.width()])
       bb[3] = max([bb[3], l.height()])
 
-    print 'bounds', bb
+    print('bounds', bb)
 
-    m = Tiled.Map(Tiled.Map.Orthogonal, bb[2], bb[3], 32,32)
+    m = T.Tiled.Map(T.Tiled.Map.Orthogonal, bb[2], bb[3], 32,32)
     maps.append(m)
 
     # -- background image
-    lai = Tiled.ImageLayer('Scenery', bb[2], bb[3])
-    img = QImage()
+    lai = T.Tiled.ImageLayer('Scenery', bb[2], bb[3])
+    img = T.qt.QImage()
     imgfile = dirname(f)+'/../../gfx/scenery/'+str(lvl.fieldFile)
     img.load(imgfile, 'BMP')
     lai.loadFromImage(img, imgfile)
 
     # -- layers
-    la1 = Tiled.TileLayer('Back', 0,0, bb[2], bb[3])
+    la1 = T.Tiled.TileLayer('Back', 0,0, bb[2], bb[3])
     lay1.doTiles(t, la1, bb)
 
-    la2 = Tiled.TileLayer('Front', 0,0, bb[2], bb[3])
+    la2 = T.Tiled.TileLayer('Front', 0,0, bb[2], bb[3])
     lay2.doTiles(t, la2, bb)
 
     sprdir = dirname(f)+'/../../sprites/'
@@ -88,11 +87,11 @@ class PK2(Plugin):
 
       if not lay3.spriteGfx.has_key(str(spr.kuvatiedosto)):
         sprfile = find_case_insensitive_filename(sprdir, str(spr.kuvatiedosto))
-        img = QImage()
+        img = T.qt.QImage()
         img.load(sprdir+sprfile, 'BMP')
-        print 'loading', sprdir+sprfile
-        sprts = Tiled.Tileset.create(sprfile, 32,32, 0, 0)
-        sprts.data().setTransparentColor(QColor(img.color(255)))
+        print('loading', sprdir+sprfile)
+        sprts = T.Tiled.Tileset.create(sprfile, 32,32, 0, 0)
+        sprts.data().setTransparentColor(T.qt.QColor(img.color(255)))
         sprts.data().loadFromImage(img, sprdir+sprfile)
         lay3.spriteGfx[str(spr.kuvatiedosto)] = sprts
 
@@ -101,7 +100,7 @@ class PK2(Plugin):
 
       #print spr
 
-    la3 = Tiled.ObjectGroup('Sprites', bb[2], bb[3])
+    la3 = T.Tiled.ObjectGroup('Sprites', bb[2], bb[3])
     lay3.doSprites(la3, bb)
     m.addLayer(lai)
     m.addTileset(t)
@@ -128,14 +127,14 @@ class PK2(Plugin):
     #setattr(out, "sprites", ['pla'])
 
     with open(fn, 'wb') as fh:
-      print >>fh, out.pack()
+      print(out.pack(), file=fh)
 
       for i in range(m.layerCount()):
         tiles = []
         l = 0
         if isTileLayerAt(m, i):
           l = tileLayerAt(m, i)
-          print l
+          print(l)
         elif isObjectGroupAt(m, i):
           #l = objectGroupAt(m, i)
           continue
@@ -144,8 +143,8 @@ class PK2(Plugin):
           for x in range(l.width()):
             if l.cellAt(x, y).tile != None:
               tiles.append( l.cellAt(x, y).tile.id() )
-        print >>fh, 0,0, l.width(), l.height()
-        print >>fh, bytearray(tiles)
+        print(0,0, l.width(), l.height(), file=fh)
+        print(bytearray(tiles), file=fh)
 
     return True
 
@@ -234,7 +233,7 @@ class PK2MAPLAYER(cpystruct.CpyStruct("asciinum lx, ly, w, h;")):
           rx = self.lx.num + x - bb[0]
           ry = self.ly.num + y - bb[1] + 1
           spr = self.sprites[sprite]
-          obj = Tiled.MapObject(str(spr.kuvatiedosto), '', QPointF(rx, ry), QSizeF(1, 1)) #spr.width, spr.height))
+          obj = T.Tiled.MapObject(str(spr.kuvatiedosto), '', T.qt.QPointF(rx, ry), T.qt.QSizeF(1, 1)) #spr.width, spr.height))
           # 0 should point to the actual sprite but how?
           obj.setCell(Tiled.Cell(self.spriteGfx[str(spr.kuvatiedosto)].data().tileAt(0)))
           la.addObject(obj)
@@ -246,15 +245,15 @@ class PK2MAPLAYER(cpystruct.CpyStruct("asciinum lx, ly, w, h;")):
         if tile != 255:
           rx = self.lx.num + x - bb[0]
           ry = self.ly.num + y - bb[1]
-          if tile == 149: print 'start @',rx,ry
-          if tile == 150: print 'end @',rx,ry
+          if tile == 149: print('start @',rx,ry)
+          if tile == 150: print('end @',rx,ry)
           ti = ts.data().tileAt(tile)
           if ti != None and rx < bb[2] and ry < bb[3]:
             # app should check that coords are within layer
             #print rx,ry,self.ly,y
-            la.setCell(rx, ry, Tiled.Cell(ti))
+            la.setCell(rx, ry, T.Tiled.Cell(ti))
           else:
-            print 'invalid',rx,ry
+            print('invalid',rx,ry)
 
 class PK2SPR_ANIM(cpystruct.CpyStruct("""
   uchar   seq[10];

--- a/src/plugins/python/scripts/zst.py
+++ b/src/plugins/python/scripts/zst.py
@@ -7,14 +7,14 @@ Note:
 - only supports bg1 of bgmode 1
 http://snesemu.black-ship.net/misc/techdocs/snesdoc.html#GraphicsFormat
 """
-import sys, re, string
-from tiled import *
-from tiled.qt import *
 from os.path import dirname
 from struct import pack,unpack,Struct
 from collections import namedtuple
+import sys, re, string
+import tiled as T
 
-class ZST(Plugin):
+
+class ZST(T.Plugin):
   @classmethod
   def nameFilter(cls):
     return "zSNES Save State (*.zs?)"
@@ -37,7 +37,7 @@ class ZST(Plugin):
         (2, 2, 0, 0, 0, 0, 0, 0),
         (2, 0, 0, 0, 0, 0, 0, 0))
 
-    img = QImage(32*8, 32*8, QImage.Format_Indexed8)
+    img = T.qt.QImage(32*8, 32*8, T.qt.QImage.Format_Indexed8)
     #img.fill(255)
     cmap = []
     with open(f, 'rb') as fh:
@@ -83,7 +83,7 @@ class ZST(Plugin):
             """
             la.setCell(x, y, Tiled.Cell(tile))
           except:
-            print 'out of range %i,%i: %i' % (x,y,t.idx)
+            print('out of range %i,%i: %i' % (x,y,t.idx))
 
       if la.width() > 32:
         for y in range(la.height()):
@@ -93,7 +93,7 @@ class ZST(Plugin):
               tile = tsets[t.pal].data().tileAt(t.idx)
               la.setCell(x, y, Tiled.Cell(tile))
             except:
-              print 'out of range %i,%i: %i' % (x,y,t.idx)
+              print('out of range %i,%i: %i' % (x,y,t.idx))
 
       for pal in range(7):
         m.addTileset(tsets[pal])
@@ -148,7 +148,7 @@ def parseColors(cgram):
     g = ((col >> 5) << 3) & 0xf8
     b = ((col >> 10) << 3) & 0xf8
     #print (r,g,b),
-    yield QColor(r,g,b).rgb()
+    yield T.qt.QColor(r,g,b).rgb()
 
 def parseTile(t):
   ret = namedtuple('Tile', 'idx pal prio flipx flipy')

--- a/src/plugins/python/tiledbinding.py
+++ b/src/plugins/python/tiledbinding.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
  Python Tiled Plugin
  Copyright 2012-2013, Samuli Tuomola <samuli@tuomola.net>
@@ -18,6 +19,8 @@
  this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
+from __future__ import print_function
+
 from pybindgen import *
 
 mod = Module('tiled')
@@ -31,7 +34,9 @@ mod.add_include('"tilelayer.h"')
 mod.add_include('"objectgroup.h"')
 mod.add_include('"tileset.h"')
 
+mod.header.writeln('#ifndef _MSC_VER')
 mod.header.writeln('#pragma GCC diagnostic ignored "-Wmissing-field-initializers"')
+mod.header.writeln('#endif')
 
 # one day PyQt/PySide could be considered
 import qtbinding
@@ -305,15 +310,15 @@ with open('pythonbind.cpp','w') as fh:
     import pybindgen.typehandlers.codesink as cs
     sink = cs.MemoryCodeSink()
 
-    print >>fh, """
+    print("""
 #ifdef __MINGW32__
 #include <cmath> // included before Python.h to fix ::hypot not declared issue
 #endif
-"""
+""", file=fh)
 
     mod.generate(fh)
 
-    print >>fh, """
+    print("""
 PyObject* _wrap_convert_c2py__Tiled__LoggingInterface(Tiled::LoggingInterface *cvalue)
 {
         PyObject *py_retval;
@@ -325,7 +330,7 @@ PyObject* _wrap_convert_c2py__Tiled__LoggingInterface(Tiled::LoggingInterface *c
         py_retval = Py_BuildValue((char *) "N", py_LoggingInterface);
         return py_retval;
 }
-"""
+""", file=fh)
     #mod.generate_c_to_python_type_converter(
     #  utils.eval_retval(retval("Tiled::LoggingInterface")),
     #  sink)
@@ -336,6 +341,6 @@ PyObject* _wrap_convert_c2py__Tiled__LoggingInterface(Tiled::LoggingInterface *c
         utils.eval_retval("const Tiled::Map"),
         sink)
 
-    print >>fh, sink.flush()
+    print(sink.flush(), file=fh)
 
 # vim: ai ts=4 sts=4 et sw=4 ft=python


### PR DESCRIPTION
### linux (mint 18) + qt5.6, and osx (10.12.6) with qt5.10

Built simply by `qmake . && make` and after `cp -a src/plugin/python/scripts ~/.tiled` at least fotf.py works out of the box (don't have data files to test all the other ones atm).

Noticed the new qbs build files later on. Since osx ships with py2 preinstalled but not with py3 I've changed the build to use pkgconfig for osx as well, which seems to work (after finally figuring out PkgConfigProbe defaulted to qbs.sysroot i.e. /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk for .pc files)

### win10, msvc2017 qt5.9 x64 runtime

Steps:

-  install [py3.6.4 x64](https://www.python.org/ftp/python/3.6.4/python-3.6.4-amd64.exe), and set the checkbox under advanced options to add it to environment variables (PATH) (there's [some reasons](https://bugs.python.org/issue3561#msg164635) why it's not on by default)
- in Qt Designer Kit-config set it to use msvc2017 as C/C++ x64 compiler
- add PYTHONHOME in Qt Designer project config, this is to locate header files
- building Release config now includes the plugin linked to py3
- copy src/plugin/python/scripts to %USERPROFILE%/.tiled .. this is something that should perhaps be changed, maybe the included scripts could be in a zip file in plugin directory and homedir .tiled is only for user's own scripts?

Some dlls changed names in msvc2017, msvcp120 became 140, and apparently due to ["Universal CRT"](https://stackoverflow.com/a/35806815/7571258) msvcr is no more. Build should work now with either set of dlls but if someone has a some other Visual Studio versions it'd be good to test?

**Troubleshooting**
If during building it errors saying something about 32/64bit, make sure it's not trying to use some other python installation.

If, when running Tiled it says "The specified module could not be found" this might mean it can't find the dynamically linked python3.dlls (one reason could be qt designer wasn't restarted after the PATH envvar was changed).

**Misc**
Should py3 be added in appveyor somehow?

Btw I'd first installed qt for windows UWP and spent an hour pondering error relating to QFileSystemWatcher being an "undeclared type" (due to qtcore-config.h defining QT_NO_FILESYSTEMWATCHER) before it dawned on me it was the wrong platform. Everything worked after reinstalling with msvc2017 x64 runtime. Perhaps it'd help others to put a check for that #define in a build script somewhere and alert people to check their qt version?

Closes #1759 and #1762