### PR TITLE
GH1976 Labels change color when layer color is changed

### DIFF
--- a/src/tiled/objectselectionitem.cpp
+++ b/src/tiled/objectselectionitem.cpp
@@ -272,6 +272,9 @@ ObjectSelectionItem::ObjectSelectionItem(MapDocument *mapDocument,
     connect(mapDocument, &MapDocument::objectsChanged,
             this, &ObjectSelectionItem::syncOverlayItems);
 
+    connect(mapDocument, &MapDocument::objectGroupChanged,
+            this, &ObjectSelectionItem::objectGroupChanged);
+
     connect(mapDocument, &MapDocument::hoveredMapObjectChanged,
             this, &ObjectSelectionItem::hoveredMapObjectChanged);
 
@@ -418,6 +421,10 @@ void ObjectSelectionItem::layerChanged(Layer *layer)
         collectObjects(*groupLayer, affectedObjects);
         syncOverlayItems(affectedObjects);
     }
+}
+
+void ObjectSelectionItem::objectGroupChanged(ObjectGroup * objectGroup) {
+    updateObjectLabelColors();
 }
 
 void ObjectSelectionItem::syncOverlayItems(const QList<MapObject*> &objects)

--- a/src/tiled/objectselectionitem.cpp
+++ b/src/tiled/objectselectionitem.cpp
@@ -27,7 +27,6 @@
 #include "mapobject.h"
 #include "mapobjectitem.h"
 #include "maprenderer.h"
-#include "objectgroup.h"
 #include "preferences.h"
 #include "tile.h"
 #include "utils.h"
@@ -273,7 +272,7 @@ ObjectSelectionItem::ObjectSelectionItem(MapDocument *mapDocument,
             this, &ObjectSelectionItem::syncOverlayItems);
 
     connect(mapDocument, &MapDocument::objectGroupChanged,
-            this, &ObjectSelectionItem::objectGroupChanged);
+            this, &ObjectSelectionItem::updateObjectLabelColors);
 
     connect(mapDocument, &MapDocument::hoveredMapObjectChanged,
             this, &ObjectSelectionItem::hoveredMapObjectChanged);
@@ -421,10 +420,6 @@ void ObjectSelectionItem::layerChanged(Layer *layer)
         collectObjects(*groupLayer, affectedObjects);
         syncOverlayItems(affectedObjects);
     }
-}
-
-void ObjectSelectionItem::objectGroupChanged(ObjectGroup * objectGroup) {
-    updateObjectLabelColors();
 }
 
 void ObjectSelectionItem::syncOverlayItems(const QList<MapObject*> &objects)

--- a/src/tiled/objectselectionitem.cpp
+++ b/src/tiled/objectselectionitem.cpp
@@ -27,6 +27,7 @@
 #include "mapobject.h"
 #include "mapobjectitem.h"
 #include "maprenderer.h"
+#include "objectgroup.h"
 #include "preferences.h"
 #include "tile.h"
 #include "utils.h"

--- a/src/tiled/objectselectionitem.h
+++ b/src/tiled/objectselectionitem.h
@@ -25,8 +25,6 @@
 
 #include <memory>
 
-#include "objectgroup.h"
-
 namespace Tiled {
 
 class GroupLayer;

--- a/src/tiled/objectselectionitem.h
+++ b/src/tiled/objectselectionitem.h
@@ -67,7 +67,6 @@ private slots:
     void layerAdded(Layer *layer);
     void layerAboutToBeRemoved(GroupLayer *parentLayer, int index);
     void layerChanged(Layer *layer);
-    void objectGroupChanged(ObjectGroup * objectGroup);
     void syncOverlayItems(const QList<MapObject *> &objects);
     void updateObjectLabelColors();
     void objectsAdded(const QList<MapObject*> &objects);

--- a/src/tiled/objectselectionitem.h
+++ b/src/tiled/objectselectionitem.h
@@ -25,6 +25,8 @@
 
 #include <memory>
 
+#include "objectgroup.h"
+
 namespace Tiled {
 
 class GroupLayer;
@@ -65,6 +67,7 @@ private slots:
     void layerAdded(Layer *layer);
     void layerAboutToBeRemoved(GroupLayer *parentLayer, int index);
     void layerChanged(Layer *layer);
+    void objectGroupChanged(ObjectGroup * objectGroup);
     void syncOverlayItems(const QList<MapObject *> &objects);
     void updateObjectLabelColors();
     void objectsAdded(const QList<MapObject*> &objects);


### PR DESCRIPTION
Closes #1976.

Adds new slot to `ObjectSelectionItem` that listens for `objectGroupChanged` from `MapDocument` (a signal that is triggered whenever the layer color is changed) and updates color labels when a signal is received.