### PR TITLE
Fixed typo in tiled_de.ts

### DIFF
--- a/translations/tiled_de.ts
+++ b/translations/tiled_de.ts
@@ -640,7 +640,7 @@
     <message>
         <location line="+5"/>
         <source>User Manual</source>
-        <translation>Benutzerhanduch</translation>
+        <translation>Benutzerhandbuch</translation>
     </message>
     <message>
         <location line="+70"/>


### PR DESCRIPTION
I fixed a small typo in the help section.

User manual != Benutzerhanduch
User manual == Benutzerhand**b**uch

