### PR TITLE
GH1997 Add QFileSystemWatcher for rules.txt

### DIFF
--- a/src/tiled/automappingmanager.cpp
+++ b/src/tiled/automappingmanager.cpp
@@ -224,9 +224,8 @@ void AutomappingManager::setMapDocument(MapDocument *mapDocument)
         newRules = rulesFileName();
     }
 
-    if (newRules != oldRules) {
+    if (newRules != oldRules)
         cleanUp();
-    }
 }
 
 void AutomappingManager::cleanUp()

--- a/src/tiled/automappingmanager.h
+++ b/src/tiled/automappingmanager.h
@@ -139,7 +139,7 @@ private:
 
     QFileSystemWatcher mWatcher;
 
-    const QString rulesFileName();
+    QString rulesFileName() const;
 };
 
 } // namespace Internal

--- a/src/tiled/automappingmanager.h
+++ b/src/tiled/automappingmanager.h
@@ -24,6 +24,7 @@
 #include <QRegion>
 #include <QString>
 #include <QVector>
+#include <QFileSystemWatcher>
 
 namespace Tiled {
 
@@ -76,6 +77,7 @@ public slots:
 
 private slots:
     void onRegionEdited(const QRegion &where, Layer *touchedLayer);
+    void onFileChanged();
 
 private:
     Q_DISABLE_COPY(AutomappingManager)
@@ -134,6 +136,10 @@ private:
      * behavior.
      */
     QString mWarning;
+
+    QFileSystemWatcher *mWatcher;
+
+    QString getRulesFileName();
 };
 
 } // namespace Internal

--- a/src/tiled/automappingmanager.h
+++ b/src/tiled/automappingmanager.h
@@ -137,9 +137,9 @@ private:
      */
     QString mWarning;
 
-    QFileSystemWatcher *mWatcher;
+    QFileSystemWatcher mWatcher;
 
-    QString getRulesFileName();
+    const QString rulesFileName();
 };
 
 } // namespace Internal


### PR DESCRIPTION
closes #1997 

Automatic update of mapping rules whenever rules.txt is changed, and rules are only reloaded when switching maps if the maps are in different directories