### PR TITLE
Allow qrc-based tileset images

### DIFF
--- a/src/libtiled/imagereference.cpp
+++ b/src/libtiled/imagereference.cpp
@@ -35,7 +35,7 @@ QPixmap ImageReference::create() const
     if (source.isLocalFile())
         return ImageCache::loadPixmap(source.toLocalFile());
     else if (source.scheme() == QLatin1String("qrc"))
-        return QImage(QLatin1Char(':') + source.path());
+        return ImageCache::loadPixmap(QLatin1Char(':') + source.path());
     else if (!data.isEmpty())
         return QPixmap::fromImage(QImage::fromData(data, format));
 

--- a/src/libtiled/imagereference.cpp
+++ b/src/libtiled/imagereference.cpp
@@ -34,6 +34,8 @@ QPixmap ImageReference::create() const
 {
     if (source.isLocalFile())
         return ImageCache::loadPixmap(source.toLocalFile());
+    else if (source.scheme() == QLatin1String("qrc"))
+        return QImage(QLatin1Char(':') + source.path());
     else if (!data.isEmpty())
         return QPixmap::fromImage(QImage::fromData(data, format));
 

--- a/src/libtiled/tiled.cpp
+++ b/src/libtiled/tiled.cpp
@@ -50,5 +50,8 @@ QUrl Tiled::toUrl(const QString &filePathOrUrl, const QDir &dir)
 
     // Resolve possible relative file reference
     QString absolutePath = QDir::cleanPath(dir.filePath(filePathOrUrl));
+    if (absolutePath.startsWith(QLatin1String(":/")))
+        return QUrl(QLatin1String("qrc") + absolutePath);
+
     return QUrl::fromLocalFile(absolutePath);
 }


### PR DESCRIPTION
While irrelevant for the end users of Tiled as an application, this
allows those of us using Tiled as a library to have maps whose tilesets
are stored in resources.