### PR TITLE
tiledquick: allow qrc-based tileset images

### DIFF
--- a/src/libtiled/tiled.cpp
+++ b/src/libtiled/tiled.cpp
@@ -52,3 +52,26 @@ QUrl Tiled::toUrl(const QString &filePathOrUrl, const QDir &dir)
     QString absolutePath = QDir::cleanPath(dir.filePath(filePathOrUrl));
     return QUrl::fromLocalFile(absolutePath);
 }
+
+/*
+    If \a url is a local file returns a path suitable for passing to QFile.
+    Otherwise returns an empty string.
+*/
+QString Tiled::urlToLocalFileOrQrc(const QUrl &url)
+{
+    if (url.scheme().compare(QLatin1String("qrc"), Qt::CaseInsensitive) == 0) {
+        if (url.authority().isEmpty())
+            return QLatin1Char(':') + url.path();
+        return QString();
+    }
+
+#if defined(Q_OS_ANDROID)
+    else if (url.scheme().compare(QLatin1String("assets"), Qt::CaseInsensitive) == 0) {
+        if (url.authority().isEmpty())
+            return url.toString();
+        return QString();
+    }
+#endif
+
+    return url.toLocalFile();
+}

--- a/src/libtiled/tiled.h
+++ b/src/libtiled/tiled.h
@@ -77,5 +77,6 @@ static const char PROPERTIES_MIMETYPE[] = "application/vnd.properties.list";
 
 TILEDSHARED_EXPORT QString toFileReference(const QUrl &url, const QDir &dir);
 TILEDSHARED_EXPORT QUrl toUrl(const QString &reference, const QDir &dir);
+TILEDSHARED_EXPORT QString urlToLocalFileOrQrc(const QUrl &url);
 
 } // namespace Tiled

--- a/src/tiledquickplugin/maploader.cpp
+++ b/src/tiledquickplugin/maploader.cpp
@@ -22,6 +22,7 @@
 
 #include "map.h"
 #include "mapreader.h"
+#include "tiled.h"
 #include "tileset.h"
 
 using namespace TiledQuick;
@@ -37,29 +38,6 @@ MapLoader::~MapLoader()
 {
 }
 
-/*
-    If \a url is a local file returns a path suitable for passing to QFile.
-    Otherwise returns an empty string.
-*/
-static QString urlToLocalFileOrQrc(const QUrl &url)
-{
-    if (url.scheme().compare(QLatin1String("qrc"), Qt::CaseInsensitive) == 0) {
-        if (url.authority().isEmpty())
-            return QLatin1Char(':') + url.path();
-        return QString();
-    }
-
-#if defined(Q_OS_ANDROID)
-    else if (url.scheme().compare(QLatin1String("assets"), Qt::CaseInsensitive) == 0) {
-        if (url.authority().isEmpty())
-            return url.toString();
-        return QString();
-    }
-#endif
-
-    return url.toLocalFile();
-}
-
 void MapLoader::setSource(const QUrl &source)
 {
     if (m_source == source)
@@ -69,7 +47,7 @@ void MapLoader::setSource(const QUrl &source)
 
     Tiled::MapReader mapReader;
 
-    Tiled::Map *map = mapReader.readMap(urlToLocalFileOrQrc(source));
+    Tiled::Map *map = mapReader.readMap(Tiled::urlToLocalFileOrQrc(source));
     Status status = map ? Ready : Error;
     QString error = map ? QString() : mapReader.errorString();
 

--- a/src/tiledquickplugin/tilelayeritem.cpp
+++ b/src/tiledquickplugin/tilelayeritem.cpp
@@ -48,7 +48,8 @@ static inline QSGTexture *tilesetTexture(Tileset *tileset,
 
     QSGTexture *texture = cache.value(tileset);
     if (!texture) {
-        texture = window->createTextureFromImage(QImage(tileset->imageSource().toLocalFile()));
+        const QString imagePath(Tiled::urlToLocalFileOrQrc(tileset->imageSource()));
+        texture = window->createTextureFromImage(QImage(imagePath));
         cache.insert(tileset, texture);
     }
     return texture;


### PR DESCRIPTION
A similar change was done a while ago in a1ceb57e, but the code has
changed a lot since then, so it needs to be updated.