### PR TITLE
Support for PEP384 + separate user script dir

### DIFF
--- a/src/plugins/python/pythonplugin.h
+++ b/src/plugins/python/pythonplugin.h
@@ -71,13 +71,15 @@ public:
     void log(const QString &msg);
 
 private slots:
-    void reloadModules();
+    void reloadUserModules();
 
 private:
     bool loadOrReloadModule(ScriptEntry &script);
+    void reloadModules(QString path);
     PyObject *findPluginSubclass(PyObject *module);
 
-    QString mScriptDir;
+    QString mSysScriptDir;
+    QString mUserScriptDir;
     QMap<QString,ScriptEntry> mScripts;
     PyObject *mPluginClass;
 

--- a/src/plugins/python/scripts/_preload.py
+++ b/src/plugins/python/scripts/_preload.py
@@ -1,0 +1,27 @@
+import sys
+#from tiled.Tiled.LoggingInterface import INFO,ERROR
+
+class _LogCatcher:
+    def __init__(self, type):
+        self.buffer = ''
+        self.type = type
+
+    def flush(self):
+        pass
+
+    def write(self, msg):
+        self.buffer += msg
+        try:
+            if self.buffer.endswith('\n'):
+                sys._logger.log(self.type, self.buffer)
+                self.buffer = ''
+        except Exception as ex:
+            import traceback
+            traceback.print_exc(file=sys._oldstderr)
+
+
+sys._oldstdout = sys.stdout
+sys._oldstderr = sys.stdout
+sys.stdout = _LogCatcher(0)
+sys.stderr = _LogCatcher(1)
+


### PR DESCRIPTION
Todo: assumes `scripts` directory is under QCoreApplication::applicationDirPath(), if this is ok packaging scripts would need to be updated.

Actually for me doing `make install INSTALL_ROOT=/tmp/tiled-pkg` doesn't copy any of the examples etc directories to INSTALL_ROOT that dist/distribute.qbs seems to indicate should be copied in the package?