### PR TITLE
Fixed crash on remove command attempt (#2014)

### DIFF
--- a/src/tiled/commanddatamodel.cpp
+++ b/src/tiled/commanddatamodel.cpp
@@ -89,7 +89,7 @@ bool CommandDataModel::removeRows(int row, int count, const QModelIndex &parent)
     if (row < 0 || row + count > mCommands.size())
         return false;
 
-    beginRemoveRows(parent, row, row + count);
+    beginRemoveRows(parent, row, row + count - 1);
     mCommands.erase(mCommands.begin() + row, mCommands.begin() + row + count);
     endRemoveRows();
 


### PR DESCRIPTION
Fixed crash caused by badly calculated argument in beginRemoveRows function call that led to SIGSEGV when attepting to remove command and only one left in list