### PR TITLE
Animation preview follows zoom factor for tiles

### DIFF
--- a/src/tiled/tileanimationeditor.cpp
+++ b/src/tiled/tileanimationeditor.cpp
@@ -541,8 +541,11 @@ void TileAnimationEditor::advancePreviewAnimation(int ms)
 
     if (previousTileId != frame.tileId) {
         Tileset *tileset = mTile->tileset();
-        if (const Tile *tile = tileset->findTile(frame.tileId))
-            mUi->preview->setPixmap(tile->image());
+        if (const Tile *tile = tileset->findTile(frame.tileId)) {
+            const int w = tile->image().width() * mUi->tilesetView->zoomable()->scale();
+            const int h = tile->image().height() * mUi->tilesetView->zoomable()->scale();
+            mUi->preview->setPixmap(tile->image().scaled(w, h, Qt::KeepAspectRatio));
+        }
     }
 }
 


### PR DESCRIPTION
On HiDPI displays preview box tile animation is very small.
This patch adds zooming to scale defined for animation editor popup.

![image](https://user-images.githubusercontent.com/1594349/50570858-de338d80-0dab-11e9-8883-e2965b708fb4.png)

