### PR TITLE
Tile scalefactor property

### DIFF
--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -427,6 +427,9 @@ void MapReaderPrivate::readTilesetTile(Tileset &tileset)
     Tile *tile = tileset.findOrCreateTile(id);
 
     tile->setType(atts.value(QLatin1String("type")).toString());
+    QStringRef scaleFactor = atts.value(QLatin1String("scalefactor"));
+    if(!scaleFactor.isEmpty())
+        tile->setScaleFactor(scaleFactor.toDouble());
 
     // Read tile quadrant terrain ids
     QString terrain = atts.value(QLatin1String("terrain")).toString();

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -403,6 +403,8 @@ void MapWriterPrivate::writeTileset(QXmlStreamWriter &w, const Tileset &tileset,
             w.writeAttribute(QLatin1String("id"), QString::number(tile->id()));
             if (!tile->type().isEmpty())
                 w.writeAttribute(QLatin1String("type"), tile->type());
+            if (tile->scaleFactor() != 1.0)
+                w.writeAttribute(QLatin1String("scalefactor"), QString::number(tile->scaleFactor()));
             if (tile->terrain() != 0xFFFFFFFF)
                 w.writeAttribute(QLatin1String("terrain"), makeTerrainAttribute(tile));
             if (tile->probability() != 1.0)

--- a/src/libtiled/tile.cpp
+++ b/src/libtiled/tile.cpp
@@ -39,6 +39,7 @@ Tile::Tile(int id, Tileset *tileset):
     mTileset(tileset),
     mImageStatus(LoadingReady),
     mTerrain(-1),
+    mScaleFactor(1.0),
     mProbability(1.0),
     mObjectGroup(nullptr),
     mCurrentFrameIndex(0),

--- a/src/libtiled/tile.h
+++ b/src/libtiled/tile.h
@@ -120,6 +120,9 @@ public:
     const QString &type() const;
     void setType(const QString &type);
 
+    qreal scaleFactor() const;
+    void setScaleFactor(qreal scaleFactor);
+
     Terrain *terrainAtCorner(int corner) const;
 
     int cornerTerrainId(int corner) const;
@@ -149,6 +152,7 @@ public:
 
 private:
     int mId;
+    qreal mScaleFactor;
     Tileset *mTileset;
     QPixmap mImage;
     QUrl mImageSource;
@@ -230,6 +234,14 @@ inline int Tile::height() const
 }
 
 /**
+* Returns the scale which the tile gets applied when placed.
+*/
+inline qreal Tile::scaleFactor() const
+{
+    return mScaleFactor;
+}
+
+/**
  * Returns the size of this tile.
  */
 inline QSize Tile::size() const
