### PR TITLE
Add missing include.

### DIFF
--- a/src/tiled/newsfeed.cpp
+++ b/src/tiled/newsfeed.cpp
@@ -22,6 +22,7 @@
 
 #include "preferences.h"
 
+#include <QDebug>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QSettings>


### PR DESCRIPTION
Under certain conditions, this seems to be causing a [build failure](https://667000.bugs.gentoo.org/attachment.cgi?id=547810) with qt-5.11.