### PR TITLE
Added export to Defold .collection files

### DIFF
--- a/src/plugins/defoldcollection/defoldcollection.pro
+++ b/src/plugins/defoldcollection/defoldcollection.pro
@@ -1,0 +1,7 @@
+include(../plugin.pri)
+
+DEFINES += CSV_LIBRARY
+
+SOURCES += defoldcollectionplugin.cpp
+HEADERS += defoldcollectionplugin.h \
+    defoldcollectionplugin_global.h

--- a/src/plugins/defoldcollection/defoldcollection.qbs
+++ b/src/plugins/defoldcollection/defoldcollection.qbs
@@ -1,0 +1,12 @@
+import qbs 1.0
+
+TiledPlugin {
+    cpp.defines: base.concat(["DEFOLDCOLLECTION_LIBRARY"])
+
+    files: [
+        "defoldcollectionplugin_global.h",
+        "defoldcollectionplugin.cpp",
+        "defoldcollectionplugin.h",
+        "plugin.json",
+    ]
+}

--- a/src/plugins/defoldcollection/defoldcollectionplugin.cpp
+++ b/src/plugins/defoldcollection/defoldcollectionplugin.cpp
@@ -326,7 +326,7 @@ bool DefoldCollectionPlugin::write(const Tiled::Map *map, const QString &collect
                 QVariantHash map_h;
 
                 QString layers;
-                int cells_on_this_tilemap = 0;
+                int cellsOnThisTilemap = 0;
                 int layerOrder = 0;
                 for (auto &subLayer : layer->asGroupLayer()->layers()) {
                     auto tileLayer = subLayer->asTileLayer();
@@ -355,13 +355,13 @@ bool DefoldCollectionPlugin::write(const Tiled::Map *map, const QString &collect
                             cell_h["h_flip"] = cell.flippedHorizontally() ? 1 : 0;
                             cell_h["v_flip"] = cell.flippedVertically() ? 1 : 0;
                             cells.append(replaceTags(QLatin1String(cell_t), cell_h));
-                            cells_on_this_tilemap++;
+                            cellsOnThisTilemap++;
 
                             // Create a component for this embedded instance only when the first cell is found.
                             // If 0 cells are found, this component is not necessary.
                             // If more than 1 cells are found, recreating it would be redundant.
                             // Hence, only when encountering the first cell do we create it.
-                            if (cells_on_this_tilemap == 1) {
+                            if (cellsOnThisTilemap == 1) {
                                 QVariantHash component_h;
                                 component_h["tilemap_name"] = mapName + "-" + layer->name() + "-" + tileset->name();
                                 component_h["tilemap_rel_path"] = tilesetRelativePath(tilemapFilePath);
@@ -382,7 +382,7 @@ bool DefoldCollectionPlugin::write(const Tiled::Map *map, const QString &collect
                 map_h["tile_set"] = "/tilesources/" + tileset->name() + ".tilesource";
 
                 // avoid saving tilemaps with 0 cells
-                if (cells_on_this_tilemap == 0)
+                if (cellsOnThisTilemap == 0)
                     continue;
 
                 QString result = replaceTags(QLatin1String(map_t), map_h);

--- a/src/plugins/defoldcollection/defoldcollectionplugin.cpp
+++ b/src/plugins/defoldcollection/defoldcollectionplugin.cpp
@@ -1,0 +1,473 @@
+/*
+ * DefoldCollection Tiled Plugin
+ * Copyright 2019, CodeSpartan
+ * Based on Defold Tiled Plugin by Nikita Razdobreev and Thorbjørn Lindeijer
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "defoldcollectionplugin.h"
+
+#include "layer.h"
+#include "map.h"
+#include "mapobject.h"
+#include "objectgroup.h"
+#include "savefile.h"
+#include "tile.h"
+#include "tilelayer.h"
+#include "grouplayer.h"
+
+#include <QTextStream>
+#include <QFileInfo>
+#include <QDir>
+
+#include <cmath>
+
+namespace DefoldCollection {
+
+static const char cell_t[] =
+"  cell {\n\
+    x: {{x}}\n\
+    y: {{y}}\n\
+    tile: {{tile}}\n\
+    h_flip: {{h_flip}}\n\
+    v_flip: {{v_flip}}\n\
+  }\n";
+
+static const char layer_t[] =
+"layers {\n\
+  id: \"{{id}}\"\n\
+  z: {{z}}\n\
+  is_visible: {{is_visible}}\n\
+{{cells}}\
+}\n";
+
+static const char map_t[] =
+"tile_set: \"{{tile_set}}\"\n\
+{{layers}}\n\
+material: \"{{material}}\"\n\
+blend_mode: {{blend_mode}}\n";
+
+static const char collection_t[] =
+"name: \"default\"\n\
+scale_along_z: 0\n\
+embedded_instances {\n\
+  id: \"tilemaps\"\n\
+{{children}}\
+  data: {{components}}\n\
+  \"\"\n\
+  position {\n\
+    x: {{pos-x}}\n\
+    y: {{pos-y}}\n\
+    z: 0.0\n\
+  }\n\
+  rotation {\n\
+    x: 0.0\n\
+    y: 0.0\n\
+    z: 0.0\n\
+    w: 1.0\n\
+  }\n\
+  scale3 {\n\
+    x: 1.0\n\
+    y: 1.0\n\
+    z: 1.0\n\
+  }\n\
+}\n\
+{{embedded-instances}}\n\
+\n";
+
+static const char component_t[] =
+"  \"components {\\n\"\n\
+  \"  id: \\\"{{tilemap_name}}\\\"\\n\"\n\
+  \"  component: \\\"{{tilemap_rel_path}}\\\"\\n\"\n\
+  \"  position {\\n\"\n\
+  \"    x: 0.0\\n\"\n\
+  \"    y: 0.0\\n\"\n\
+  \"    z: 0.0\\n\"\n\
+  \"  }\\n\"\n\
+  \"  rotation {\\n\"\n\
+  \"    x: 0.0\\n\"\n\
+  \"    y: 0.0\\n\"\n\
+  \"    z: 0.0\\n\"\n\
+  \"    w: 1.0\\n\"\n\
+  \"  }\\n\"\n\
+  \"}\\n\"\n\
+";
+
+static const char child_t[] =
+"  children: \"{{child-name}}\"\n\
+";
+
+static const char emdedded_instance_t[] =
+"embedded_instances {\n\
+  id: \"{{instance-name}}\"\n\
+  data: {{components}}\n\
+  \"\"\n\
+  position {\n\
+    x: 0.0\n\
+    y: 0.0\n\
+    z: 0.0\n\
+  }\n\
+  rotation {\n\
+    x: 0.0\n\
+    y: 0.0\n\
+    z: 0.0\n\
+    w: 1.0\n\
+  }\n\
+  scale3 {\n\
+    x: 1.0\n\
+    y: 1.0\n\
+    z: 1.0\n\
+  }\n\
+}\n\
+";
+
+static QString replaceTags(QString context, const QVariantHash &map)
+{
+    QHashIterator<QString,QVariant> it{map};
+    while (it.hasNext()) {
+        it.next();
+        context.replace(QLatin1String("{{") + it.key() + QLatin1String("}}"),
+                        it.value().toString());
+    }
+    return context;
+}
+
+DefoldCollectionPlugin::DefoldCollectionPlugin()
+{
+}
+
+QString DefoldCollectionPlugin::nameFilter() const
+{
+    return tr("Defold collection (*.collection)");
+}
+
+QString DefoldCollectionPlugin::shortName() const
+{
+    return QLatin1String("defoldcollection");
+}
+
+QString DefoldCollectionPlugin::errorString() const
+{
+    return mError;
+}
+
+/*
+ * Returns a new filepath relative to the root of the Defold project if we're in one.
+ * Determines the root of the project by looking for a file called "game.project".
+ * If no such file is found by going up the heirarchy, return filename from the filepath.
+*/
+QString DefoldCollectionPlugin::TilesetRelativePath(QString filePath)
+{
+    QString gameproject = "/game.project";
+    QFileInfo fi(filePath);
+    QDir Qd = fi.dir();
+
+    while (Qd.exists() && !Qd.isRoot())
+    {
+        if (QFileInfo::exists(Qd.path() + gameproject))
+        {
+            // return relative path
+            filePath.replace(Qd.path(), "");
+            return filePath;
+        }
+        else if (!Qd.cdUp())
+        {
+            break;
+        }
+    }
+    return fi.fileName();
+}
+
+bool DefoldCollectionPlugin::write(const Tiled::Map *map, const QString &fileName)
+{
+    QFileInfo fi(fileName);
+    QString outputFilePath = fi.filePath();
+    QString outputFileName = fi.fileName();
+
+    QString mapName = outputFileName;
+    mapName.replace(".collection", "");
+
+    QString tilesetFileDir = outputFilePath;
+    tilesetFileDir.chop(outputFileName.length());
+
+    // if there are no group layers, all tilemaps are components of the top gameobject called "tilemaps"
+    if (map->groupLayerCount() == 0)
+    {
+        QString components;
+
+        // create a tilemap for each tileset this map uses
+        for (auto& tileset_current : map->tilesets())
+        {
+            QString tilesetFilePath = tilesetFileDir;
+            tilesetFilePath.append(mapName + "-" + tileset_current->name() + ".tilemap");
+
+            QVariantHash component_h;
+            component_h["tilemap_name"] = mapName + "-" + tileset_current->name();
+            component_h["tilemap_rel_path"] = TilesetRelativePath(tilesetFilePath);
+            components.append(replaceTags(QLatin1String(component_t), component_h));
+
+            QVariantHash map_h;
+
+            QString layers;            
+            Tiled::LayerIterator it(map, Tiled::Layer::TileLayerType);
+            int layerOrder = 0;
+            while (auto tileLayer = static_cast<Tiled::TileLayer*>(it.next()))
+            {
+                QVariantHash layer_h;
+                layer_h["id"] = tileLayer->name();
+                float zIndex = qBound(0, layerOrder, 1000) * 0.00000001f;
+                layer_h["z"] = zIndex;
+                layer_h["is_visible"] = tileLayer->isVisible() ? 1 : 0;
+                QString cells;
+
+                for (int x = 0; x < tileLayer->width(); ++x)
+                {
+                    for (int y = 0; y < tileLayer->height(); ++y)
+                    {
+                        const Tiled::Cell &cell = tileLayer->cellAt(x, y);
+                        if (cell.isEmpty() || cell.tileset() != tileset_current) // skip cell if it doesn't belong to current tileset
+                            continue;
+                        QVariantHash cell_h;
+                        cell_h["x"] = x;
+                        cell_h["y"] = tileLayer->height() - y - 1;
+                        cell_h["tile"] = cell.tileId();
+                        cell_h["h_flip"] = cell.flippedHorizontally() ? 1 : 0;
+                        cell_h["v_flip"] = cell.flippedVertically() ? 1 : 0;
+                        cells.append(replaceTags(QLatin1String(cell_t), cell_h));
+                    }
+                }
+                layer_h["cells"] = cells;
+                layers.append(replaceTags(QLatin1String(layer_t), layer_h));
+                layerOrder++;
+            }
+            map_h["layers"] = layers;
+            map_h["material"] = "/builtins/materials/tile_map.material";
+            map_h["blend_mode"] = "BLEND_MODE_ALPHA";
+            // Below, we input a value that's not necessarily correct in Defold, but it lets the user know what tilesource to link this tilemap with manually.
+            // However, if the user keeps all tilesources in /tilesources/ and the name of the tilesource corresponds with the name of the tileset in Defold,
+            // the value will be automatically correct.
+            map_h["tile_set"] = "/tilesources/" + tileset_current->name() + ".tilesource";
+
+            QString result = replaceTags(QLatin1String(map_t), map_h);
+            Tiled::SaveFile mapFile(tilesetFilePath);
+            if (!mapFile.open(QIODevice::WriteOnly | QIODevice::Text))
+            {
+                mError = tr("Could not open file for writing.");
+                return false;
+            }
+            QTextStream stream(mapFile.device());
+            stream << result;
+
+            if (mapFile.error() != QFileDevice::NoError)
+            {
+                mError = mapFile.errorString();
+                return false;
+            }
+
+            if (!mapFile.commit())
+            {
+                mError = mapFile.errorString();
+                return false;
+            }
+        }
+
+        QVariantHash collection_h;
+        collection_h["children"] = QString("");
+        collection_h["embedded-instances"] = QString("");
+        // optional custom properties that allow exporting a map with an offset
+        collection_h["pos-x"] = map->property(QLatin1String("x-offset")).toInt();
+        collection_h["pos-y"] = map->property(QLatin1String("y-offset")).toInt();
+        collection_h["components"] = components;        
+
+        QString result = replaceTags(QLatin1String(collection_t), collection_h);
+        Tiled::SaveFile mapFile(fileName);
+        if (!mapFile.open(QIODevice::WriteOnly | QIODevice::Text))
+        {
+            mError = tr("Could not open file for writing.");
+            return false;
+        }
+        QTextStream stream(mapFile.device());
+        stream << result;
+
+        if (mapFile.error() != QFileDevice::NoError)
+        {
+            mError = mapFile.errorString();
+            return false;
+        }
+
+        if (!mapFile.commit()) {
+            mError = mapFile.errorString();
+            return false;
+        }
+    }
+    // if there are group layers, each group layer is a gameobject, parented to the top gameobject, while being a parent to multiple tilemap components
+    else
+    {
+        QString children;
+        QString embeddedInstances;
+
+        // foreach Group Layer
+        int groupLayerOrder = 0;
+        for (auto& layer : map->layers())
+        {
+            if (layer->layerType() != Tiled::Layer::GroupLayerType)
+                continue;
+
+            QVariantHash child_h;
+            child_h["child-name"] = layer->name();
+            children.append(replaceTags(QLatin1String(child_t), child_h));
+
+            QVariantHash emdedded_instance_h;
+            emdedded_instance_h["instance-name"] = layer->name();
+
+            QString components;
+
+            // write as many tilemaps as there are tilesets per group layer
+            for (auto& tileset_current : map->tilesets())
+            {
+                QString tilesetFilePath = tilesetFileDir;
+                tilesetFilePath.append(mapName + "-" + layer->name() + "-" + tileset_current->name() + ".tilemap");
+
+                QVariantHash map_h;
+
+                QString layers;
+                int cells_on_this_tilemap = 0;
+                int layerOrder = 0;
+                for (auto& subLayer : layer->asGroupLayer()->layers())
+                {
+                    auto tileLayer = subLayer->asTileLayer();
+                    if (tileLayer == nullptr)
+                        continue;
+
+                    QVariantHash layer_h;
+                    layer_h["id"] = tileLayer->name();
+
+                    float zIndex = qBound(0, groupLayerOrder, 1000) * 0.0001f;
+                    zIndex += qBound(0, layerOrder, 1000) * 0.00000001f;
+                    layer_h["z"] = zIndex;
+
+                    layer_h["is_visible"] = layer->isVisible() ? 1 : 0;
+                    QString cells;
+
+                    for (int x = 0; x < tileLayer->width(); ++x)
+                    {
+                        for (int y = 0; y < tileLayer->height(); ++y)
+                        {
+                            const Tiled::Cell &cell = tileLayer->cellAt(x, y);
+                            if (cell.isEmpty() || cell.tileset() != tileset_current) // skip cell if it doesn't belong to current tileset
+                                continue;
+                            QVariantHash cell_h;
+                            cell_h["x"] = x;
+                            cell_h["y"] = tileLayer->height() - y - 1;
+                            cell_h["tile"] = cell.tileId();
+                            cell_h["h_flip"] = cell.flippedHorizontally() ? 1 : 0;
+                            cell_h["v_flip"] = cell.flippedVertically() ? 1 : 0;
+                            cells.append(replaceTags(QLatin1String(cell_t), cell_h));
+                            cells_on_this_tilemap++;
+
+                            // Create a component for this embedded instance only when the first cell is found.
+                            // If 0 cells are found, this component is not necessary.
+                            // If more than 1 cells are found, recreating it would be redundant.
+                            // Hence, only when encountering the first cell do we create it.
+                            if (cells_on_this_tilemap == 1)
+                            {
+                                QVariantHash component_h;
+                                component_h["tilemap_name"] = mapName + "-" + layer->name() + "-" + tileset_current->name();
+                                component_h["tilemap_rel_path"] = TilesetRelativePath(tilesetFilePath);
+                                components.append(replaceTags(QLatin1String(component_t), component_h));
+                            }
+                        }
+                    }
+                    layer_h["cells"] = cells;
+                    layers.append(replaceTags(QLatin1String(layer_t), layer_h));
+                    layerOrder++;
+                }
+                map_h["layers"] = layers;
+                map_h["material"] = "/builtins/materials/tile_map.material";
+                map_h["blend_mode"] = "BLEND_MODE_ALPHA";
+                // Below, we input a value that's not necessarily correct in Defold, but it lets the user know what tilesource to link this tilemap with manually.
+                // However, if the user keeps all tilesources in /tilesources/ and the name of the tilesource corresponds with the name of the tileset in Defold,
+                // the value will be automatically correct.
+                map_h["tile_set"] = "/tilesources/" + tileset_current->name() + ".tilesource";
+
+                // avoid saving tilemaps with 0 cells
+                if (cells_on_this_tilemap == 0)
+                    continue;
+
+                QString result = replaceTags(QLatin1String(map_t), map_h);
+                Tiled::SaveFile mapFile(tilesetFilePath);
+                if (!mapFile.open(QIODevice::WriteOnly | QIODevice::Text))
+                {
+                    mError = tr("Could not open file for writing.");
+                    return false;
+                }
+
+                QTextStream stream(mapFile.device());
+                stream << result;
+
+                if (mapFile.error() != QFileDevice::NoError)
+                {
+                    mError = mapFile.errorString();
+                    return false;
+                }
+
+                if (!mapFile.commit())
+                {
+                    mError = mapFile.errorString();
+                    return false;
+                }
+            }
+            emdedded_instance_h["components"] = components;
+            embeddedInstances.append(replaceTags(QLatin1String(emdedded_instance_t), emdedded_instance_h));
+
+            groupLayerOrder++;
+        }
+        QVariantHash collection_h;
+        // optional custom properties that allow exporting a map with an offset
+        collection_h["pos-x"] = map->property(QLatin1String("x-offset")).toInt();
+        collection_h["pos-y"] = map->property(QLatin1String("y-offset")).toInt();
+        collection_h["components"] = QString("");
+        collection_h["children"] = children;
+        collection_h["embedded-instances"] = embeddedInstances;
+
+        QString result = replaceTags(QLatin1String(collection_t), collection_h);
+        Tiled::SaveFile mapFile(fileName);
+        if (!mapFile.open(QIODevice::WriteOnly | QIODevice::Text))
+        {
+            mError = tr("Could not open file for writing.");
+            return false;
+        }
+        QTextStream stream(mapFile.device());
+        stream << result;
+
+        if (mapFile.error() != QFileDevice::NoError)
+        {
+            mError = mapFile.errorString();
+            return false;
+        }
+
+        if (!mapFile.commit())
+        {
+            mError = mapFile.errorString();
+            return false;
+        }
+    }
+
+    return true;
+}
+
+} // namespace DefoldCollection

--- a/src/plugins/defoldcollection/defoldcollectionplugin.cpp
+++ b/src/plugins/defoldcollection/defoldcollectionplugin.cpp
@@ -327,8 +327,6 @@ bool DefoldCollectionPlugin::write(const Tiled::Map *map, const QString &collect
 
         QString components;
 
-        int cellsOnThisTilemap = 0;
-
         // write as many tilemaps as there are tilesets per group layer
         for (auto &tileset : map->tilesets()) {
             QString tilemapFilePath = tilesetFileDir;
@@ -363,7 +361,6 @@ bool DefoldCollectionPlugin::write(const Tiled::Map *map, const QString &collect
                         cellHash["h_flip"] = cell.flippedHorizontally() ? 1 : 0;
                         cellHash["v_flip"] = cell.flippedVertically() ? 1 : 0;
                         cells.append(replaceTags(QLatin1String(cellTemplate), cellHash));
-                        cellsOnThisTilemap++;
                         componentCells++;
 
                         // Create a component for this embedded instance only when the first cell of this component is found.
@@ -377,6 +374,7 @@ bool DefoldCollectionPlugin::write(const Tiled::Map *map, const QString &collect
                         }
                     }
                 }
+
                 if (!cells.isEmpty()) {
                     layerHash["cells"] = cells;
                     layers.append(replaceTags(QLatin1String(layerTemplate), layerHash));
@@ -384,7 +382,7 @@ bool DefoldCollectionPlugin::write(const Tiled::Map *map, const QString &collect
             }
 
             // no need to save a tilemap with 0 cells
-            if (layers.length() == 0)
+            if (layers.isEmpty())
                 continue;
 
             tileMapHash["layers"] = layers;
@@ -394,10 +392,6 @@ bool DefoldCollectionPlugin::write(const Tiled::Map *map, const QString &collect
             // However, if the user keeps all tilesources in /tilesources/ and the name of the tilesource corresponds with the name of the tileset in Defold,
             // the value will be automatically correct.
             tileMapHash["tile_set"] = "/tilesources/" + tileset->name() + ".tilesource";
-
-            // avoid saving tilemaps with 0 cells
-            if (cellsOnThisTilemap == 0)
-                continue;
 
             QString result = replaceTags(QLatin1String(tileMapTemplate), tileMapHash);
             Tiled::SaveFile mapFile(tilemapFilePath);

--- a/src/plugins/defoldcollection/defoldcollectionplugin.cpp
+++ b/src/plugins/defoldcollection/defoldcollectionplugin.cpp
@@ -168,7 +168,7 @@ QString DefoldCollectionPlugin::errorString() const
 /*
  * Returns a new filepath relative to the root of the Defold project if we're in one.
  * Determines the root of the project by looking for a file called "game.project".
- * If no such file is found by going up the heirarchy, return filename from the filepath.
+ * If no such file is found by going up the hierarchy, return filename from the \a filePath.
 */
 QString DefoldCollectionPlugin::TilesetRelativePath(QString filePath)
 {

--- a/src/plugins/defoldcollection/defoldcollectionplugin.h
+++ b/src/plugins/defoldcollection/defoldcollectionplugin.h
@@ -47,6 +47,4 @@ private:
     QString mError;
 };
 
-static QString tilesetRelativePath(const QString & filePath);
-
 } // namespace DefoldCollection

--- a/src/plugins/defoldcollection/defoldcollectionplugin.h
+++ b/src/plugins/defoldcollection/defoldcollectionplugin.h
@@ -36,7 +36,7 @@ class DEFOLDCOLLECTIONPLUGINSHARED_EXPORT DefoldCollectionPlugin : public Tiled:
 public:
     DefoldCollectionPlugin();
 
-    bool write(const Tiled::Map *map, const QString &fileName) override;
+    bool write(const Tiled::Map *map, const QString &collectionFile) override;
     QString errorString() const override;
     QString shortName() const override;
 
@@ -44,9 +44,9 @@ protected:
     QString nameFilter() const override;
 
 private:
-    QString TilesetRelativePath(QString filePath);
-
     QString mError;
 };
+
+static QString tilesetRelativePath(const QString & filePath);
 
 } // namespace DefoldCollection

--- a/src/plugins/defoldcollection/defoldcollectionplugin.h
+++ b/src/plugins/defoldcollection/defoldcollectionplugin.h
@@ -1,0 +1,52 @@
+/*
+ * DefoldCollection Tiled Plugin
+ * Copyright 2019, CodeSpartan
+ * Based on Defold Tiled Plugin by Nikita Razdobreev and Thorbjørn Lindeijer
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "defoldcollectionplugin_global.h"
+#include "tiled.h"
+
+#include "mapformat.h"
+
+namespace DefoldCollection {
+
+class DEFOLDCOLLECTIONPLUGINSHARED_EXPORT DefoldCollectionPlugin : public Tiled::WritableMapFormat
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.mapeditor.MapFormat" FILE "plugin.json")
+
+public:
+    DefoldCollectionPlugin();
+
+    bool write(const Tiled::Map *map, const QString &fileName) override;
+    QString errorString() const override;
+    QString shortName() const override;
+
+protected:
+    QString nameFilter() const override;
+
+private:
+    QString TilesetRelativePath(QString filePath);
+
+    QString mError;
+};
+
+} // namespace DefoldCollection

--- a/src/plugins/defoldcollection/defoldcollectionplugin_global.h
+++ b/src/plugins/defoldcollection/defoldcollectionplugin_global.h
@@ -1,0 +1,30 @@
+/*
+ * DefoldCollection Tiled Plugin
+ * Copyright 2019, CodeSpartan
+ * Based on Defold Tiled Plugin by Nikita Razdobreev and Thorbjørn Lindeijer
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QtCore/qglobal.h>
+
+#if defined(DEFOLDCOLLECTION_LIBRARY)
+#  define DEFOLDCOLLECTIONPLUGINSHARED_EXPORT Q_DECL_EXPORT
+#else
+#  define DEFOLDCOLLECTIONPLUGINSHARED_EXPORT Q_DECL_IMPORT
+#endif

--- a/src/plugins/defoldcollection/plugin.json
+++ b/src/plugins/defoldcollection/plugin.json
@@ -1,0 +1,1 @@
+{ "defaultEnable": false }

--- a/src/plugins/plugins.pro
+++ b/src/plugins/plugins.pro
@@ -1,6 +1,7 @@
 TEMPLATE = subdirs
 SUBDIRS = csv \
           defold \
+          defoldcollection \
           droidcraft \
           flare \
           gmx \

--- a/src/plugins/plugins.qbs
+++ b/src/plugins/plugins.qbs
@@ -4,6 +4,7 @@ Project {
     references: [
         "csv",
         "defold",
+        "defoldcollection",
         "droidcraft",
         "flare",
         "gmx",


### PR DESCRIPTION
This pull request adds a plugin to Tiled, which allows exporting a map into a .collection (Defold's prefab).

Exporting into a collection allows the use of:
- Group layers (**only top-level group layers are supported, not nested ones!**)
- Multiple Tilesets per Tilemap

Upon export:
- The **Path** property of each Tileset may need to be set up manually in Defold after each export. However, Tiled will attempt to find the .tilesource file corresponding with the name of the Tileset in Tiled in your project's /tilesources/ directory. If one is found, manual adjustments won't be necessary. The way Tiled finds the root of your project is by looking for a file called "game.project" while going up the hierarchy, starting from the directory where you save the collection. Therefore, if you save your Collection outside your project, manually setting up the **Path** property will be necessary afterwards.
- If you create custom properties on your map called "x-offset" and "y-offset", these values will be used as coordinates for your top-level GameObject in the Collection.

All layers of a Tilemap will have **Z**-index property assigned with values ranging between **0** and **0.1**.
The plugin supports the use of 9999 Group Layers and 9999 Tile Layers per Group Layer.
Z-Index is assigned by combining Group Layer's order (from bottom up) with Tile Layer's order (from bottom up) in the following way: group's order is divided by 10000, layer's order is divided by 1'0000'0000, and their sum is the Z-index. So, for example, if the Group Layer's order was 15, and the Tile Layer's order was 200, the resulting Z-index would be 0.00150200. This guarantees correct superimposing of all elements in Defold.