@@ -254,6 +266,15 @@ inline const QString &Tile::type() const
 inline void Tile::setType(const QString &type)
 {
     mType = type;
+}
+
+/**
+ * Sets the scale factor for this tile
+ * \sa scaleFactor()
+ */
+inline void Tile::setScaleFactor(qreal scaleFactor)
+{
+    mScaleFactor = scaleFactor;
 }
 
 /**

--- a/src/tiled/adjusttileindexes.cpp
+++ b/src/tiled/adjusttileindexes.cpp
@@ -153,6 +153,8 @@ AdjustTileMetaData::AdjustTileMetaData(TilesetDocument *tilesetDocument)
     // Adjust tile meta data
     QList<Tile*> tilesChangingProbability;
     QList<qreal> tileProbabilities;
+    QList<Tile*> tilesChangingScaleFactor;
+    QList<qreal> tileScaleFactors;
     ChangeTileTerrain::Changes terrainChanges;
     QSet<Tile*> tilesToReset;
 
@@ -171,6 +173,7 @@ AdjustTileMetaData::AdjustTileMetaData(TilesetDocument *tilesetDocument)
                              const Properties &properties,
                              unsigned terrain,
                              qreal probability,
+                             qreal scaleFactor,
                              ObjectGroup *objectGroup,
                              const QVector<Frame> &frames)
     {
@@ -190,6 +193,11 @@ AdjustTileMetaData::AdjustTileMetaData(TilesetDocument *tilesetDocument)
         if (probability != toTile->probability()) {
             tilesChangingProbability.append(toTile);
             tileProbabilities.append(probability);
+        }
+        
+        if (scaleFactor != toTile->scaleFactor()){
+            tilesChangingScaleFactor.append(toTile);
+            tileScaleFactors.append(scaleFactor);
         }
 
         if (objectGroup != toTile->objectGroup())
@@ -221,6 +229,7 @@ AdjustTileMetaData::AdjustTileMetaData(TilesetDocument *tilesetDocument)
                       fromTile->properties(),
                       fromTile->terrain(),
                       fromTile->probability(),
+                      fromTile->scaleFactor(),
                       objectGroup,
                       adjustAnimationFrames(fromTile->frames()));
     };
@@ -242,7 +251,7 @@ AdjustTileMetaData::AdjustTileMetaData(TilesetDocument *tilesetDocument)
     QSetIterator<Tile*> resetIterator(tilesToReset);
     while (resetIterator.hasNext()) {
         applyMetaData(resetIterator.next(),
-                      Properties(), -1, 1.0, nullptr, QVector<Frame>());
+                      Properties(), -1, 1.0,1.0, nullptr, QVector<Frame>());
     }
 
     if (!tilesChangingProbability.isEmpty()) {
@@ -251,7 +260,6 @@ AdjustTileMetaData::AdjustTileMetaData(TilesetDocument *tilesetDocument)
                                   tileProbabilities,
                                   this);
     }
-
     if (!terrainChanges.isEmpty())
         new ChangeTileTerrain(tilesetDocument, terrainChanges, this);
 }

--- a/src/tiled/changetilescalefactor.cpp
+++ b/src/tiled/changetilescalefactor.cpp
@@ -1,0 +1,72 @@
+﻿/*
+ * changetilescalefactor.cpp
+ * Copyright 2018, Kristian Pilegaard <kralle@gmail.com>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "changetileprobability.h"
+
+#include "tilesetdocument.h"
+#include "tile.h"
+
+#include <QCoreApplication>
+#include "changetilescalefactor.h"
+
+namespace Tiled {
+namespace Internal {
+
+ChangeTileScaleFactor::ChangeTileScaleFactor(TilesetDocument *tilesetDocument,
+                                             const QList<Tile*>& tiles,
+                                             qreal scaleFactor)
+    : mTilesetDocument(tilesetDocument)
+    , mTiles(tiles)
+{
+    mScaleFactors.reserve(tiles.size());
+    for (int i = 0; i < tiles.size(); ++i)
+        mScaleFactors.append(scaleFactor);
+
+    setText(QCoreApplication::translate("Undo Commands",
+                                        "Change Tile Scale Factor"));
+}
+
+ChangeTileScaleFactor::ChangeTileScaleFactor(TilesetDocument *tilesetDocument,
+                                             const QList<Tile *> &tiles,
+                                             const QList<qreal> &scaleFactors,
+                                             QUndoCommand *parent)
+    : QUndoCommand(parent)
+    , mTilesetDocument(tilesetDocument)
+    , mTiles(tiles)
+    , mScaleFactors(scaleFactors)
+{
+    Q_ASSERT(mTiles.size() == mScaleFactors.size());
+    setText(QCoreApplication::translate("Undo Commands",
+                                        "Change Tile Scale Factor"));
+}
+
+void ChangeTileScaleFactor::swap()
+{
+    for (int i = 0; i < mTiles.size(); ++i) {
+        Tile *tile = mTiles[i];
+        qreal scaleFactor = tile->scaleFactor();
+        tile->setScaleFactor(mScaleFactors[i]);
+        mScaleFactors[i] = scaleFactor;
+    }
+}
+
+} // namespace Internal
+} // namespace Tiled
+

--- a/src/tiled/changetilescalefactor.h
+++ b/src/tiled/changetilescalefactor.h
@@ -1,0 +1,57 @@
+﻿/*
+ * changetilescalefactor.h
+ * Copyright 2018, Kristian Pilegaard <kralle@gmail.com>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <QUndoCommand>
+
+namespace Tiled {
+
+class Tile;
+
+namespace Internal {
+
+class TilesetDocument;
+
+class ChangeTileScaleFactor : public QUndoCommand
+{
+public:
+    ChangeTileScaleFactor(TilesetDocument *tilesetDocument,
+                          const QList<Tile*> &tiles,
+                          qreal scaleFactor);
+
+    ChangeTileScaleFactor(TilesetDocument *tilesetDocument,
+                          const QList<Tile*> &tiles,
+                          const QList<qreal> &scaleFactors,
+                          QUndoCommand *parent = nullptr);
+
+    void undo() override { swap(); }
+    void redo() override { swap(); }
+
+private:
+    void swap();
+
+    TilesetDocument *mTilesetDocument;
+    QList<Tile*> mTiles;
+    QList<qreal> mScaleFactors;
+};
+
+} // namespace Internal
+} // namespace Tiled

--- a/src/tiled/createtileobjecttool.cpp
+++ b/src/tiled/createtileobjecttool.cpp
@@ -31,7 +31,7 @@
 using namespace Tiled;
 using namespace Tiled::Internal;
 
-CreateTileObjectTool::CreateTileObjectTool(QObject *parent)
+CreateTileObjectTool::CreateTileObjectTool(QObject* parent)
     : CreateObjectTool(parent)
 {
     QIcon icon(QLatin1String(":images/24x24/insert-image.png"));
@@ -41,11 +41,11 @@ CreateTileObjectTool::CreateTileObjectTool(QObject *parent)
     languageChanged();
 }
 
-void CreateTileObjectTool::mouseMovedWhileCreatingObject(const QPointF &pos, Qt::KeyboardModifiers modifiers)
+void CreateTileObjectTool::mouseMovedWhileCreatingObject(const QPointF& pos, Qt::KeyboardModifiers modifiers)
 {
-    const MapRenderer *renderer = mapDocument()->renderer();
+    const MapRenderer* renderer = mapDocument()->renderer();
 
-    const QSize imgSize = mNewMapObjectItem->mapObject()->cell().tile()->size();
+    const QSize imgSize = mNewMapObjectItem->mapObject()->cell().tile()->size()*mNewMapObjectItem->mapObject()->cell().tile()->scaleFactor();
     const QPointF diff(-imgSize.width() / 2, imgSize.height() / 2);
     QPointF pixelCoords = renderer->screenToPixelCoords(pos + diff);
 
@@ -57,19 +57,19 @@ void CreateTileObjectTool::mouseMovedWhileCreatingObject(const QPointF &pos, Qt:
     mNewMapObjectItem->setOpacity(0.75);
 }
 
-void CreateTileObjectTool::mousePressedWhileCreatingObject(QGraphicsSceneMouseEvent *event)
+void CreateTileObjectTool::mousePressedWhileCreatingObject(QGraphicsSceneMouseEvent* event)
 {
     if (event->button() == Qt::RightButton)
         cancelNewMapObject();
 }
 
-void CreateTileObjectTool::mouseReleasedWhileCreatingObject(QGraphicsSceneMouseEvent *event)
+void CreateTileObjectTool::mouseReleasedWhileCreatingObject(QGraphicsSceneMouseEvent* event)
 {
     if (event->button() == Qt::LeftButton)
         finishNewMapObject();
 }
 
-bool CreateTileObjectTool::startNewMapObject(const QPointF &pos, ObjectGroup *objectGroup)
+bool CreateTileObjectTool::startNewMapObject(const QPointF& pos, ObjectGroup* objectGroup)
 {
     if (!CreateObjectTool::startNewMapObject(pos, objectGroup))
         return false;
@@ -84,14 +84,14 @@ void CreateTileObjectTool::languageChanged()
     setShortcut(QKeySequence(tr("T")));
 }
 
-MapObject *CreateTileObjectTool::createNewMapObject()
+MapObject* CreateTileObjectTool::createNewMapObject()
 {
     if (!tile())
         return nullptr;
 
-    MapObject *newMapObject = new MapObject;
+    MapObject* newMapObject = new MapObject;
     newMapObject->setShape(MapObject::Rectangle);
     newMapObject->setCell(Cell(tile()));
-    newMapObject->setSize(tile()->size());
+    newMapObject->setSize(tile()->size() * tile()->scaleFactor());
     return newMapObject;
 }

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -656,6 +656,7 @@ void PropertyBrowser::addMapObjectProperties()
         addProperty(WidthProperty, QVariant::Double, tr("Width"), groupProperty);
         addProperty(HeightProperty, QVariant::Double, tr("Height"), groupProperty);
     }
+    addProperty(TileScaleFactorProperty, QVariant::Double, tr("ScaleFactor"), groupProperty)->setEnabled(false);
 
     bool isPoint = mapObject->shape() == MapObject::Point;
     addProperty(RotationProperty, QVariant::Double, tr("Rotation"), groupProperty)->setEnabled(!isPoint);
@@ -1585,7 +1586,7 @@ void PropertyBrowser::updateProperties()
             mIdToProperty[WidthProperty]->setValue(mapObject->width());
             mIdToProperty[HeightProperty]->setValue(mapObject->height());
         }
-
+        mIdToProperty[TileScaleFactorProperty]->setValue(mapObject->cell().tile()->scaleFactor());
         mIdToProperty[RotationProperty]->setValue(mapObject->rotation());
 
         if (flags & ObjectHasTile) {

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -68,6 +68,7 @@
 #include <QDebug>
 #include <QKeyEvent>
 #include <QMessageBox>
+#include "changetilescalefactor.h"
 
 namespace Tiled {
 namespace Internal {
@@ -824,6 +825,9 @@ void PropertyBrowser::addTileProperties()
     addProperty(WidthProperty, QVariant::Int, tr("Width"), groupProperty)->setEnabled(false);
     addProperty(HeightProperty, QVariant::Int, tr("Height"), groupProperty)->setEnabled(false);
 
+    QtVariantProperty *scaleFactorProperty =  addProperty(TileScaleFactorProperty, QVariant::Double, tr("ScaleFactor"), groupProperty);
+    scaleFactorProperty->setEnabled(mTilesetDocument);
+
     QtVariantProperty *probabilityProperty = addProperty(TileProbabilityProperty,
                                                          QVariant::Double,
                                                          tr("Probability"),
@@ -1278,6 +1282,11 @@ void PropertyBrowser::applyTileValue(PropertyId id, const QVariant &val)
                                                   mTilesetDocument->selectedTiles(),
                                                   val.toFloat()));
         break;
+    case TileScaleFactorProperty:
+        undoStack->push(new ChangeTileScaleFactor(mTilesetDocument,
+                                                  mTilesetDocument->selectedTiles(),
+                                                  val.toFloat()));
+        break;
     case ImageSourceProperty: {
         const FilePath filePath = val.value<FilePath>();
         undoStack->push(new ChangeTileImageSource(mTilesetDocument,
@@ -1663,6 +1672,7 @@ void PropertyBrowser::updateProperties()
         mIdToProperty[TypeProperty]->setValue(tile->type());
         mIdToProperty[WidthProperty]->setValue(tileSize.width());
         mIdToProperty[HeightProperty]->setValue(tileSize.height());
+        mIdToProperty[TileScaleFactorProperty]->setValue(tile->scaleFactor());
         mIdToProperty[TileProbabilityProperty]->setValue(tile->probability());
         if (QtVariantProperty *imageSourceProperty = mIdToProperty.value(ImageSourceProperty))
             imageSourceProperty->setValue(QVariant::fromValue(FilePath { tile->imageSource() }));

--- a/src/tiled/propertybrowser.h
+++ b/src/tiled/propertybrowser.h
@@ -122,6 +122,7 @@ private:
         YProperty,
         WidthProperty,
         HeightProperty,
+        TileScaleFactorProperty,
         RotationProperty,
         VisibleProperty,
         LockedProperty,

--- a/src/tiled/tiled.qbs
+++ b/src/tiled/tiled.qbs
@@ -157,6 +157,8 @@ QtGuiApplication {
         "changetileobjectgroup.h",
         "changetileprobability.cpp",
         "changetileprobability.h",
+        "changetilescalefactor.cpp",
+        "changetilescalefactor.h",
         "changetileterrain.cpp",
         "changetileterrain.h",
         "changetilewangid.cpp",


### PR DESCRIPTION
Made it possible to set a scalefactor on tiles on tilesets. When placing an object on a map, the object will be scaled up/down using this scalefactor. This is useful for sprites that are scaled down to reduce file sizes and scaled up again when the map is loaded in a game.