### PR TITLE
Add support to Lua exporter for object templates

### DIFF
--- a/src/plugins/lua/luaplugin.cpp
+++ b/src/plugins/lua/luaplugin.cpp
@@ -656,13 +656,14 @@ void LuaWriter::writeMapObject(LuaTableWriter &writer,
         break;
     }
 
-    Properties props;
-    if (const ObjectTemplate *objectTemplate = mapObject->objectTemplate()) {
-        props.merge(objectTemplate->object()->properties());
+    if (const MapObject *base = mapObject->templateObject()) {
+        // Include template properties
+        Properties props = base->properties();
+        props.merge(mapObject->properties());
+        writeProperties(writer, props);
+    } else {
+        writeProperties(writer, mapObject->properties());
     }
-    // Override template properties if they exist
-    props.merge(mapObject->properties());
-    writeProperties(writer, props);
 
     writer.writeEndTable();
 }

--- a/src/plugins/lua/luaplugin.cpp
+++ b/src/plugins/lua/luaplugin.cpp
@@ -28,6 +28,7 @@
 #include "map.h"
 #include "mapobject.h"
 #include "objectgroup.h"
+#include "objecttemplate.h"
 #include "properties.h"
 #include "savefile.h"
 #include "terrain.h"
@@ -655,7 +656,13 @@ void LuaWriter::writeMapObject(LuaTableWriter &writer,
         break;
     }
 
-    writeProperties(writer, mapObject->properties());
+    Properties props;
+    if (const ObjectTemplate *objectTemplate = mapObject->objectTemplate()) {
+        props.merge(objectTemplate->object()->properties());
+    }
+    // Override template properties if they exist
+    props.merge(mapObject->properties());
+    writeProperties(writer, props);
 
     writer.writeEndTable();
 }


### PR DESCRIPTION
Properties are copied from the template, then overwritten by the instances's properties before being written to the export.

Pros:
* Backwards compatible with older tools/importers
* No need to check templates for properties
* No extra runtime overhead, compared to not using templates

Cons:
* Can't directly tell if the object had a template
* Can't tell if any properties were from the template or not