### PR TITLE
Add support for .world files in tmxrasterizer

### DIFF
--- a/src/libtiled/worldmanager.cpp
+++ b/src/libtiled/worldmanager.cpp
@@ -172,14 +172,14 @@ std::unique_ptr<World> WorldManager::privateLoadWorld(const QString &fileName,
 /**
  * Loads the world with the given \a fileName.
  *
- * \returns whether the world was loaded succesfully, optionally setting
+ * \returns the world if it was loaded succesfully, optionally setting
  *          \a errorString when not.
  */
-bool WorldManager::loadWorld(const QString &fileName, QString *errorString)
+World *WorldManager::loadWorld(const QString &fileName, QString *errorString)
 {
     auto world = privateLoadWorld(fileName, errorString);
     if (!world)
-        return false;
+        return nullptr;
 
     if (mWorlds.contains(fileName))
         delete mWorlds.take(fileName);
@@ -189,7 +189,7 @@ bool WorldManager::loadWorld(const QString &fileName, QString *errorString)
     mWorlds.insert(fileName, world.release());
     emit worldsChanged();
 
-    return true;
+    return mWorlds.value(fileName);
 }
 
 /**

--- a/src/libtiled/worldmanager.h
+++ b/src/libtiled/worldmanager.h
@@ -82,7 +82,7 @@ public:
     static WorldManager &instance();
     static void deleteInstance();
 
-    bool loadWorld(const QString &fileName, QString *errorString = nullptr);
+    World *loadWorld(const QString &fileName, QString *errorString = nullptr);
     void unloadWorld(const QString &fileName);
 
     const QMap<QString, World*> &worlds() const { return mWorlds; }

--- a/src/tmxrasterizer/main.cpp
+++ b/src/tmxrasterizer/main.cpp
@@ -118,6 +118,6 @@ int main(int argc, char *argv[])
             exit(1);
         }
     }
-    
+
     return w.render(fileToOpen, fileToSave);
 }

--- a/src/tmxrasterizer/main.cpp
+++ b/src/tmxrasterizer/main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
     app.setApplicationVersion(QLatin1String("1.0"));
 
     QCommandLineParser parser;
-    parser.setApplicationDescription(QCoreApplication::translate("main", "Renders a Tiled map (TMX format) to an image."));
+    parser.setApplicationDescription(QCoreApplication::translate("main", "Renders a Tiled map (TMX format) or a World map (WORLD format) to an image."));
     parser.addHelpOption();
     parser.addVersionOption();
     parser.addOptions({
@@ -118,6 +118,6 @@ int main(int argc, char *argv[])
             exit(1);
         }
     }
-
+    
     return w.render(fileToOpen, fileToSave);
 }

--- a/src/tmxrasterizer/tmxrasterizer.cpp
+++ b/src/tmxrasterizer/tmxrasterizer.cpp
@@ -46,17 +46,7 @@
 
 using namespace Tiled;
 
-TmxRasterizer::TmxRasterizer():
-    mScale(1.0),
-    mTileSize(0),
-    mSize(0),
-    mUseAntiAliasing(false),
-    mSmoothImages(true),
-    mIgnoreVisibility(false)
-{
-}
-
-std::unique_ptr<MapRenderer> TmxRasterizer::createRenderer(Map &map) const
+static std::unique_ptr<MapRenderer> createRenderer(Map &map)
 {
     switch (map.orientation()) {
     case Map::Isometric:
@@ -70,6 +60,17 @@ std::unique_ptr<MapRenderer> TmxRasterizer::createRenderer(Map &map) const
         return std::unique_ptr<MapRenderer>(new OrthogonalRenderer(&map));
     }
 }
+
+TmxRasterizer::TmxRasterizer():
+    mScale(1.0),
+    mTileSize(0),
+    mSize(0),
+    mUseAntiAliasing(false),
+    mSmoothImages(true),
+    mIgnoreVisibility(false)
+{
+}
+
 void TmxRasterizer::drawMapLayers(MapRenderer &renderer,
                                   QPainter &painter,
                                   Map &map,

--- a/src/tmxrasterizer/tmxrasterizer.cpp
+++ b/src/tmxrasterizer/tmxrasterizer.cpp
@@ -37,6 +37,7 @@
 #include "orthogonalrenderer.h"
 #include "staggeredrenderer.h"
 #include "tilelayer.h"
+#include "worldmanager.h"
 
 #include <QDebug>
 #include <QImageWriter>
@@ -55,6 +56,48 @@ TmxRasterizer::TmxRasterizer():
 {
 }
 
+std::unique_ptr<MapRenderer> TmxRasterizer::createRenderer(Map& map) const
+{
+    switch (map.orientation()) {
+    case Map::Isometric:
+        return std::unique_ptr<MapRenderer>(new IsometricRenderer(&map));
+    case Map::Staggered:
+        return std::unique_ptr<MapRenderer>(new StaggeredRenderer(&map));
+    case Map::Hexagonal:
+        return std::unique_ptr<MapRenderer>(new HexagonalRenderer(&map));
+    case Map::Orthogonal:
+    default:
+        return std::unique_ptr<MapRenderer>(new OrthogonalRenderer(&map));
+    }
+}
+void TmxRasterizer::drawMapLayers(MapRenderer& renderer,
+                                 QPainter& painter,
+                                 Map& map,
+                                 QPoint mapOffset) const
+{
+    // Perform a similar rendering than found in exportasimagedialog.cpp
+    LayerIterator iterator(&map);
+    while (const Layer *layer = iterator.next()) {
+        if (!shouldDrawLayer(layer))
+            continue;
+
+        const auto offset = layer->totalOffset() + mapOffset;
+        painter.setOpacity(layer->effectiveOpacity());
+        painter.translate(offset);
+
+        const TileLayer *tileLayer = dynamic_cast<const TileLayer*>(layer);
+        const ImageLayer *imageLayer = dynamic_cast<const ImageLayer*>(layer);
+
+        if (tileLayer) {
+            renderer.drawTileLayer(&painter, tileLayer);
+        } else if (imageLayer) {
+            renderer.drawImageLayer(&painter, imageLayer);
+        }
+
+        painter.translate(-offset);
+    }
+}
+
 bool TmxRasterizer::shouldDrawLayer(const Layer *layer) const
 {
     if (layer->isObjectGroup() || layer->isGroupLayer())
@@ -69,8 +112,17 @@ bool TmxRasterizer::shouldDrawLayer(const Layer *layer) const
     return !layer->isHidden();
 }
 
-int TmxRasterizer::render(const QString &mapFileName,
+int TmxRasterizer::render(const QString &fileName,
                           const QString &imageFileName)
+{
+    if(fileName.endsWith(".world"))
+        return renderWorld(fileName, imageFileName);
+    else
+        return renderMap(fileName, imageFileName);
+}
+
+int TmxRasterizer::renderMap(const QString &mapFileName,
+                             const QString &imageFileName)
 {
     MapReader reader;
     std::unique_ptr<Map> map { reader.readMap(mapFileName) };
@@ -81,24 +133,7 @@ int TmxRasterizer::render(const QString &mapFileName,
         return 1;
     }
 
-    std::unique_ptr<MapRenderer> renderer;
-
-    switch (map->orientation()) {
-    case Map::Isometric:
-        renderer.reset(new IsometricRenderer(map.get()));
-        break;
-    case Map::Staggered:
-        renderer.reset(new StaggeredRenderer(map.get()));
-        break;
-    case Map::Hexagonal:
-        renderer.reset(new HexagonalRenderer(map.get()));
-        break;
-    case Map::Orthogonal:
-    default:
-        renderer.reset(new OrthogonalRenderer(map.get()));
-        break;
-    }
-
+    std::unique_ptr<MapRenderer> renderer = createRenderer(*map.get());
     QRect mapBoundingRect = renderer->mapBoundingRect();
     QSize mapSize = mapBoundingRect.size();
     QPoint mapOffset = mapBoundingRect.topLeft();
@@ -133,32 +168,15 @@ int TmxRasterizer::render(const QString &mapFileName,
     painter.translate(margins.left(), margins.top());
     painter.translate(-mapOffset);
 
-    // Perform a similar rendering than found in exportasimagedialog.cpp
-    LayerIterator iterator(map.get());
-    while (const Layer *layer = iterator.next()) {
-        if (!shouldDrawLayer(layer))
-            continue;
-
-        const auto offset = layer->totalOffset();
-
-        painter.setOpacity(layer->effectiveOpacity());
-        painter.translate(offset);
-
-        const TileLayer *tileLayer = dynamic_cast<const TileLayer*>(layer);
-        const ImageLayer *imageLayer = dynamic_cast<const ImageLayer*>(layer);
-
-        if (tileLayer) {
-            renderer->drawTileLayer(&painter, tileLayer);
-        } else if (imageLayer) {
-            renderer->drawImageLayer(&painter, imageLayer);
-        }
-
-        painter.translate(-offset);
-    }
-
+    drawMapLayers(*renderer.get(), painter, *map.get());
     map.reset();
+    return saveImage(imageFileName, image);
+}
 
-    // Save image
+
+int TmxRasterizer::saveImage(const QString& imageFileName,
+                             const QImage& image) const
+{
     QImageWriter imageWriter(imageFileName);
 
     if (!imageWriter.canWrite())
@@ -172,4 +190,72 @@ int TmxRasterizer::render(const QString &mapFileName,
     }
 
     return 0;
+}
+
+int TmxRasterizer::renderWorld(const QString &worldFileName,
+                               const QString &imageFileName)
+{
+    WorldManager &worldManager = WorldManager::instance();
+    QString errorString;
+    const World *world = nullptr;
+    if (worldManager.loadWorld(worldFileName, &errorString)){
+        auto const &worlds = worldManager.worlds();
+        auto WorldIt = worlds.find(worldFileName);
+        if (WorldIt != worlds.end())
+            world = WorldIt.value();
+    }
+    if (world == nullptr) {
+        qWarning("Error loading the world file \"%s\":\n%s",
+                 qUtf8Printable(worldFileName),
+                 qUtf8Printable(errorString));
+        return 1;
+    }
+        
+    auto const maps = world->allMaps();
+    QRect worldBoundingRect;
+    bool boundsAreInit = false;
+    for (const World::MapEntry &mapEntry : maps) {
+        if (!boundsAreInit){
+            boundsAreInit = true;
+            worldBoundingRect = mapEntry.rect;
+            continue;
+        }
+        if (worldBoundingRect.left() > mapEntry.rect.left())
+            worldBoundingRect.setLeft(mapEntry.rect.left());
+        if (worldBoundingRect.top() > mapEntry.rect.top())
+            worldBoundingRect.setTop(mapEntry.rect.top());
+        if (worldBoundingRect.right() < mapEntry.rect.right())
+            worldBoundingRect.setRight(mapEntry.rect.right());
+        if (worldBoundingRect.bottom() < mapEntry.rect.bottom())
+            worldBoundingRect.setBottom(mapEntry.rect.bottom());
+    }   
+        
+    QSize mapSize = worldBoundingRect.size();
+    QPoint mapOffset = worldBoundingRect.topLeft();
+    
+    QImage image(mapSize * mScale, QImage::Format_ARGB32);
+    image.fill(Qt::transparent);
+    QPainter painter(&image);
+
+    painter.setRenderHint(QPainter::Antialiasing, mUseAntiAliasing);
+    painter.setRenderHint(QPainter::SmoothPixmapTransform, mSmoothImages);
+    painter.setTransform(QTransform::fromScale(mScale, mScale));
+
+    painter.translate(-mapOffset);
+
+    for (const World::MapEntry &mapEntry : maps) {
+        MapReader reader;
+        std::unique_ptr<Map> map { reader.readMap(mapEntry.fileName) };
+        if (!map) {
+            qWarning("Error while reading \"%s\":\n%s",
+                    qUtf8Printable(mapEntry.fileName),
+                    qUtf8Printable(reader.errorString()));
+            return 1;
+        }
+
+        std::unique_ptr<MapRenderer> renderer = createRenderer(*map.get());
+        drawMapLayers(*renderer.get(), painter, *map.get(), mapEntry.rect.topLeft());
+    }
+
+    return saveImage(imageFileName, image);
 }

--- a/src/tmxrasterizer/tmxrasterizer.cpp
+++ b/src/tmxrasterizer/tmxrasterizer.cpp
@@ -56,7 +56,7 @@ TmxRasterizer::TmxRasterizer():
 {
 }
 
-std::unique_ptr<MapRenderer> TmxRasterizer::createRenderer(Map& map) const
+std::unique_ptr<MapRenderer> TmxRasterizer::createRenderer(Map &map) const
 {
     switch (map.orientation()) {
     case Map::Isometric:
@@ -71,9 +71,9 @@ std::unique_ptr<MapRenderer> TmxRasterizer::createRenderer(Map& map) const
     }
 }
 void TmxRasterizer::drawMapLayers(MapRenderer& renderer,
-                                 QPainter& painter,
-                                 Map& map,
-                                 QPoint mapOffset) const
+                                  QPainter& painter,
+                                  Map& map,
+                                  QPoint mapOffset) const
 {
     // Perform a similar rendering than found in exportasimagedialog.cpp
     LayerIterator iterator(&map);
@@ -115,7 +115,7 @@ bool TmxRasterizer::shouldDrawLayer(const Layer *layer) const
 int TmxRasterizer::render(const QString &fileName,
                           const QString &imageFileName)
 {
-    if(fileName.endsWith(".world"))
+    if (fileName.endsWith(".world", Qt::CaseInsensitive))
         return renderWorld(fileName, imageFileName);
     else
         return renderMap(fileName, imageFileName);
@@ -133,7 +133,7 @@ int TmxRasterizer::renderMap(const QString &mapFileName,
         return 1;
     }
 
-    std::unique_ptr<MapRenderer> renderer = createRenderer(*map.get());
+    std::unique_ptr<MapRenderer> renderer = createRenderer(*map);
     QRect mapBoundingRect = renderer->mapBoundingRect();
     QSize mapSize = mapBoundingRect.size();
     QPoint mapOffset = mapBoundingRect.topLeft();
@@ -168,7 +168,7 @@ int TmxRasterizer::renderMap(const QString &mapFileName,
     painter.translate(margins.left(), margins.top());
     painter.translate(-mapOffset);
 
-    drawMapLayers(*renderer.get(), painter, *map.get());
+    drawMapLayers(*renderer, painter, *map);
     map.reset();
     return saveImage(imageFileName, image);
 }
@@ -197,51 +197,57 @@ int TmxRasterizer::renderWorld(const QString &worldFileName,
 {
     WorldManager &worldManager = WorldManager::instance();
     QString errorString;
-    const World *world = nullptr;
-    if (worldManager.loadWorld(worldFileName, &errorString)){
-        auto const &worlds = worldManager.worlds();
-        auto WorldIt = worlds.find(worldFileName);
-        if (WorldIt != worlds.end())
-            world = WorldIt.value();
-    }
-    if (world == nullptr) {
+    const World *world = worldManager.loadWorld(worldFileName, &errorString);
+    if (!world) {
         qWarning("Error loading the world file \"%s\":\n%s",
                  qUtf8Printable(worldFileName),
                  qUtf8Printable(errorString));
         return 1;
     }
-        
+    
     auto const maps = world->allMaps();
+    if (maps.isEmpty()) {
+        qWarning("Error: The world file to rasterize contains no maps : \"%s\"",
+                 qUtf8Printable(worldFileName));
+        return 1;
+    }
     QRect worldBoundingRect;
-    bool boundsAreInit = false;
+    MapReader reader;
     for (const World::MapEntry &mapEntry : maps) {
-        if (!boundsAreInit){
-            boundsAreInit = true;
-            worldBoundingRect = mapEntry.rect;
+        std::unique_ptr<Map> map { reader.readMap(mapEntry.fileName) };
+        if (!map) {
+            qWarning("Error while reading \"%s\":\n%s",
+                     qUtf8Printable(mapEntry.fileName),
+                     qUtf8Printable(reader.errorString()));
             continue;
         }
-        if (worldBoundingRect.left() > mapEntry.rect.left())
-            worldBoundingRect.setLeft(mapEntry.rect.left());
-        if (worldBoundingRect.top() > mapEntry.rect.top())
-            worldBoundingRect.setTop(mapEntry.rect.top());
-        if (worldBoundingRect.right() < mapEntry.rect.right())
-            worldBoundingRect.setRight(mapEntry.rect.right());
-        if (worldBoundingRect.bottom() < mapEntry.rect.bottom())
-            worldBoundingRect.setBottom(mapEntry.rect.bottom());
-    }   
-        
-    QSize mapSize = worldBoundingRect.size();
-    QPoint mapOffset = worldBoundingRect.topLeft();
-    
-    QImage image(mapSize * mScale, QImage::Format_ARGB32);
+        std::unique_ptr<MapRenderer> renderer = createRenderer(*map);
+        QRect mapBoundingRect = renderer->mapBoundingRect();
+        mapBoundingRect.translate(mapEntry.rect.topLeft());
+
+        worldBoundingRect = worldBoundingRect.united(mapBoundingRect);
+    }
+    qDebug() << worldBoundingRect; //NO_PROD
+    QSize worldSize = worldBoundingRect.size();
+    qreal xScale, yScale;
+    if (mSize > 0) {
+        xScale = (qreal) mSize / worldSize.width();
+        yScale = (qreal) mSize / worldSize.height();
+        xScale = yScale = qMin(1.0, qMin(xScale, yScale));
+    } else
+        xScale = yScale = mScale;
+
+    worldSize.rwidth() *= xScale;
+    worldSize.rheight() *= yScale;
+    QImage image(worldSize, QImage::Format_ARGB32);
     image.fill(Qt::transparent);
     QPainter painter(&image);
 
     painter.setRenderHint(QPainter::Antialiasing, mUseAntiAliasing);
     painter.setRenderHint(QPainter::SmoothPixmapTransform, mSmoothImages);
-    painter.setTransform(QTransform::fromScale(mScale, mScale));
+    painter.setTransform(QTransform::fromScale(xScale, yScale));
 
-    painter.translate(-mapOffset);
+    painter.translate(-worldBoundingRect.topLeft());
 
     for (const World::MapEntry &mapEntry : maps) {
         MapReader reader;
@@ -253,8 +259,8 @@ int TmxRasterizer::renderWorld(const QString &worldFileName,
             return 1;
         }
 
-        std::unique_ptr<MapRenderer> renderer = createRenderer(*map.get());
-        drawMapLayers(*renderer.get(), painter, *map.get(), mapEntry.rect.topLeft());
+        std::unique_ptr<MapRenderer> renderer = createRenderer(*map);
+        drawMapLayers(*renderer, painter, *map, mapEntry.rect.topLeft());
     }
 
     return saveImage(imageFileName, image);

--- a/src/tmxrasterizer/tmxrasterizer.cpp
+++ b/src/tmxrasterizer/tmxrasterizer.cpp
@@ -140,12 +140,12 @@ int TmxRasterizer::renderMap(const QString &mapFileName,
     qreal xScale, yScale;
 
     if (mSize > 0) {
-        xScale = (qreal) mSize / mapSize.width();
-        yScale = (qreal) mSize / mapSize.height();
+        xScale = static_cast<qreal>(mSize) / mapSize.width();
+        yScale = static_cast<qreal>(mSize) / mapSize.height();
         xScale = yScale = qMin(1.0, qMin(xScale, yScale));
     } else if (mTileSize > 0) {
-        xScale = (qreal) mTileSize / map->tileWidth();
-        yScale = (qreal) mTileSize / map->tileHeight();
+        xScale = static_cast<qreal>(mTileSize) / map->tileWidth();
+        yScale = static_cast<qreal>(mTileSize) / map->tileHeight();
     } else {
         xScale = yScale = mScale;
     }
@@ -174,8 +174,8 @@ int TmxRasterizer::renderMap(const QString &mapFileName,
 }
 
 
-int TmxRasterizer::saveImage(const QString& imageFileName,
-                             const QImage& image) const
+int TmxRasterizer::saveImage(const QString &imageFileName,
+                             const QImage &image) const
 {
     QImageWriter imageWriter(imageFileName);
 
@@ -227,15 +227,16 @@ int TmxRasterizer::renderWorld(const QString &worldFileName,
 
         worldBoundingRect = worldBoundingRect.united(mapBoundingRect);
     }
-    qDebug() << worldBoundingRect; //NO_PROD
+
     QSize worldSize = worldBoundingRect.size();
     qreal xScale, yScale;
     if (mSize > 0) {
-        xScale = (qreal) mSize / worldSize.width();
-        yScale = (qreal) mSize / worldSize.height();
+        xScale = static_cast<qreal>(mSize) / worldSize.width();
+        yScale = static_cast<qreal>(mSize) / worldSize.height();
         xScale = yScale = qMin(1.0, qMin(xScale, yScale));
-    } else
+    } else {
         xScale = yScale = mScale;
+    }
 
     worldSize.rwidth() *= xScale;
     worldSize.rheight() *= yScale;

--- a/src/tmxrasterizer/tmxrasterizer.cpp
+++ b/src/tmxrasterizer/tmxrasterizer.cpp
@@ -70,9 +70,9 @@ std::unique_ptr<MapRenderer> TmxRasterizer::createRenderer(Map &map) const
         return std::unique_ptr<MapRenderer>(new OrthogonalRenderer(&map));
     }
 }
-void TmxRasterizer::drawMapLayers(MapRenderer& renderer,
-                                  QPainter& painter,
-                                  Map& map,
+void TmxRasterizer::drawMapLayers(MapRenderer &renderer,
+                                  QPainter &painter,
+                                  Map &map,
                                   QPoint mapOffset) const
 {
     // Perform a similar rendering than found in exportasimagedialog.cpp

--- a/src/tmxrasterizer/tmxrasterizer.h
+++ b/src/tmxrasterizer/tmxrasterizer.h
@@ -73,7 +73,6 @@ private:
     bool mIgnoreVisibility;
     QStringList mLayersToHide;
 
-    std::unique_ptr<MapRenderer> createRenderer(Map& map) const;
     void drawMapLayers(MapRenderer &renderer, QPainter &painter, Map &map, QPoint mapOffset = QPoint(0, 0)) const;
     int renderMap(const QString &mapFileName, const QString &imageFileName);
     int renderWorld(const QString &worldFileName, const QString &imageFileName);

--- a/src/tmxrasterizer/tmxrasterizer.h
+++ b/src/tmxrasterizer/tmxrasterizer.h
@@ -51,7 +51,7 @@ public:
     int size() const { return mSize; }
     bool useAntiAliasing() const { return mUseAntiAliasing; }
     bool smoothImages() const { return mSmoothImages; }
-    bool IgnoreVisibility() const { return mIgnoreVisibility; }
+    bool ignoreVisibility() const { return mIgnoreVisibility; }
 
     void setScale(qreal scale) { mScale = scale; }
     void setTileSize(int tileSize) { mTileSize = tileSize; }
@@ -74,9 +74,9 @@ private:
     QStringList mLayersToHide;
 
     std::unique_ptr<MapRenderer> createRenderer(Map& map) const;
-    void drawMapLayers(MapRenderer& renderer, QPainter& painter, Map& map, QPoint mapOffset = QPoint(0,0)) const;
+    void drawMapLayers(MapRenderer &renderer, QPainter &painter, Map &map, QPoint mapOffset = QPoint(0, 0)) const;
     int renderMap(const QString &mapFileName, const QString &imageFileName);
     int renderWorld(const QString &worldFileName, const QString &imageFileName);
-    int saveImage(const QString& imageFileName, const QImage& image) const;
+    int saveImage(const QString &imageFileName, const QImage &image) const;
     bool shouldDrawLayer(const Layer *layer) const;
 };

--- a/src/tmxrasterizer/tmxrasterizer.h
+++ b/src/tmxrasterizer/tmxrasterizer.h
@@ -30,10 +30,15 @@
 
 #include "layer.h"
 
+#include "map.h"
+#include "mapreader.h"
 #include <QString>
 #include <QStringList>
 
 using namespace Tiled;
+
+class QImage;
+class QPainter;
 
 class TmxRasterizer
 {
@@ -57,7 +62,7 @@ public:
 
     void setLayersToHide(QStringList layersToHide) { mLayersToHide = layersToHide; }
 
-    int render(const QString &mapFileName, const QString &imageFileName);
+    int render(const QString &fileName, const QString &imageFileName);
 
 private:
     qreal mScale;
@@ -68,5 +73,10 @@ private:
     bool mIgnoreVisibility;
     QStringList mLayersToHide;
 
+    std::unique_ptr<MapRenderer> createRenderer(Map& map) const;
+    void drawMapLayers(MapRenderer& renderer, QPainter& painter, Map& map, QPoint mapOffset = QPoint(0,0)) const;
+    int renderMap(const QString &mapFileName, const QString &imageFileName);
+    int renderWorld(const QString &worldFileName, const QString &imageFileName);
+    int saveImage(const QString& imageFileName, const QImage& image) const;
     bool shouldDrawLayer(const Layer *layer) const;
 };


### PR DESCRIPTION
With this PR, users will be able to convert a .world file into a .png file by running the command :
tmxrasterizer <worldFile> <destPngFile> [options...]

This PR does not affect .tmx/.json conversion to png.