### PR TITLE
Allow qrc-based tileset images in new tileset code

### DIFF
--- a/src/libtiled/tileset.cpp
+++ b/src/libtiled/tileset.cpp
@@ -286,7 +286,7 @@ bool Tileset::loadFromImage(const QString &fileName)
 bool Tileset::loadImage()
 {
     TilesheetParameters p;
-    p.fileName = mImageReference.source.toLocalFile();
+    p.fileName = Tiled::urlToLocalFileOrQrc(mImageReference.source);
     p.tileWidth = mTileWidth;
     p.tileHeight = mTileHeight;
     p.spacing = mTileSpacing;


### PR DESCRIPTION
89aa41b and 9764a01 already made these kind of changes, so this
just fixes it in another place after 9202e25.