### PR TITLE
Allow loading a TSX file from Python plugins

### DIFF
--- a/src/plugins/python/pythonbind.cpp
+++ b/src/plugins/python/pythonbind.cpp
@@ -9,51 +9,6 @@
 #include <stddef.h>
 
 
-#if PY_VERSION_HEX < 0x020400F0
-
-#define PyEval_ThreadsInitialized() 1
-
-#define Py_CLEAR(op)				\
-        do {                            	\
-                if (op) {			\
-                        PyObject *tmp = (PyObject *)(op);	\
-                        (op) = NULL;		\
-                        Py_DECREF(tmp);		\
-                }				\
-        } while (0)
-
-
-#define Py_VISIT(op)							\
-        do { 								\
-                if (op) {						\
-                        int vret = visit((PyObject *)(op), arg);	\
-                        if (vret)					\
-                                return vret;				\
-                }							\
-        } while (0)
-
-#endif
-
-
-
-#if PY_VERSION_HEX < 0x020500F0
-
-typedef int Py_ssize_t;
-# define PY_SSIZE_T_MAX INT_MAX
-# define PY_SSIZE_T_MIN INT_MIN
-typedef inquiry lenfunc;
-typedef intargfunc ssizeargfunc;
-typedef intobjargproc ssizeobjargproc;
-
-#endif
-
-
-#ifndef PyVarObject_HEAD_INIT
-#define PyVarObject_HEAD_INIT(type, size) \
-        PyObject_HEAD_INIT(type) size,
-#endif
-
-
 #if PY_VERSION_HEX >= 0x03000000
 #if PY_VERSION_HEX >= 0x03050000
 typedef PyAsyncMethods* cmpfunc;
@@ -94,6 +49,7 @@ typedef enum _PyBindGenWrapperFlags {
 #include "tile.h"
 #include "tilelayer.h"
 #include "tileset.h"
+#include "mapreader.h"
 #include <QImage>
 #include <QFileDialog>
 #include <QWidget>
@@ -544,8 +500,8 @@ _wrap_PyQPoint__copy__(PyQPoint *self)
 }
 
 static PyMethodDef PyQPoint_methods[] = {
-    {(char *) "setX", (PyCFunction) _wrap_PyQPoint_setX, METH_KEYWORDS|METH_VARARGS, "setX(x)\n\ntype: x: int" },
-    {(char *) "setY", (PyCFunction) _wrap_PyQPoint_setY, METH_KEYWORDS|METH_VARARGS, "setY(y)\n\ntype: y: int" },
+    {(char *) "setX", (PyCFunction) _wrap_PyQPoint_setX, METH_VARARGS|METH_KEYWORDS, "setX(x)\n\ntype: x: int" },
+    {(char *) "setY", (PyCFunction) _wrap_PyQPoint_setY, METH_VARARGS|METH_KEYWORDS, "setY(y)\n\ntype: y: int" },
     {(char *) "x", (PyCFunction) _wrap_PyQPoint_x, METH_NOARGS, "x()\n\n" },
     {(char *) "y", (PyCFunction) _wrap_PyQPoint_y, METH_NOARGS, "y()\n\n" },
     {(char *) "__copy__", (PyCFunction) _wrap_PyQPoint__copy__, METH_NOARGS, NULL},
@@ -790,8 +746,8 @@ _wrap_PyQPointF__copy__(PyQPointF *self)
 }
 
 static PyMethodDef PyQPointF_methods[] = {
-    {(char *) "setX", (PyCFunction) _wrap_PyQPointF_setX, METH_KEYWORDS|METH_VARARGS, "setX(x)\n\ntype: x: double" },
-    {(char *) "setY", (PyCFunction) _wrap_PyQPointF_setY, METH_KEYWORDS|METH_VARARGS, "setY(y)\n\ntype: y: double" },
+    {(char *) "setX", (PyCFunction) _wrap_PyQPointF_setX, METH_VARARGS|METH_KEYWORDS, "setX(x)\n\ntype: x: double" },
+    {(char *) "setY", (PyCFunction) _wrap_PyQPointF_setY, METH_VARARGS|METH_KEYWORDS, "setY(y)\n\ntype: y: double" },
     {(char *) "x", (PyCFunction) _wrap_PyQPointF_x, METH_NOARGS, "x()\n\n" },
     {(char *) "y", (PyCFunction) _wrap_PyQPointF_y, METH_NOARGS, "y()\n\n" },
     {(char *) "__copy__", (PyCFunction) _wrap_PyQPointF__copy__, METH_NOARGS, NULL},
@@ -1037,8 +993,8 @@ _wrap_PyQSize__copy__(PyQSize *self)
 
 static PyMethodDef PyQSize_methods[] = {
     {(char *) "height", (PyCFunction) _wrap_PyQSize_height, METH_NOARGS, "height()\n\n" },
-    {(char *) "setHeight", (PyCFunction) _wrap_PyQSize_setHeight, METH_KEYWORDS|METH_VARARGS, "setHeight(h)\n\ntype: h: int" },
-    {(char *) "setWidth", (PyCFunction) _wrap_PyQSize_setWidth, METH_KEYWORDS|METH_VARARGS, "setWidth(w)\n\ntype: w: int" },
+    {(char *) "setHeight", (PyCFunction) _wrap_PyQSize_setHeight, METH_VARARGS|METH_KEYWORDS, "setHeight(h)\n\ntype: h: int" },
+    {(char *) "setWidth", (PyCFunction) _wrap_PyQSize_setWidth, METH_VARARGS|METH_KEYWORDS, "setWidth(w)\n\ntype: w: int" },
     {(char *) "width", (PyCFunction) _wrap_PyQSize_width, METH_NOARGS, "width()\n\n" },
     {(char *) "__copy__", (PyCFunction) _wrap_PyQSize__copy__, METH_NOARGS, NULL},
     {NULL, NULL, 0, NULL}
@@ -1283,8 +1239,8 @@ _wrap_PyQSizeF__copy__(PyQSizeF *self)
 
 static PyMethodDef PyQSizeF_methods[] = {
     {(char *) "height", (PyCFunction) _wrap_PyQSizeF_height, METH_NOARGS, "height()\n\n" },
-    {(char *) "setHeight", (PyCFunction) _wrap_PyQSizeF_setHeight, METH_KEYWORDS|METH_VARARGS, "setHeight(h)\n\ntype: h: double" },
-    {(char *) "setWidth", (PyCFunction) _wrap_PyQSizeF_setWidth, METH_KEYWORDS|METH_VARARGS, "setWidth(w)\n\ntype: w: double" },
+    {(char *) "setHeight", (PyCFunction) _wrap_PyQSizeF_setHeight, METH_VARARGS|METH_KEYWORDS, "setHeight(h)\n\ntype: h: double" },
+    {(char *) "setWidth", (PyCFunction) _wrap_PyQSizeF_setWidth, METH_VARARGS|METH_KEYWORDS, "setWidth(w)\n\ntype: w: double" },
     {(char *) "width", (PyCFunction) _wrap_PyQSizeF_width, METH_NOARGS, "width()\n\n" },
     {(char *) "__copy__", (PyCFunction) _wrap_PyQSizeF__copy__, METH_NOARGS, NULL},
     {NULL, NULL, 0, NULL}
@@ -2136,15 +2092,15 @@ _wrap_PyQImage__copy__(PyQImage *self)
 }
 
 static PyMethodDef PyQImage_methods[] = {
-    {(char *) "color", (PyCFunction) _wrap_PyQImage_color, METH_KEYWORDS|METH_VARARGS, "color(i)\n\ntype: i: int" },
+    {(char *) "color", (PyCFunction) _wrap_PyQImage_color, METH_VARARGS|METH_KEYWORDS, "color(i)\n\ntype: i: int" },
     {(char *) "colorTable", (PyCFunction) _wrap_PyQImage_colorTable, METH_NOARGS, "colorTable()\n\n" },
-    {(char *) "fill", (PyCFunction) _wrap_PyQImage_fill, METH_KEYWORDS|METH_VARARGS, "fill(color)\n\ntype: color: int" },
+    {(char *) "fill", (PyCFunction) _wrap_PyQImage_fill, METH_VARARGS|METH_KEYWORDS, "fill(color)\n\ntype: color: int" },
     {(char *) "height", (PyCFunction) _wrap_PyQImage_height, METH_NOARGS, "height()\n\n" },
-    {(char *) "load", (PyCFunction) _wrap_PyQImage_load, METH_KEYWORDS|METH_VARARGS, "load(fileName, fmt)\n\ntype: fileName: QString const\ntype: fmt: char *" },
-    {(char *) "mirrored", (PyCFunction) _wrap_PyQImage_mirrored, METH_KEYWORDS|METH_VARARGS, "mirrored(horiz, vert)\n\ntype: horiz: bool\ntype: vert: bool" },
-    {(char *) "setColor", (PyCFunction) _wrap_PyQImage_setColor, METH_KEYWORDS|METH_VARARGS, "setColor(i, c)\n\ntype: i: int\ntype: c: QRgb" },
-    {(char *) "setColorTable", (PyCFunction) _wrap_PyQImage_setColorTable, METH_KEYWORDS|METH_VARARGS, "setColorTable(colors)\n\ntype: colors: QVector< QRgb >" },
-    {(char *) "setPixel", (PyCFunction) _wrap_PyQImage_setPixel, METH_KEYWORDS|METH_VARARGS, NULL },
+    {(char *) "load", (PyCFunction) _wrap_PyQImage_load, METH_VARARGS|METH_KEYWORDS, "load(fileName, fmt)\n\ntype: fileName: QString const\ntype: fmt: char *" },
+    {(char *) "mirrored", (PyCFunction) _wrap_PyQImage_mirrored, METH_VARARGS|METH_KEYWORDS, "mirrored(horiz, vert)\n\ntype: horiz: bool\ntype: vert: bool" },
+    {(char *) "setColor", (PyCFunction) _wrap_PyQImage_setColor, METH_VARARGS|METH_KEYWORDS, "setColor(i, c)\n\ntype: i: int\ntype: c: QRgb" },
+    {(char *) "setColorTable", (PyCFunction) _wrap_PyQImage_setColorTable, METH_VARARGS|METH_KEYWORDS, "setColorTable(colors)\n\ntype: colors: QVector< QRgb >" },
+    {(char *) "setPixel", (PyCFunction) _wrap_PyQImage_setPixel, METH_VARARGS|METH_KEYWORDS, NULL },
     {(char *) "width", (PyCFunction) _wrap_PyQImage_width, METH_NOARGS, "width()\n\n" },
     {(char *) "__copy__", (PyCFunction) _wrap_PyQImage__copy__, METH_NOARGS, NULL},
     {NULL, NULL, 0, NULL}
@@ -2351,8 +2307,8 @@ _wrap_PyQPixmap__copy__(PyQPixmap *self)
 }
 
 static PyMethodDef PyQPixmap_methods[] = {
-    {(char *) "convertFromImage", (PyCFunction) _wrap_PyQPixmap_convertFromImage, METH_KEYWORDS|METH_VARARGS, "convertFromImage(image)\n\ntype: image: QImage const &" },
-    {(char *) "fromImage", (PyCFunction) _wrap_PyQPixmap_fromImage, METH_KEYWORDS|METH_VARARGS, "fromImage(image)\n\ntype: image: QImage const &" },
+    {(char *) "convertFromImage", (PyCFunction) _wrap_PyQPixmap_convertFromImage, METH_VARARGS|METH_KEYWORDS, "convertFromImage(image)\n\ntype: image: QImage const &" },
+    {(char *) "fromImage", (PyCFunction) _wrap_PyQPixmap_fromImage, METH_VARARGS|METH_KEYWORDS, "fromImage(image)\n\ntype: image: QImage const &" },
     {(char *) "height", (PyCFunction) _wrap_PyQPixmap_height, METH_NOARGS, "height()\n\n" },
     {(char *) "toImage", (PyCFunction) _wrap_PyQPixmap_toImage, METH_NOARGS, "toImage()\n\n" },
     {(char *) "width", (PyCFunction) _wrap_PyQPixmap_width, METH_NOARGS, "width()\n\n" },
@@ -2619,7 +2575,7 @@ _wrap_PyQFileDialog_getOpenFileName(PyQFileDialog *PYBINDGEN_UNUSED(dummy), PyOb
 }
 
 static PyMethodDef PyQFileDialog_methods[] = {
-    {(char *) "getOpenFileName", (PyCFunction) _wrap_PyQFileDialog_getOpenFileName, METH_KEYWORDS|METH_VARARGS|METH_STATIC, "getOpenFileName(parent, caption, dir, filter, selectedFilter, options)\n\ntype: parent: QWidget *\ntype: caption: QString const\ntype: dir: QString const\ntype: filter: QString const\ntype: selectedFilter: QString *\ntype: options: QFlags< QFileDialog::Option >" },
+    {(char *) "getOpenFileName", (PyCFunction) _wrap_PyQFileDialog_getOpenFileName, METH_VARARGS|METH_KEYWORDS|METH_STATIC, "getOpenFileName(parent, caption, dir, filter, selectedFilter, options)\n\ntype: parent: QWidget *\ntype: caption: QString const\ntype: dir: QString const\ntype: filter: QString const\ntype: selectedFilter: QString *\ntype: options: QFlags< QFileDialog::Option >" },
     {NULL, NULL, 0, NULL}
 };
 
@@ -3250,6 +3206,19 @@ static bool loadTilesetFromFile(Tiled::Tileset *ts, const QString &file)
     return ts->loadFromImage(img, file);
 }
 
+
+static bool loadSharedTilesetFromTsx(Tiled::SharedTileset& sts, const QString &file)
+{
+    Tiled::MapReader reader;
+    Tiled::SharedTileset result = reader.readTileset(file);
+    if (result == 0)
+    {
+        return false;
+    }
+    sts = result;
+    return true;
+}
+
 #if PY_VERSION_HEX >= 0x03000000
 static struct PyModuleDef tiled_qt_moduledef = {
     PyModuleDef_HEAD_INIT,
@@ -3636,8 +3605,9 @@ _wrap_PyTiledObject_propertyAsString(PyTiledObject *self, PyObject *args, PyObje
 }
 
 
+
 PyObject *
-_wrap_PyTiledObject_setProperty(PyTiledObject *self, PyObject *args, PyObject *kwargs)
+_wrap_PyTiledObject_setProperty__0(PyTiledObject *self, PyObject *args, PyObject *kwargs, PyObject **return_exception)
 {
     PyObject *py_retval;
     const char *prop;
@@ -3647,6 +3617,12 @@ _wrap_PyTiledObject_setProperty(PyTiledObject *self, PyObject *args, PyObject *k
     const char *keywords[] = {"prop", "val", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "s#s#", (char **) keywords, &prop, &prop_len, &val, &val_len)) {
+        {
+            PyObject *exc_type, *traceback;
+            PyErr_Fetch(&exc_type, return_exception, &traceback);
+            Py_XDECREF(exc_type);
+            Py_XDECREF(traceback);
+        }
         return NULL;
     }
     self->obj->setProperty(QString::fromUtf8(prop), QString::fromUtf8(val));
@@ -3655,10 +3631,58 @@ _wrap_PyTiledObject_setProperty(PyTiledObject *self, PyObject *args, PyObject *k
     return py_retval;
 }
 
+PyObject *
+_wrap_PyTiledObject_setProperty__1(PyTiledObject *self, PyObject *args, PyObject *kwargs, PyObject **return_exception)
+{
+    PyObject *py_retval;
+    const char *prop;
+    Py_ssize_t prop_len;
+    int val;
+    const char *keywords[] = {"prop", "val", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "s#i", (char **) keywords, &prop, &prop_len, &val)) {
+        {
+            PyObject *exc_type, *traceback;
+            PyErr_Fetch(&exc_type, return_exception, &traceback);
+            Py_XDECREF(exc_type);
+            Py_XDECREF(traceback);
+        }
+        return NULL;
+    }
+    self->obj->setProperty(QString::fromUtf8(prop), val);
+    Py_INCREF(Py_None);
+    py_retval = Py_None;
+    return py_retval;
+}
+
+PyObject * _wrap_PyTiledObject_setProperty(PyTiledObject *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject * retval;
+    PyObject *error_list;
+    PyObject *exceptions[2] = {0,};
+    retval = _wrap_PyTiledObject_setProperty__0(self, args, kwargs, &exceptions[0]);
+    if (!exceptions[0]) {
+        return retval;
+    }
+    retval = _wrap_PyTiledObject_setProperty__1(self, args, kwargs, &exceptions[1]);
+    if (!exceptions[1]) {
+        Py_DECREF(exceptions[0]);
+        return retval;
+    }
+    error_list = PyList_New(2);
+    PyList_SET_ITEM(error_list, 0, PyObject_Str(exceptions[0]));
+    Py_DECREF(exceptions[0]);
+    PyList_SET_ITEM(error_list, 1, PyObject_Str(exceptions[1]));
+    Py_DECREF(exceptions[1]);
+    PyErr_SetObject(PyExc_TypeError, error_list);
+    Py_DECREF(error_list);
+    return NULL;
+}
+
 static PyMethodDef PyTiledObject_methods[] = {
     {(char *) "properties", (PyCFunction) _wrap_PyTiledObject_properties, METH_NOARGS, "properties()\n\n" },
-    {(char *) "propertyAsString", (PyCFunction) _wrap_PyTiledObject_propertyAsString, METH_KEYWORDS|METH_VARARGS, "propertyAsString(prop)\n\ntype: prop: QString" },
-    {(char *) "setProperty", (PyCFunction) _wrap_PyTiledObject_setProperty, METH_KEYWORDS|METH_VARARGS, "setProperty(prop, val)\n\ntype: prop: QString\ntype: val: QString" },
+    {(char *) "propertyAsString", (PyCFunction) _wrap_PyTiledObject_propertyAsString, METH_VARARGS|METH_KEYWORDS, "propertyAsString(prop)\n\ntype: prop: QString" },
+    {(char *) "setProperty", (PyCFunction) _wrap_PyTiledObject_setProperty, METH_VARARGS|METH_KEYWORDS, NULL },
     {NULL, NULL, 0, NULL}
 };
 
@@ -3888,7 +3912,7 @@ static PyMethodDef PyTiledTile_methods[] = {
     {(char *) "height", (PyCFunction) _wrap_PyTiledTile_height, METH_NOARGS, "height()\n\n" },
     {(char *) "id", (PyCFunction) _wrap_PyTiledTile_id, METH_NOARGS, "id()\n\n" },
     {(char *) "image", (PyCFunction) _wrap_PyTiledTile_image, METH_NOARGS, "image()\n\n" },
-    {(char *) "setImage", (PyCFunction) _wrap_PyTiledTile_setImage, METH_KEYWORDS|METH_VARARGS, "setImage(image)\n\ntype: image: QPixmap const &" },
+    {(char *) "setImage", (PyCFunction) _wrap_PyTiledTile_setImage, METH_VARARGS|METH_KEYWORDS, "setImage(image)\n\ntype: image: QPixmap const &" },
     {(char *) "size", (PyCFunction) _wrap_PyTiledTile_size, METH_NOARGS, "size()\n\n" },
     {(char *) "tileset", (PyCFunction) _wrap_PyTiledTile_tileset, METH_NOARGS, "tileset()\n\n" },
     {(char *) "width", (PyCFunction) _wrap_PyTiledTile_width, METH_NOARGS, "width()\n\n" },
@@ -4429,27 +4453,27 @@ _wrap_PyTiledTileset_transparentColor(PyTiledTileset *self)
 
 static PyMethodDef PyTiledTileset_methods[] = {
     {(char *) "columnCount", (PyCFunction) _wrap_PyTiledTileset_columnCount, METH_NOARGS, "columnCount()\n\n" },
-    {(char *) "create", (PyCFunction) _wrap_PyTiledTileset_create, METH_KEYWORDS|METH_VARARGS|METH_STATIC, "create(name, tileWidth, tileHeight, tileSpacing, margin)\n\ntype: name: QString\ntype: tileWidth: int\ntype: tileHeight: int\ntype: tileSpacing: int\ntype: margin: int" },
+    {(char *) "create", (PyCFunction) _wrap_PyTiledTileset_create, METH_VARARGS|METH_KEYWORDS|METH_STATIC, "create(name, tileWidth, tileHeight, tileSpacing, margin)\n\ntype: name: QString\ntype: tileWidth: int\ntype: tileHeight: int\ntype: tileSpacing: int\ntype: margin: int" },
     {(char *) "fileName", (PyCFunction) _wrap_PyTiledTileset_fileName, METH_NOARGS, "fileName()\n\n" },
-    {(char *) "findTile", (PyCFunction) _wrap_PyTiledTileset_findTile, METH_KEYWORDS|METH_VARARGS, "findTile(id)\n\ntype: id: int" },
+    {(char *) "findTile", (PyCFunction) _wrap_PyTiledTileset_findTile, METH_VARARGS|METH_KEYWORDS, "findTile(id)\n\ntype: id: int" },
     {(char *) "gridSize", (PyCFunction) _wrap_PyTiledTileset_gridSize, METH_NOARGS, "gridSize()\n\n" },
     {(char *) "imageHeight", (PyCFunction) _wrap_PyTiledTileset_imageHeight, METH_NOARGS, "imageHeight()\n\n" },
     {(char *) "imageSourceString", (PyCFunction) _wrap_PyTiledTileset_imageSourceString, METH_NOARGS, "imageSourceString()\n\n" },
     {(char *) "imageWidth", (PyCFunction) _wrap_PyTiledTileset_imageWidth, METH_NOARGS, "imageWidth()\n\n" },
     {(char *) "isCollection", (PyCFunction) _wrap_PyTiledTileset_isCollection, METH_NOARGS, "isCollection()\n\n" },
     {(char *) "isExternal", (PyCFunction) _wrap_PyTiledTileset_isExternal, METH_NOARGS, "isExternal()\n\n" },
-    {(char *) "loadFromImage", (PyCFunction) _wrap_PyTiledTileset_loadFromImage, METH_KEYWORDS|METH_VARARGS, "loadFromImage(img, file)\n\ntype: img: QImage const &\ntype: file: QString" },
+    {(char *) "loadFromImage", (PyCFunction) _wrap_PyTiledTileset_loadFromImage, METH_VARARGS|METH_KEYWORDS, "loadFromImage(img, file)\n\ntype: img: QImage const &\ntype: file: QString" },
     {(char *) "loadImage", (PyCFunction) _wrap_PyTiledTileset_loadImage, METH_NOARGS, "loadImage()\n\n" },
     {(char *) "margin", (PyCFunction) _wrap_PyTiledTileset_margin, METH_NOARGS, "margin()\n\n" },
     {(char *) "name", (PyCFunction) _wrap_PyTiledTileset_name, METH_NOARGS, "name()\n\n" },
     {(char *) "rowCount", (PyCFunction) _wrap_PyTiledTileset_rowCount, METH_NOARGS, "rowCount()\n\n" },
-    {(char *) "setFileName", (PyCFunction) _wrap_PyTiledTileset_setFileName, METH_KEYWORDS|METH_VARARGS, "setFileName(name)\n\ntype: name: QString" },
-    {(char *) "setGridSize", (PyCFunction) _wrap_PyTiledTileset_setGridSize, METH_KEYWORDS|METH_VARARGS, "setGridSize(gridSize)\n\ntype: gridSize: QSize" },
-    {(char *) "setImageSource", (PyCFunction) _wrap_PyTiledTileset_setImageSource, METH_KEYWORDS|METH_VARARGS, "setImageSource(source)\n\ntype: source: QString" },
-    {(char *) "setName", (PyCFunction) _wrap_PyTiledTileset_setName, METH_KEYWORDS|METH_VARARGS, "setName(name)\n\ntype: name: QString" },
-    {(char *) "setTileOffset", (PyCFunction) _wrap_PyTiledTileset_setTileOffset, METH_KEYWORDS|METH_VARARGS, "setTileOffset(offset)\n\ntype: offset: QPoint" },
-    {(char *) "setTransparentColor", (PyCFunction) _wrap_PyTiledTileset_setTransparentColor, METH_KEYWORDS|METH_VARARGS, "setTransparentColor(col)\n\ntype: col: QColor" },
-    {(char *) "tileAt", (PyCFunction) _wrap_PyTiledTileset_tileAt, METH_KEYWORDS|METH_VARARGS, "tileAt(id)\n\ntype: id: int" },
+    {(char *) "setFileName", (PyCFunction) _wrap_PyTiledTileset_setFileName, METH_VARARGS|METH_KEYWORDS, "setFileName(name)\n\ntype: name: QString" },
+    {(char *) "setGridSize", (PyCFunction) _wrap_PyTiledTileset_setGridSize, METH_VARARGS|METH_KEYWORDS, "setGridSize(gridSize)\n\ntype: gridSize: QSize" },
+    {(char *) "setImageSource", (PyCFunction) _wrap_PyTiledTileset_setImageSource, METH_VARARGS|METH_KEYWORDS, "setImageSource(source)\n\ntype: source: QString" },
+    {(char *) "setName", (PyCFunction) _wrap_PyTiledTileset_setName, METH_VARARGS|METH_KEYWORDS, "setName(name)\n\ntype: name: QString" },
+    {(char *) "setTileOffset", (PyCFunction) _wrap_PyTiledTileset_setTileOffset, METH_VARARGS|METH_KEYWORDS, "setTileOffset(offset)\n\ntype: offset: QPoint" },
+    {(char *) "setTransparentColor", (PyCFunction) _wrap_PyTiledTileset_setTransparentColor, METH_VARARGS|METH_KEYWORDS, "setTransparentColor(col)\n\ntype: col: QColor" },
+    {(char *) "tileAt", (PyCFunction) _wrap_PyTiledTileset_tileAt, METH_VARARGS|METH_KEYWORDS, "tileAt(id)\n\ntype: id: int" },
     {(char *) "tileCount", (PyCFunction) _wrap_PyTiledTileset_tileCount, METH_NOARGS, "tileCount()\n\n" },
     {(char *) "tileHeight", (PyCFunction) _wrap_PyTiledTileset_tileHeight, METH_NOARGS, "tileHeight()\n\n" },
     {(char *) "tileOffset", (PyCFunction) _wrap_PyTiledTileset_tileOffset, METH_NOARGS, "tileOffset()\n\n" },
@@ -5105,13 +5129,13 @@ static PyMethodDef PyTiledLayer_methods[] = {
     {(char *) "map", (PyCFunction) _wrap_PyTiledLayer_map, METH_NOARGS, "map()\n\n" },
     {(char *) "name", (PyCFunction) _wrap_PyTiledLayer_name, METH_NOARGS, "name()\n\n" },
     {(char *) "opacity", (PyCFunction) _wrap_PyTiledLayer_opacity, METH_NOARGS, "opacity()\n\n" },
-    {(char *) "setLocked", (PyCFunction) _wrap_PyTiledLayer_setLocked, METH_KEYWORDS|METH_VARARGS, "setLocked(locked)\n\ntype: locked: bool" },
-    {(char *) "setName", (PyCFunction) _wrap_PyTiledLayer_setName, METH_KEYWORDS|METH_VARARGS, "setName(name)\n\ntype: name: QString" },
-    {(char *) "setOpacity", (PyCFunction) _wrap_PyTiledLayer_setOpacity, METH_KEYWORDS|METH_VARARGS, "setOpacity(opacity)\n\ntype: opacity: double" },
-    {(char *) "setPosition", (PyCFunction) _wrap_PyTiledLayer_setPosition, METH_KEYWORDS|METH_VARARGS, "setPosition(x, y)\n\ntype: x: int\ntype: y: int" },
-    {(char *) "setVisible", (PyCFunction) _wrap_PyTiledLayer_setVisible, METH_KEYWORDS|METH_VARARGS, "setVisible(visible)\n\ntype: visible: bool" },
-    {(char *) "setX", (PyCFunction) _wrap_PyTiledLayer_setX, METH_KEYWORDS|METH_VARARGS, "setX(x)\n\ntype: x: int" },
-    {(char *) "setY", (PyCFunction) _wrap_PyTiledLayer_setY, METH_KEYWORDS|METH_VARARGS, "setY(y)\n\ntype: y: int" },
+    {(char *) "setLocked", (PyCFunction) _wrap_PyTiledLayer_setLocked, METH_VARARGS|METH_KEYWORDS, "setLocked(locked)\n\ntype: locked: bool" },
+    {(char *) "setName", (PyCFunction) _wrap_PyTiledLayer_setName, METH_VARARGS|METH_KEYWORDS, "setName(name)\n\ntype: name: QString" },
+    {(char *) "setOpacity", (PyCFunction) _wrap_PyTiledLayer_setOpacity, METH_VARARGS|METH_KEYWORDS, "setOpacity(opacity)\n\ntype: opacity: double" },
+    {(char *) "setPosition", (PyCFunction) _wrap_PyTiledLayer_setPosition, METH_VARARGS|METH_KEYWORDS, "setPosition(x, y)\n\ntype: x: int\ntype: y: int" },
+    {(char *) "setVisible", (PyCFunction) _wrap_PyTiledLayer_setVisible, METH_VARARGS|METH_KEYWORDS, "setVisible(visible)\n\ntype: visible: bool" },
+    {(char *) "setX", (PyCFunction) _wrap_PyTiledLayer_setX, METH_VARARGS|METH_KEYWORDS, "setX(x)\n\ntype: x: int" },
+    {(char *) "setY", (PyCFunction) _wrap_PyTiledLayer_setY, METH_VARARGS|METH_KEYWORDS, "setY(y)\n\ntype: y: int" },
     {(char *) "x", (PyCFunction) _wrap_PyTiledLayer_x, METH_NOARGS, "x()\n\n" },
     {(char *) "y", (PyCFunction) _wrap_PyTiledLayer_y, METH_NOARGS, "y()\n\n" },
     {NULL, NULL, 0, NULL}
@@ -5974,44 +5998,44 @@ _wrap_PyTiledMap_width(PyTiledMap *self)
 }
 
 static PyMethodDef PyTiledMap_methods[] = {
-    {(char *) "addLayer", (PyCFunction) _wrap_PyTiledMap_addLayer, METH_KEYWORDS|METH_VARARGS, NULL },
-    {(char *) "addTileset", (PyCFunction) _wrap_PyTiledMap_addTileset, METH_KEYWORDS|METH_VARARGS, "addTileset(tileset)\n\ntype: tileset: SharedTileset" },
+    {(char *) "addLayer", (PyCFunction) _wrap_PyTiledMap_addLayer, METH_VARARGS|METH_KEYWORDS, NULL },
+    {(char *) "addTileset", (PyCFunction) _wrap_PyTiledMap_addTileset, METH_VARARGS|METH_KEYWORDS, "addTileset(tileset)\n\ntype: tileset: SharedTileset" },
     {(char *) "backgroundColor", (PyCFunction) _wrap_PyTiledMap_backgroundColor, METH_NOARGS, "backgroundColor()\n\n" },
     {(char *) "groupLayerCount", (PyCFunction) _wrap_PyTiledMap_groupLayerCount, METH_NOARGS, "groupLayerCount()\n\n" },
     {(char *) "height", (PyCFunction) _wrap_PyTiledMap_height, METH_NOARGS, "height()\n\n" },
     {(char *) "hexSideLength", (PyCFunction) _wrap_PyTiledMap_hexSideLength, METH_NOARGS, "hexSideLength()\n\n" },
     {(char *) "imageLayerCount", (PyCFunction) _wrap_PyTiledMap_imageLayerCount, METH_NOARGS, "imageLayerCount()\n\n" },
-    {(char *) "indexOfTileset", (PyCFunction) _wrap_PyTiledMap_indexOfTileset, METH_KEYWORDS|METH_VARARGS, "indexOfTileset(tileset)\n\ntype: tileset: SharedTileset const &" },
+    {(char *) "indexOfTileset", (PyCFunction) _wrap_PyTiledMap_indexOfTileset, METH_VARARGS|METH_KEYWORDS, "indexOfTileset(tileset)\n\ntype: tileset: SharedTileset const &" },
     {(char *) "infinite", (PyCFunction) _wrap_PyTiledMap_infinite, METH_NOARGS, "infinite()\n\n" },
-    {(char *) "insertTileset", (PyCFunction) _wrap_PyTiledMap_insertTileset, METH_KEYWORDS|METH_VARARGS, "insertTileset(pos, tileset)\n\ntype: pos: int\ntype: tileset: SharedTileset" },
-    {(char *) "isTilesetUsed", (PyCFunction) _wrap_PyTiledMap_isTilesetUsed, METH_KEYWORDS|METH_VARARGS, "isTilesetUsed(tileset)\n\ntype: tileset: Tileset const *" },
-    {(char *) "layerAt", (PyCFunction) _wrap_PyTiledMap_layerAt, METH_KEYWORDS|METH_VARARGS, "layerAt(index)\n\ntype: index: int" },
+    {(char *) "insertTileset", (PyCFunction) _wrap_PyTiledMap_insertTileset, METH_VARARGS|METH_KEYWORDS, "insertTileset(pos, tileset)\n\ntype: pos: int\ntype: tileset: SharedTileset" },
+    {(char *) "isTilesetUsed", (PyCFunction) _wrap_PyTiledMap_isTilesetUsed, METH_VARARGS|METH_KEYWORDS, "isTilesetUsed(tileset)\n\ntype: tileset: Tileset const *" },
+    {(char *) "layerAt", (PyCFunction) _wrap_PyTiledMap_layerAt, METH_VARARGS|METH_KEYWORDS, "layerAt(index)\n\ntype: index: int" },
     {(char *) "layerCount", (PyCFunction) _wrap_PyTiledMap_layerCount, METH_NOARGS, "layerCount()\n\n" },
     {(char *) "nextLayerId", (PyCFunction) _wrap_PyTiledMap_nextLayerId, METH_NOARGS, "nextLayerId()\n\n" },
     {(char *) "nextObjectId", (PyCFunction) _wrap_PyTiledMap_nextObjectId, METH_NOARGS, "nextObjectId()\n\n" },
     {(char *) "objectGroupCount", (PyCFunction) _wrap_PyTiledMap_objectGroupCount, METH_NOARGS, "objectGroupCount()\n\n" },
     {(char *) "orientation", (PyCFunction) _wrap_PyTiledMap_orientation, METH_NOARGS, "orientation()\n\n" },
-    {(char *) "removeTilesetAt", (PyCFunction) _wrap_PyTiledMap_removeTilesetAt, METH_KEYWORDS|METH_VARARGS, "removeTilesetAt(pos)\n\ntype: pos: int" },
+    {(char *) "removeTilesetAt", (PyCFunction) _wrap_PyTiledMap_removeTilesetAt, METH_VARARGS|METH_KEYWORDS, "removeTilesetAt(pos)\n\ntype: pos: int" },
     {(char *) "renderOrder", (PyCFunction) _wrap_PyTiledMap_renderOrder, METH_NOARGS, "renderOrder()\n\n" },
-    {(char *) "replaceTileset", (PyCFunction) _wrap_PyTiledMap_replaceTileset, METH_KEYWORDS|METH_VARARGS, "replaceTileset(oldTileset, newTileset)\n\ntype: oldTileset: SharedTileset\ntype: newTileset: SharedTileset" },
-    {(char *) "setBackgroundColor", (PyCFunction) _wrap_PyTiledMap_setBackgroundColor, METH_KEYWORDS|METH_VARARGS, "setBackgroundColor(col)\n\ntype: col: QColor" },
-    {(char *) "setHeight", (PyCFunction) _wrap_PyTiledMap_setHeight, METH_KEYWORDS|METH_VARARGS, "setHeight(h)\n\ntype: h: int" },
-    {(char *) "setHexSideLength", (PyCFunction) _wrap_PyTiledMap_setHexSideLength, METH_KEYWORDS|METH_VARARGS, "setHexSideLength(hexSideLength)\n\ntype: hexSideLength: int" },
-    {(char *) "setInfinite", (PyCFunction) _wrap_PyTiledMap_setInfinite, METH_KEYWORDS|METH_VARARGS, "setInfinite(infinite)\n\ntype: infinite: bool" },
-    {(char *) "setNextLayerId", (PyCFunction) _wrap_PyTiledMap_setNextLayerId, METH_KEYWORDS|METH_VARARGS, "setNextLayerId(nextLayerId)\n\ntype: nextLayerId: int" },
-    {(char *) "setNextObjectId", (PyCFunction) _wrap_PyTiledMap_setNextObjectId, METH_KEYWORDS|METH_VARARGS, "setNextObjectId(nextObjectId)\n\ntype: nextObjectId: int" },
-    {(char *) "setOrientation", (PyCFunction) _wrap_PyTiledMap_setOrientation, METH_KEYWORDS|METH_VARARGS, "setOrientation(orientation)\n\ntype: orientation: Tiled::Map::Orientation" },
-    {(char *) "setRenderOrder", (PyCFunction) _wrap_PyTiledMap_setRenderOrder, METH_KEYWORDS|METH_VARARGS, "setRenderOrder(renderOrder)\n\ntype: renderOrder: Tiled::Map::RenderOrder" },
-    {(char *) "setStaggerAxis", (PyCFunction) _wrap_PyTiledMap_setStaggerAxis, METH_KEYWORDS|METH_VARARGS, "setStaggerAxis(staggerAxis)\n\ntype: staggerAxis: Tiled::Map::StaggerAxis" },
-    {(char *) "setStaggerIndex", (PyCFunction) _wrap_PyTiledMap_setStaggerIndex, METH_KEYWORDS|METH_VARARGS, "setStaggerIndex(staggerIndex)\n\ntype: staggerIndex: Tiled::Map::StaggerIndex" },
-    {(char *) "setWidth", (PyCFunction) _wrap_PyTiledMap_setWidth, METH_KEYWORDS|METH_VARARGS, "setWidth(w)\n\ntype: w: int" },
+    {(char *) "replaceTileset", (PyCFunction) _wrap_PyTiledMap_replaceTileset, METH_VARARGS|METH_KEYWORDS, "replaceTileset(oldTileset, newTileset)\n\ntype: oldTileset: SharedTileset\ntype: newTileset: SharedTileset" },
+    {(char *) "setBackgroundColor", (PyCFunction) _wrap_PyTiledMap_setBackgroundColor, METH_VARARGS|METH_KEYWORDS, "setBackgroundColor(col)\n\ntype: col: QColor" },
+    {(char *) "setHeight", (PyCFunction) _wrap_PyTiledMap_setHeight, METH_VARARGS|METH_KEYWORDS, "setHeight(h)\n\ntype: h: int" },
+    {(char *) "setHexSideLength", (PyCFunction) _wrap_PyTiledMap_setHexSideLength, METH_VARARGS|METH_KEYWORDS, "setHexSideLength(hexSideLength)\n\ntype: hexSideLength: int" },
+    {(char *) "setInfinite", (PyCFunction) _wrap_PyTiledMap_setInfinite, METH_VARARGS|METH_KEYWORDS, "setInfinite(infinite)\n\ntype: infinite: bool" },
+    {(char *) "setNextLayerId", (PyCFunction) _wrap_PyTiledMap_setNextLayerId, METH_VARARGS|METH_KEYWORDS, "setNextLayerId(nextLayerId)\n\ntype: nextLayerId: int" },
+    {(char *) "setNextObjectId", (PyCFunction) _wrap_PyTiledMap_setNextObjectId, METH_VARARGS|METH_KEYWORDS, "setNextObjectId(nextObjectId)\n\ntype: nextObjectId: int" },
+    {(char *) "setOrientation", (PyCFunction) _wrap_PyTiledMap_setOrientation, METH_VARARGS|METH_KEYWORDS, "setOrientation(orientation)\n\ntype: orientation: Tiled::Map::Orientation" },
+    {(char *) "setRenderOrder", (PyCFunction) _wrap_PyTiledMap_setRenderOrder, METH_VARARGS|METH_KEYWORDS, "setRenderOrder(renderOrder)\n\ntype: renderOrder: Tiled::Map::RenderOrder" },
+    {(char *) "setStaggerAxis", (PyCFunction) _wrap_PyTiledMap_setStaggerAxis, METH_VARARGS|METH_KEYWORDS, "setStaggerAxis(staggerAxis)\n\ntype: staggerAxis: Tiled::Map::StaggerAxis" },
+    {(char *) "setStaggerIndex", (PyCFunction) _wrap_PyTiledMap_setStaggerIndex, METH_VARARGS|METH_KEYWORDS, "setStaggerIndex(staggerIndex)\n\ntype: staggerIndex: Tiled::Map::StaggerIndex" },
+    {(char *) "setWidth", (PyCFunction) _wrap_PyTiledMap_setWidth, METH_VARARGS|METH_KEYWORDS, "setWidth(w)\n\ntype: w: int" },
     {(char *) "staggerAxis", (PyCFunction) _wrap_PyTiledMap_staggerAxis, METH_NOARGS, "staggerAxis()\n\n" },
     {(char *) "staggerIndex", (PyCFunction) _wrap_PyTiledMap_staggerIndex, METH_NOARGS, "staggerIndex()\n\n" },
     {(char *) "tileHeight", (PyCFunction) _wrap_PyTiledMap_tileHeight, METH_NOARGS, "tileHeight()\n\n" },
     {(char *) "tileLayerCount", (PyCFunction) _wrap_PyTiledMap_tileLayerCount, METH_NOARGS, "tileLayerCount()\n\n" },
     {(char *) "tileSize", (PyCFunction) _wrap_PyTiledMap_tileSize, METH_NOARGS, "tileSize()\n\n" },
     {(char *) "tileWidth", (PyCFunction) _wrap_PyTiledMap_tileWidth, METH_NOARGS, "tileWidth()\n\n" },
-    {(char *) "tilesetAt", (PyCFunction) _wrap_PyTiledMap_tilesetAt, METH_KEYWORDS|METH_VARARGS, "tilesetAt(index)\n\ntype: index: int" },
+    {(char *) "tilesetAt", (PyCFunction) _wrap_PyTiledMap_tilesetAt, METH_VARARGS|METH_KEYWORDS, "tilesetAt(index)\n\ntype: index: int" },
     {(char *) "tilesetCount", (PyCFunction) _wrap_PyTiledMap_tilesetCount, METH_NOARGS, "tilesetCount()\n\n" },
     {(char *) "width", (PyCFunction) _wrap_PyTiledMap_width, METH_NOARGS, "width()\n\n" },
     {NULL, NULL, 0, NULL}
@@ -6234,9 +6258,23 @@ static int _wrap_PyTiledCell__set_checked(PyTiledCell *self, PyObject *value, vo
 }
 static PyGetSetDef PyTiledCell__getsets[] = {
     {
+        (char*) "flippedHorizontally", /* attribute name */
+        (getter) _wrap_PyTiledCell__get_flippedHorizontally, /* C function to get the attribute */
+        (setter) _wrap_PyTiledCell__set_flippedHorizontally, /* C function to set the attribute */
+        NULL, /* optional doc string */
+        NULL /* optional additional data for getter and setter */
+    },
+    {
         (char*) "flippedVertically", /* attribute name */
         (getter) _wrap_PyTiledCell__get_flippedVertically, /* C function to get the attribute */
         (setter) _wrap_PyTiledCell__set_flippedVertically, /* C function to set the attribute */
+        NULL, /* optional doc string */
+        NULL /* optional additional data for getter and setter */
+    },
+    {
+        (char*) "flippedAntiDiagonally", /* attribute name */
+        (getter) _wrap_PyTiledCell__get_flippedAntiDiagonally, /* C function to get the attribute */
+        (setter) _wrap_PyTiledCell__set_flippedAntiDiagonally, /* C function to set the attribute */
         NULL, /* optional doc string */
         NULL /* optional additional data for getter and setter */
     },
@@ -6251,20 +6289,6 @@ static PyGetSetDef PyTiledCell__getsets[] = {
         (char*) "checked", /* attribute name */
         (getter) _wrap_PyTiledCell__get_checked, /* C function to get the attribute */
         (setter) _wrap_PyTiledCell__set_checked, /* C function to set the attribute */
-        NULL, /* optional doc string */
-        NULL /* optional additional data for getter and setter */
-    },
-    {
-        (char*) "flippedAntiDiagonally", /* attribute name */
-        (getter) _wrap_PyTiledCell__get_flippedAntiDiagonally, /* C function to get the attribute */
-        (setter) _wrap_PyTiledCell__set_flippedAntiDiagonally, /* C function to set the attribute */
-        NULL, /* optional doc string */
-        NULL /* optional additional data for getter and setter */
-    },
-    {
-        (char*) "flippedHorizontally", /* attribute name */
-        (getter) _wrap_PyTiledCell__get_flippedHorizontally, /* C function to get the attribute */
-        (setter) _wrap_PyTiledCell__set_flippedHorizontally, /* C function to set the attribute */
         NULL, /* optional doc string */
         NULL /* optional additional data for getter and setter */
     },
@@ -6423,7 +6447,7 @@ _wrap_PyTiledCell__copy__(PyTiledCell *self)
 
 static PyMethodDef PyTiledCell_methods[] = {
     {(char *) "isEmpty", (PyCFunction) _wrap_PyTiledCell_isEmpty, METH_NOARGS, "isEmpty()\n\n" },
-    {(char *) "setTile", (PyCFunction) _wrap_PyTiledCell_setTile, METH_KEYWORDS|METH_VARARGS, "setTile(tile)\n\ntype: tile: Tiled::Tile *" },
+    {(char *) "setTile", (PyCFunction) _wrap_PyTiledCell_setTile, METH_VARARGS|METH_KEYWORDS, "setTile(tile)\n\ntype: tile: Tiled::Tile *" },
     {(char *) "tile", (PyCFunction) _wrap_PyTiledCell_tile, METH_NOARGS, "tile()\n\n" },
     {(char *) "tileset", (PyCFunction) _wrap_PyTiledCell_tileset, METH_NOARGS, "tileset()\n\n" },
     {(char *) "__copy__", (PyCFunction) _wrap_PyTiledCell__copy__, METH_NOARGS, NULL},
@@ -6656,11 +6680,11 @@ _wrap_PyTiledTileLayer_width(PyTiledTileLayer *self)
 }
 
 static PyMethodDef PyTiledTileLayer_methods[] = {
-    {(char *) "cellAt", (PyCFunction) _wrap_PyTiledTileLayer_cellAt, METH_KEYWORDS|METH_VARARGS, "cellAt(x, y)\n\ntype: x: int\ntype: y: int" },
+    {(char *) "cellAt", (PyCFunction) _wrap_PyTiledTileLayer_cellAt, METH_VARARGS|METH_KEYWORDS, "cellAt(x, y)\n\ntype: x: int\ntype: y: int" },
     {(char *) "height", (PyCFunction) _wrap_PyTiledTileLayer_height, METH_NOARGS, "height()\n\n" },
     {(char *) "isEmpty", (PyCFunction) _wrap_PyTiledTileLayer_isEmpty, METH_NOARGS, "isEmpty()\n\n" },
-    {(char *) "referencesTileset", (PyCFunction) _wrap_PyTiledTileLayer_referencesTileset, METH_KEYWORDS|METH_VARARGS, "referencesTileset(ts)\n\ntype: ts: Tileset *" },
-    {(char *) "setCell", (PyCFunction) _wrap_PyTiledTileLayer_setCell, METH_KEYWORDS|METH_VARARGS, "setCell(x, y, c)\n\ntype: x: int\ntype: y: int\ntype: c: Cell" },
+    {(char *) "referencesTileset", (PyCFunction) _wrap_PyTiledTileLayer_referencesTileset, METH_VARARGS|METH_KEYWORDS, "referencesTileset(ts)\n\ntype: ts: Tileset *" },
+    {(char *) "setCell", (PyCFunction) _wrap_PyTiledTileLayer_setCell, METH_VARARGS|METH_KEYWORDS, "setCell(x, y, c)\n\ntype: x: int\ntype: y: int\ntype: c: Cell" },
     {(char *) "width", (PyCFunction) _wrap_PyTiledTileLayer_width, METH_NOARGS, "width()\n\n" },
     {NULL, NULL, 0, NULL}
 };
@@ -6836,8 +6860,8 @@ _wrap_PyTiledImageLayer_setImage(PyTiledImageLayer *self, PyObject *args, PyObje
 
 static PyMethodDef PyTiledImageLayer_methods[] = {
     {(char *) "image", (PyCFunction) _wrap_PyTiledImageLayer_image, METH_NOARGS, "image()\n\n" },
-    {(char *) "loadFromImage", (PyCFunction) _wrap_PyTiledImageLayer_loadFromImage, METH_KEYWORDS|METH_VARARGS, "loadFromImage(img, file)\n\ntype: img: QImage const &\ntype: file: QString" },
-    {(char *) "setImage", (PyCFunction) _wrap_PyTiledImageLayer_setImage, METH_KEYWORDS|METH_VARARGS, "setImage(image)\n\ntype: image: QPixmap const &" },
+    {(char *) "loadFromImage", (PyCFunction) _wrap_PyTiledImageLayer_loadFromImage, METH_VARARGS|METH_KEYWORDS, "loadFromImage(img, file)\n\ntype: img: QImage const &\ntype: file: QString" },
+    {(char *) "setImage", (PyCFunction) _wrap_PyTiledImageLayer_setImage, METH_VARARGS|METH_KEYWORDS, "setImage(image)\n\ntype: image: QPixmap const &" },
     {NULL, NULL, 0, NULL}
 };
 
@@ -6997,7 +7021,7 @@ _wrap_PyTiledGroupLayer_layerCount(PyTiledGroupLayer *self)
 }
 
 static PyMethodDef PyTiledGroupLayer_methods[] = {
-    {(char *) "layerAt", (PyCFunction) _wrap_PyTiledGroupLayer_layerAt, METH_KEYWORDS|METH_VARARGS, "layerAt(index)\n\ntype: index: int" },
+    {(char *) "layerAt", (PyCFunction) _wrap_PyTiledGroupLayer_layerAt, METH_VARARGS|METH_KEYWORDS, "layerAt(index)\n\ntype: index: int" },
     {(char *) "layerCount", (PyCFunction) _wrap_PyTiledGroupLayer_layerCount, METH_NOARGS, "layerCount()\n\n" },
     {NULL, NULL, 0, NULL}
 };
@@ -7238,12 +7262,12 @@ _wrap_PyTiledObjectGroup_removeObject(PyTiledObjectGroup *self, PyObject *args, 
 }
 
 static PyMethodDef PyTiledObjectGroup_methods[] = {
-    {(char *) "addObject", (PyCFunction) _wrap_PyTiledObjectGroup_addObject, METH_KEYWORDS|METH_VARARGS, "addObject(object)\n\ntype: object: MapObject *" },
-    {(char *) "insertObject", (PyCFunction) _wrap_PyTiledObjectGroup_insertObject, METH_KEYWORDS|METH_VARARGS, "insertObject(index, object)\n\ntype: index: int\ntype: object: MapObject *" },
-    {(char *) "objectAt", (PyCFunction) _wrap_PyTiledObjectGroup_objectAt, METH_KEYWORDS|METH_VARARGS, "objectAt(index)\n\ntype: index: int" },
+    {(char *) "addObject", (PyCFunction) _wrap_PyTiledObjectGroup_addObject, METH_VARARGS|METH_KEYWORDS, "addObject(object)\n\ntype: object: MapObject *" },
+    {(char *) "insertObject", (PyCFunction) _wrap_PyTiledObjectGroup_insertObject, METH_VARARGS|METH_KEYWORDS, "insertObject(index, object)\n\ntype: index: int\ntype: object: MapObject *" },
+    {(char *) "objectAt", (PyCFunction) _wrap_PyTiledObjectGroup_objectAt, METH_VARARGS|METH_KEYWORDS, "objectAt(index)\n\ntype: index: int" },
     {(char *) "objectCount", (PyCFunction) _wrap_PyTiledObjectGroup_objectCount, METH_NOARGS, "objectCount()\n\n" },
-    {(char *) "referencesTileset", (PyCFunction) _wrap_PyTiledObjectGroup_referencesTileset, METH_KEYWORDS|METH_VARARGS, "referencesTileset(ts)\n\ntype: ts: Tileset *" },
-    {(char *) "removeObject", (PyCFunction) _wrap_PyTiledObjectGroup_removeObject, METH_KEYWORDS|METH_VARARGS, "removeObject(object)\n\ntype: object: MapObject *" },
+    {(char *) "referencesTileset", (PyCFunction) _wrap_PyTiledObjectGroup_referencesTileset, METH_VARARGS|METH_KEYWORDS, "referencesTileset(ts)\n\ntype: ts: Tileset *" },
+    {(char *) "removeObject", (PyCFunction) _wrap_PyTiledObjectGroup_removeObject, METH_VARARGS|METH_KEYWORDS, "removeObject(object)\n\ntype: object: MapObject *" },
     {NULL, NULL, 0, NULL}
 };
 
@@ -7775,18 +7799,18 @@ static PyMethodDef PyTiledMapObject_methods[] = {
     {(char *) "name", (PyCFunction) _wrap_PyTiledMapObject_name, METH_NOARGS, "name()\n\n" },
     {(char *) "objectGroup", (PyCFunction) _wrap_PyTiledMapObject_objectGroup, METH_NOARGS, "objectGroup()\n\n" },
     {(char *) "rotation", (PyCFunction) _wrap_PyTiledMapObject_rotation, METH_NOARGS, "rotation()\n\n" },
-    {(char *) "setCell", (PyCFunction) _wrap_PyTiledMapObject_setCell, METH_KEYWORDS|METH_VARARGS, "setCell(c)\n\ntype: c: Tiled::Cell const" },
-    {(char *) "setHeight", (PyCFunction) _wrap_PyTiledMapObject_setHeight, METH_KEYWORDS|METH_VARARGS, "setHeight(h)\n\ntype: h: double" },
-    {(char *) "setName", (PyCFunction) _wrap_PyTiledMapObject_setName, METH_KEYWORDS|METH_VARARGS, "setName(n)\n\ntype: n: QString" },
-    {(char *) "setPosition", (PyCFunction) _wrap_PyTiledMapObject_setPosition, METH_KEYWORDS|METH_VARARGS, "setPosition(pos)\n\ntype: pos: QPointF" },
-    {(char *) "setRotation", (PyCFunction) _wrap_PyTiledMapObject_setRotation, METH_KEYWORDS|METH_VARARGS, "setRotation(r)\n\ntype: r: double" },
-    {(char *) "setShape", (PyCFunction) _wrap_PyTiledMapObject_setShape, METH_KEYWORDS|METH_VARARGS, "setShape(s)\n\ntype: s: Tiled::MapObject::Shape" },
-    {(char *) "setSize", (PyCFunction) _wrap_PyTiledMapObject_setSize, METH_KEYWORDS|METH_VARARGS, "setSize(size)\n\ntype: size: QSizeF" },
-    {(char *) "setType", (PyCFunction) _wrap_PyTiledMapObject_setType, METH_KEYWORDS|METH_VARARGS, "setType(n)\n\ntype: n: QString" },
-    {(char *) "setVisible", (PyCFunction) _wrap_PyTiledMapObject_setVisible, METH_KEYWORDS|METH_VARARGS, "setVisible(v)\n\ntype: v: bool" },
-    {(char *) "setWidth", (PyCFunction) _wrap_PyTiledMapObject_setWidth, METH_KEYWORDS|METH_VARARGS, "setWidth(w)\n\ntype: w: double" },
-    {(char *) "setX", (PyCFunction) _wrap_PyTiledMapObject_setX, METH_KEYWORDS|METH_VARARGS, "setX(x)\n\ntype: x: double" },
-    {(char *) "setY", (PyCFunction) _wrap_PyTiledMapObject_setY, METH_KEYWORDS|METH_VARARGS, "setY(y)\n\ntype: y: double" },
+    {(char *) "setCell", (PyCFunction) _wrap_PyTiledMapObject_setCell, METH_VARARGS|METH_KEYWORDS, "setCell(c)\n\ntype: c: Tiled::Cell const" },
+    {(char *) "setHeight", (PyCFunction) _wrap_PyTiledMapObject_setHeight, METH_VARARGS|METH_KEYWORDS, "setHeight(h)\n\ntype: h: double" },
+    {(char *) "setName", (PyCFunction) _wrap_PyTiledMapObject_setName, METH_VARARGS|METH_KEYWORDS, "setName(n)\n\ntype: n: QString" },
+    {(char *) "setPosition", (PyCFunction) _wrap_PyTiledMapObject_setPosition, METH_VARARGS|METH_KEYWORDS, "setPosition(pos)\n\ntype: pos: QPointF" },
+    {(char *) "setRotation", (PyCFunction) _wrap_PyTiledMapObject_setRotation, METH_VARARGS|METH_KEYWORDS, "setRotation(r)\n\ntype: r: double" },
+    {(char *) "setShape", (PyCFunction) _wrap_PyTiledMapObject_setShape, METH_VARARGS|METH_KEYWORDS, "setShape(s)\n\ntype: s: Tiled::MapObject::Shape" },
+    {(char *) "setSize", (PyCFunction) _wrap_PyTiledMapObject_setSize, METH_VARARGS|METH_KEYWORDS, "setSize(size)\n\ntype: size: QSizeF" },
+    {(char *) "setType", (PyCFunction) _wrap_PyTiledMapObject_setType, METH_VARARGS|METH_KEYWORDS, "setType(n)\n\ntype: n: QString" },
+    {(char *) "setVisible", (PyCFunction) _wrap_PyTiledMapObject_setVisible, METH_VARARGS|METH_KEYWORDS, "setVisible(v)\n\ntype: v: bool" },
+    {(char *) "setWidth", (PyCFunction) _wrap_PyTiledMapObject_setWidth, METH_VARARGS|METH_KEYWORDS, "setWidth(w)\n\ntype: w: double" },
+    {(char *) "setX", (PyCFunction) _wrap_PyTiledMapObject_setX, METH_VARARGS|METH_KEYWORDS, "setX(x)\n\ntype: x: double" },
+    {(char *) "setY", (PyCFunction) _wrap_PyTiledMapObject_setY, METH_VARARGS|METH_KEYWORDS, "setY(y)\n\ntype: y: double" },
     {(char *) "shape", (PyCFunction) _wrap_PyTiledMapObject_shape, METH_NOARGS, "shape()\n\n" },
     {(char *) "type", (PyCFunction) _wrap_PyTiledMapObject_type, METH_NOARGS, "type()\n\n" },
     {(char *) "width", (PyCFunction) _wrap_PyTiledMapObject_width, METH_NOARGS, "width()\n\n" },
@@ -7923,7 +7947,7 @@ _wrap_PyTiledLoggingInterface_log(PyTiledLoggingInterface *self, PyObject *args,
 }
 
 static PyMethodDef PyTiledLoggingInterface_methods[] = {
-    {(char *) "log", (PyCFunction) _wrap_PyTiledLoggingInterface_log, METH_KEYWORDS|METH_VARARGS, "log(type, msg)\n\ntype: type: Tiled::LoggingInterface::OutputType\ntype: msg: QString const" },
+    {(char *) "log", (PyCFunction) _wrap_PyTiledLoggingInterface_log, METH_VARARGS|METH_KEYWORDS, "log(type, msg)\n\ntype: type: Tiled::LoggingInterface::OutputType\ntype: msg: QString const" },
     {NULL, NULL, 0, NULL}
 };
 
@@ -8351,6 +8375,26 @@ PyObject * _wrap_tiled_isTileLayerAt(PyObject * PYBINDGEN_UNUSED(dummy), PyObjec
 
 
 PyObject *
+_wrap_tiled_loadSharedTilesetFromTsx(PyObject * PYBINDGEN_UNUSED(dummy), PyObject *args, PyObject *kwargs)
+{
+    PyObject *py_retval;
+    bool retval;
+    PyTiledSharedTileset *sts;
+    const char *file;
+    Py_ssize_t file_len;
+    const char *keywords[] = {"sts", "file", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!s#", (char **) keywords, &PyTiledSharedTileset_Type, &sts, &file, &file_len)) {
+        return NULL;
+    }
+    retval = loadSharedTilesetFromTsx(*((PyTiledSharedTileset *) sts)->obj, QString::fromUtf8(file));
+    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
+    return py_retval;
+}
+PyObject * _wrap_tiled_loadSharedTilesetFromTsx(PyObject * PYBINDGEN_UNUSED(dummy), PyObject *args, PyObject *kwargs);
+
+
+PyObject *
 _wrap_tiled_loadTilesetFromFile(PyObject * PYBINDGEN_UNUSED(dummy), PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
@@ -8430,13 +8474,14 @@ _wrap_tiled_tileLayerAt(PyObject * PYBINDGEN_UNUSED(dummy), PyObject *args, PyOb
 PyObject * _wrap_tiled_tileLayerAt(PyObject * PYBINDGEN_UNUSED(dummy), PyObject *args, PyObject *kwargs);
 
 static PyMethodDef tiled_functions[] = {
-    {(char *) "imageLayerAt", (PyCFunction) _wrap_tiled_imageLayerAt, METH_KEYWORDS|METH_VARARGS, "imageLayerAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
-    {(char *) "isImageLayerAt", (PyCFunction) _wrap_tiled_isImageLayerAt, METH_KEYWORDS|METH_VARARGS, "isImageLayerAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
-    {(char *) "isObjectGroupAt", (PyCFunction) _wrap_tiled_isObjectGroupAt, METH_KEYWORDS|METH_VARARGS, "isObjectGroupAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
-    {(char *) "isTileLayerAt", (PyCFunction) _wrap_tiled_isTileLayerAt, METH_KEYWORDS|METH_VARARGS, "isTileLayerAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
-    {(char *) "loadTilesetFromFile", (PyCFunction) _wrap_tiled_loadTilesetFromFile, METH_KEYWORDS|METH_VARARGS, "loadTilesetFromFile(ts, file)\n\ntype: ts: Tileset *\ntype: file: QString" },
-    {(char *) "objectGroupAt", (PyCFunction) _wrap_tiled_objectGroupAt, METH_KEYWORDS|METH_VARARGS, "objectGroupAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
-    {(char *) "tileLayerAt", (PyCFunction) _wrap_tiled_tileLayerAt, METH_KEYWORDS|METH_VARARGS, "tileLayerAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
+    {(char *) "imageLayerAt", (PyCFunction) _wrap_tiled_imageLayerAt, METH_VARARGS|METH_KEYWORDS, "imageLayerAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
+    {(char *) "isImageLayerAt", (PyCFunction) _wrap_tiled_isImageLayerAt, METH_VARARGS|METH_KEYWORDS, "isImageLayerAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
+    {(char *) "isObjectGroupAt", (PyCFunction) _wrap_tiled_isObjectGroupAt, METH_VARARGS|METH_KEYWORDS, "isObjectGroupAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
+    {(char *) "isTileLayerAt", (PyCFunction) _wrap_tiled_isTileLayerAt, METH_VARARGS|METH_KEYWORDS, "isTileLayerAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
+    {(char *) "loadSharedTilesetFromTsx", (PyCFunction) _wrap_tiled_loadSharedTilesetFromTsx, METH_VARARGS|METH_KEYWORDS, "loadSharedTilesetFromTsx(sts, file)\n\ntype: sts: Tiled::SharedTileset &\ntype: file: QString" },
+    {(char *) "loadTilesetFromFile", (PyCFunction) _wrap_tiled_loadTilesetFromFile, METH_VARARGS|METH_KEYWORDS, "loadTilesetFromFile(ts, file)\n\ntype: ts: Tileset *\ntype: file: QString" },
+    {(char *) "objectGroupAt", (PyCFunction) _wrap_tiled_objectGroupAt, METH_VARARGS|METH_KEYWORDS, "objectGroupAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
+    {(char *) "tileLayerAt", (PyCFunction) _wrap_tiled_tileLayerAt, METH_VARARGS|METH_KEYWORDS, "tileLayerAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
     {NULL, NULL, 0, NULL}
 };
 /* --- classes --- */
@@ -8540,7 +8585,7 @@ PyTypeObject PyPythonPythonScript_Type = {
     (getattrofunc)NULL,     /* tp_getattro */
     (setattrofunc)NULL,     /* tp_setattro */
     (PyBufferProcs*)NULL,  /* tp_as_buffer */
-    Py_TPFLAGS_BASETYPE|Py_TPFLAGS_DEFAULT|Py_TPFLAGS_HAVE_GC,                      /* tp_flags */
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_HAVE_GC|Py_TPFLAGS_BASETYPE,                      /* tp_flags */
     "",                        /* Documentation string */
     (traverseproc)PyPythonPythonScript__tp_traverse,     /* tp_traverse */
     (inquiry)PyPythonPythonScript__tp_clear,             /* tp_clear */

--- a/src/plugins/python/pythonbind.cpp
+++ b/src/plugins/python/pythonbind.cpp
@@ -500,8 +500,8 @@ _wrap_PyQPoint__copy__(PyQPoint *self)
 }
 
 static PyMethodDef PyQPoint_methods[] = {
-    {(char *) "setX", (PyCFunction) _wrap_PyQPoint_setX, METH_VARARGS|METH_KEYWORDS, "setX(x)\n\ntype: x: int" },
-    {(char *) "setY", (PyCFunction) _wrap_PyQPoint_setY, METH_VARARGS|METH_KEYWORDS, "setY(y)\n\ntype: y: int" },
+    {(char *) "setX", (PyCFunction) _wrap_PyQPoint_setX, METH_KEYWORDS|METH_VARARGS, "setX(x)\n\ntype: x: int" },
+    {(char *) "setY", (PyCFunction) _wrap_PyQPoint_setY, METH_KEYWORDS|METH_VARARGS, "setY(y)\n\ntype: y: int" },
     {(char *) "x", (PyCFunction) _wrap_PyQPoint_x, METH_NOARGS, "x()\n\n" },
     {(char *) "y", (PyCFunction) _wrap_PyQPoint_y, METH_NOARGS, "y()\n\n" },
     {(char *) "__copy__", (PyCFunction) _wrap_PyQPoint__copy__, METH_NOARGS, NULL},
@@ -746,8 +746,8 @@ _wrap_PyQPointF__copy__(PyQPointF *self)
 }
 
 static PyMethodDef PyQPointF_methods[] = {
-    {(char *) "setX", (PyCFunction) _wrap_PyQPointF_setX, METH_VARARGS|METH_KEYWORDS, "setX(x)\n\ntype: x: double" },
-    {(char *) "setY", (PyCFunction) _wrap_PyQPointF_setY, METH_VARARGS|METH_KEYWORDS, "setY(y)\n\ntype: y: double" },
+    {(char *) "setX", (PyCFunction) _wrap_PyQPointF_setX, METH_KEYWORDS|METH_VARARGS, "setX(x)\n\ntype: x: double" },
+    {(char *) "setY", (PyCFunction) _wrap_PyQPointF_setY, METH_KEYWORDS|METH_VARARGS, "setY(y)\n\ntype: y: double" },
     {(char *) "x", (PyCFunction) _wrap_PyQPointF_x, METH_NOARGS, "x()\n\n" },
     {(char *) "y", (PyCFunction) _wrap_PyQPointF_y, METH_NOARGS, "y()\n\n" },
     {(char *) "__copy__", (PyCFunction) _wrap_PyQPointF__copy__, METH_NOARGS, NULL},
@@ -993,8 +993,8 @@ _wrap_PyQSize__copy__(PyQSize *self)
 
 static PyMethodDef PyQSize_methods[] = {
     {(char *) "height", (PyCFunction) _wrap_PyQSize_height, METH_NOARGS, "height()\n\n" },
-    {(char *) "setHeight", (PyCFunction) _wrap_PyQSize_setHeight, METH_VARARGS|METH_KEYWORDS, "setHeight(h)\n\ntype: h: int" },
-    {(char *) "setWidth", (PyCFunction) _wrap_PyQSize_setWidth, METH_VARARGS|METH_KEYWORDS, "setWidth(w)\n\ntype: w: int" },
+    {(char *) "setHeight", (PyCFunction) _wrap_PyQSize_setHeight, METH_KEYWORDS|METH_VARARGS, "setHeight(h)\n\ntype: h: int" },
+    {(char *) "setWidth", (PyCFunction) _wrap_PyQSize_setWidth, METH_KEYWORDS|METH_VARARGS, "setWidth(w)\n\ntype: w: int" },
     {(char *) "width", (PyCFunction) _wrap_PyQSize_width, METH_NOARGS, "width()\n\n" },
     {(char *) "__copy__", (PyCFunction) _wrap_PyQSize__copy__, METH_NOARGS, NULL},
     {NULL, NULL, 0, NULL}
@@ -1239,8 +1239,8 @@ _wrap_PyQSizeF__copy__(PyQSizeF *self)
 
 static PyMethodDef PyQSizeF_methods[] = {
     {(char *) "height", (PyCFunction) _wrap_PyQSizeF_height, METH_NOARGS, "height()\n\n" },
-    {(char *) "setHeight", (PyCFunction) _wrap_PyQSizeF_setHeight, METH_VARARGS|METH_KEYWORDS, "setHeight(h)\n\ntype: h: double" },
-    {(char *) "setWidth", (PyCFunction) _wrap_PyQSizeF_setWidth, METH_VARARGS|METH_KEYWORDS, "setWidth(w)\n\ntype: w: double" },
+    {(char *) "setHeight", (PyCFunction) _wrap_PyQSizeF_setHeight, METH_KEYWORDS|METH_VARARGS, "setHeight(h)\n\ntype: h: double" },
+    {(char *) "setWidth", (PyCFunction) _wrap_PyQSizeF_setWidth, METH_KEYWORDS|METH_VARARGS, "setWidth(w)\n\ntype: w: double" },
     {(char *) "width", (PyCFunction) _wrap_PyQSizeF_width, METH_NOARGS, "width()\n\n" },
     {(char *) "__copy__", (PyCFunction) _wrap_PyQSizeF__copy__, METH_NOARGS, NULL},
     {NULL, NULL, 0, NULL}
@@ -2092,15 +2092,15 @@ _wrap_PyQImage__copy__(PyQImage *self)
 }
 
 static PyMethodDef PyQImage_methods[] = {
-    {(char *) "color", (PyCFunction) _wrap_PyQImage_color, METH_VARARGS|METH_KEYWORDS, "color(i)\n\ntype: i: int" },
+    {(char *) "color", (PyCFunction) _wrap_PyQImage_color, METH_KEYWORDS|METH_VARARGS, "color(i)\n\ntype: i: int" },
     {(char *) "colorTable", (PyCFunction) _wrap_PyQImage_colorTable, METH_NOARGS, "colorTable()\n\n" },
-    {(char *) "fill", (PyCFunction) _wrap_PyQImage_fill, METH_VARARGS|METH_KEYWORDS, "fill(color)\n\ntype: color: int" },
+    {(char *) "fill", (PyCFunction) _wrap_PyQImage_fill, METH_KEYWORDS|METH_VARARGS, "fill(color)\n\ntype: color: int" },
     {(char *) "height", (PyCFunction) _wrap_PyQImage_height, METH_NOARGS, "height()\n\n" },
-    {(char *) "load", (PyCFunction) _wrap_PyQImage_load, METH_VARARGS|METH_KEYWORDS, "load(fileName, fmt)\n\ntype: fileName: QString const\ntype: fmt: char *" },
-    {(char *) "mirrored", (PyCFunction) _wrap_PyQImage_mirrored, METH_VARARGS|METH_KEYWORDS, "mirrored(horiz, vert)\n\ntype: horiz: bool\ntype: vert: bool" },
-    {(char *) "setColor", (PyCFunction) _wrap_PyQImage_setColor, METH_VARARGS|METH_KEYWORDS, "setColor(i, c)\n\ntype: i: int\ntype: c: QRgb" },
-    {(char *) "setColorTable", (PyCFunction) _wrap_PyQImage_setColorTable, METH_VARARGS|METH_KEYWORDS, "setColorTable(colors)\n\ntype: colors: QVector< QRgb >" },
-    {(char *) "setPixel", (PyCFunction) _wrap_PyQImage_setPixel, METH_VARARGS|METH_KEYWORDS, NULL },
+    {(char *) "load", (PyCFunction) _wrap_PyQImage_load, METH_KEYWORDS|METH_VARARGS, "load(fileName, fmt)\n\ntype: fileName: QString const\ntype: fmt: char *" },
+    {(char *) "mirrored", (PyCFunction) _wrap_PyQImage_mirrored, METH_KEYWORDS|METH_VARARGS, "mirrored(horiz, vert)\n\ntype: horiz: bool\ntype: vert: bool" },
+    {(char *) "setColor", (PyCFunction) _wrap_PyQImage_setColor, METH_KEYWORDS|METH_VARARGS, "setColor(i, c)\n\ntype: i: int\ntype: c: QRgb" },
+    {(char *) "setColorTable", (PyCFunction) _wrap_PyQImage_setColorTable, METH_KEYWORDS|METH_VARARGS, "setColorTable(colors)\n\ntype: colors: QVector< QRgb >" },
+    {(char *) "setPixel", (PyCFunction) _wrap_PyQImage_setPixel, METH_KEYWORDS|METH_VARARGS, NULL },
     {(char *) "width", (PyCFunction) _wrap_PyQImage_width, METH_NOARGS, "width()\n\n" },
     {(char *) "__copy__", (PyCFunction) _wrap_PyQImage__copy__, METH_NOARGS, NULL},
     {NULL, NULL, 0, NULL}
@@ -2307,8 +2307,8 @@ _wrap_PyQPixmap__copy__(PyQPixmap *self)
 }
 
 static PyMethodDef PyQPixmap_methods[] = {
-    {(char *) "convertFromImage", (PyCFunction) _wrap_PyQPixmap_convertFromImage, METH_VARARGS|METH_KEYWORDS, "convertFromImage(image)\n\ntype: image: QImage const &" },
-    {(char *) "fromImage", (PyCFunction) _wrap_PyQPixmap_fromImage, METH_VARARGS|METH_KEYWORDS, "fromImage(image)\n\ntype: image: QImage const &" },
+    {(char *) "convertFromImage", (PyCFunction) _wrap_PyQPixmap_convertFromImage, METH_KEYWORDS|METH_VARARGS, "convertFromImage(image)\n\ntype: image: QImage const &" },
+    {(char *) "fromImage", (PyCFunction) _wrap_PyQPixmap_fromImage, METH_KEYWORDS|METH_VARARGS, "fromImage(image)\n\ntype: image: QImage const &" },
     {(char *) "height", (PyCFunction) _wrap_PyQPixmap_height, METH_NOARGS, "height()\n\n" },
     {(char *) "toImage", (PyCFunction) _wrap_PyQPixmap_toImage, METH_NOARGS, "toImage()\n\n" },
     {(char *) "width", (PyCFunction) _wrap_PyQPixmap_width, METH_NOARGS, "width()\n\n" },
@@ -2575,7 +2575,7 @@ _wrap_PyQFileDialog_getOpenFileName(PyQFileDialog *PYBINDGEN_UNUSED(dummy), PyOb
 }
 
 static PyMethodDef PyQFileDialog_methods[] = {
-    {(char *) "getOpenFileName", (PyCFunction) _wrap_PyQFileDialog_getOpenFileName, METH_VARARGS|METH_KEYWORDS|METH_STATIC, "getOpenFileName(parent, caption, dir, filter, selectedFilter, options)\n\ntype: parent: QWidget *\ntype: caption: QString const\ntype: dir: QString const\ntype: filter: QString const\ntype: selectedFilter: QString *\ntype: options: QFlags< QFileDialog::Option >" },
+    {(char *) "getOpenFileName", (PyCFunction) _wrap_PyQFileDialog_getOpenFileName, METH_KEYWORDS|METH_VARARGS|METH_STATIC, "getOpenFileName(parent, caption, dir, filter, selectedFilter, options)\n\ntype: parent: QWidget *\ntype: caption: QString const\ntype: dir: QString const\ntype: filter: QString const\ntype: selectedFilter: QString *\ntype: options: QFlags< QFileDialog::Option >" },
     {NULL, NULL, 0, NULL}
 };
 
@@ -3207,15 +3207,9 @@ static bool loadTilesetFromFile(Tiled::Tileset *ts, const QString &file)
 }
 
 
-static bool loadTileset(Tiled::SharedTileset& sts, const QString &file)
+static Tiled::SharedTileset loadTileset(const QString &file)
 {
-    auto result = Tiled::TilesetManager::instance()->loadTileset(file);
-    if (!result || result->status() == Tiled::LoadingStatus::LoadingError)
-    {
-        return false;
-    }
-    sts = result;
-    return true;
+    return Tiled::TilesetManager::instance()->loadTileset(file);
 }
 
 #if PY_VERSION_HEX >= 0x03000000
@@ -3714,8 +3708,8 @@ PyObject * _wrap_PyTiledObject_setProperty(PyTiledObject *self, PyObject *args, 
 
 static PyMethodDef PyTiledObject_methods[] = {
     {(char *) "properties", (PyCFunction) _wrap_PyTiledObject_properties, METH_NOARGS, "properties()\n\n" },
-    {(char *) "propertyAsString", (PyCFunction) _wrap_PyTiledObject_propertyAsString, METH_VARARGS|METH_KEYWORDS, "propertyAsString(prop)\n\ntype: prop: QString" },
-    {(char *) "setProperty", (PyCFunction) _wrap_PyTiledObject_setProperty, METH_VARARGS|METH_KEYWORDS, NULL },
+    {(char *) "propertyAsString", (PyCFunction) _wrap_PyTiledObject_propertyAsString, METH_KEYWORDS|METH_VARARGS, "propertyAsString(prop)\n\ntype: prop: QString" },
+    {(char *) "setProperty", (PyCFunction) _wrap_PyTiledObject_setProperty, METH_KEYWORDS|METH_VARARGS, NULL },
     {NULL, NULL, 0, NULL}
 };
 
@@ -3945,7 +3939,7 @@ static PyMethodDef PyTiledTile_methods[] = {
     {(char *) "height", (PyCFunction) _wrap_PyTiledTile_height, METH_NOARGS, "height()\n\n" },
     {(char *) "id", (PyCFunction) _wrap_PyTiledTile_id, METH_NOARGS, "id()\n\n" },
     {(char *) "image", (PyCFunction) _wrap_PyTiledTile_image, METH_NOARGS, "image()\n\n" },
-    {(char *) "setImage", (PyCFunction) _wrap_PyTiledTile_setImage, METH_VARARGS|METH_KEYWORDS, "setImage(image)\n\ntype: image: QPixmap const &" },
+    {(char *) "setImage", (PyCFunction) _wrap_PyTiledTile_setImage, METH_KEYWORDS|METH_VARARGS, "setImage(image)\n\ntype: image: QPixmap const &" },
     {(char *) "size", (PyCFunction) _wrap_PyTiledTile_size, METH_NOARGS, "size()\n\n" },
     {(char *) "tileset", (PyCFunction) _wrap_PyTiledTile_tileset, METH_NOARGS, "tileset()\n\n" },
     {(char *) "width", (PyCFunction) _wrap_PyTiledTile_width, METH_NOARGS, "width()\n\n" },
@@ -4486,27 +4480,27 @@ _wrap_PyTiledTileset_transparentColor(PyTiledTileset *self)
 
 static PyMethodDef PyTiledTileset_methods[] = {
     {(char *) "columnCount", (PyCFunction) _wrap_PyTiledTileset_columnCount, METH_NOARGS, "columnCount()\n\n" },
-    {(char *) "create", (PyCFunction) _wrap_PyTiledTileset_create, METH_VARARGS|METH_KEYWORDS|METH_STATIC, "create(name, tileWidth, tileHeight, tileSpacing, margin)\n\ntype: name: QString\ntype: tileWidth: int\ntype: tileHeight: int\ntype: tileSpacing: int\ntype: margin: int" },
+    {(char *) "create", (PyCFunction) _wrap_PyTiledTileset_create, METH_KEYWORDS|METH_VARARGS|METH_STATIC, "create(name, tileWidth, tileHeight, tileSpacing, margin)\n\ntype: name: QString\ntype: tileWidth: int\ntype: tileHeight: int\ntype: tileSpacing: int\ntype: margin: int" },
     {(char *) "fileName", (PyCFunction) _wrap_PyTiledTileset_fileName, METH_NOARGS, "fileName()\n\n" },
-    {(char *) "findTile", (PyCFunction) _wrap_PyTiledTileset_findTile, METH_VARARGS|METH_KEYWORDS, "findTile(id)\n\ntype: id: int" },
+    {(char *) "findTile", (PyCFunction) _wrap_PyTiledTileset_findTile, METH_KEYWORDS|METH_VARARGS, "findTile(id)\n\ntype: id: int" },
     {(char *) "gridSize", (PyCFunction) _wrap_PyTiledTileset_gridSize, METH_NOARGS, "gridSize()\n\n" },
     {(char *) "imageHeight", (PyCFunction) _wrap_PyTiledTileset_imageHeight, METH_NOARGS, "imageHeight()\n\n" },
     {(char *) "imageSourceString", (PyCFunction) _wrap_PyTiledTileset_imageSourceString, METH_NOARGS, "imageSourceString()\n\n" },
     {(char *) "imageWidth", (PyCFunction) _wrap_PyTiledTileset_imageWidth, METH_NOARGS, "imageWidth()\n\n" },
     {(char *) "isCollection", (PyCFunction) _wrap_PyTiledTileset_isCollection, METH_NOARGS, "isCollection()\n\n" },
     {(char *) "isExternal", (PyCFunction) _wrap_PyTiledTileset_isExternal, METH_NOARGS, "isExternal()\n\n" },
-    {(char *) "loadFromImage", (PyCFunction) _wrap_PyTiledTileset_loadFromImage, METH_VARARGS|METH_KEYWORDS, "loadFromImage(img, file)\n\ntype: img: QImage const &\ntype: file: QString" },
+    {(char *) "loadFromImage", (PyCFunction) _wrap_PyTiledTileset_loadFromImage, METH_KEYWORDS|METH_VARARGS, "loadFromImage(img, file)\n\ntype: img: QImage const &\ntype: file: QString" },
     {(char *) "loadImage", (PyCFunction) _wrap_PyTiledTileset_loadImage, METH_NOARGS, "loadImage()\n\n" },
     {(char *) "margin", (PyCFunction) _wrap_PyTiledTileset_margin, METH_NOARGS, "margin()\n\n" },
     {(char *) "name", (PyCFunction) _wrap_PyTiledTileset_name, METH_NOARGS, "name()\n\n" },
     {(char *) "rowCount", (PyCFunction) _wrap_PyTiledTileset_rowCount, METH_NOARGS, "rowCount()\n\n" },
-    {(char *) "setFileName", (PyCFunction) _wrap_PyTiledTileset_setFileName, METH_VARARGS|METH_KEYWORDS, "setFileName(name)\n\ntype: name: QString" },
-    {(char *) "setGridSize", (PyCFunction) _wrap_PyTiledTileset_setGridSize, METH_VARARGS|METH_KEYWORDS, "setGridSize(gridSize)\n\ntype: gridSize: QSize" },
-    {(char *) "setImageSource", (PyCFunction) _wrap_PyTiledTileset_setImageSource, METH_VARARGS|METH_KEYWORDS, "setImageSource(source)\n\ntype: source: QString" },
-    {(char *) "setName", (PyCFunction) _wrap_PyTiledTileset_setName, METH_VARARGS|METH_KEYWORDS, "setName(name)\n\ntype: name: QString" },
-    {(char *) "setTileOffset", (PyCFunction) _wrap_PyTiledTileset_setTileOffset, METH_VARARGS|METH_KEYWORDS, "setTileOffset(offset)\n\ntype: offset: QPoint" },
-    {(char *) "setTransparentColor", (PyCFunction) _wrap_PyTiledTileset_setTransparentColor, METH_VARARGS|METH_KEYWORDS, "setTransparentColor(col)\n\ntype: col: QColor" },
-    {(char *) "tileAt", (PyCFunction) _wrap_PyTiledTileset_tileAt, METH_VARARGS|METH_KEYWORDS, "tileAt(id)\n\ntype: id: int" },
+    {(char *) "setFileName", (PyCFunction) _wrap_PyTiledTileset_setFileName, METH_KEYWORDS|METH_VARARGS, "setFileName(name)\n\ntype: name: QString" },
+    {(char *) "setGridSize", (PyCFunction) _wrap_PyTiledTileset_setGridSize, METH_KEYWORDS|METH_VARARGS, "setGridSize(gridSize)\n\ntype: gridSize: QSize" },
+    {(char *) "setImageSource", (PyCFunction) _wrap_PyTiledTileset_setImageSource, METH_KEYWORDS|METH_VARARGS, "setImageSource(source)\n\ntype: source: QString" },
+    {(char *) "setName", (PyCFunction) _wrap_PyTiledTileset_setName, METH_KEYWORDS|METH_VARARGS, "setName(name)\n\ntype: name: QString" },
+    {(char *) "setTileOffset", (PyCFunction) _wrap_PyTiledTileset_setTileOffset, METH_KEYWORDS|METH_VARARGS, "setTileOffset(offset)\n\ntype: offset: QPoint" },
+    {(char *) "setTransparentColor", (PyCFunction) _wrap_PyTiledTileset_setTransparentColor, METH_KEYWORDS|METH_VARARGS, "setTransparentColor(col)\n\ntype: col: QColor" },
+    {(char *) "tileAt", (PyCFunction) _wrap_PyTiledTileset_tileAt, METH_KEYWORDS|METH_VARARGS, "tileAt(id)\n\ntype: id: int" },
     {(char *) "tileCount", (PyCFunction) _wrap_PyTiledTileset_tileCount, METH_NOARGS, "tileCount()\n\n" },
     {(char *) "tileHeight", (PyCFunction) _wrap_PyTiledTileset_tileHeight, METH_NOARGS, "tileHeight()\n\n" },
     {(char *) "tileOffset", (PyCFunction) _wrap_PyTiledTileset_tileOffset, METH_NOARGS, "tileOffset()\n\n" },
@@ -5162,13 +5156,13 @@ static PyMethodDef PyTiledLayer_methods[] = {
     {(char *) "map", (PyCFunction) _wrap_PyTiledLayer_map, METH_NOARGS, "map()\n\n" },
     {(char *) "name", (PyCFunction) _wrap_PyTiledLayer_name, METH_NOARGS, "name()\n\n" },
     {(char *) "opacity", (PyCFunction) _wrap_PyTiledLayer_opacity, METH_NOARGS, "opacity()\n\n" },
-    {(char *) "setLocked", (PyCFunction) _wrap_PyTiledLayer_setLocked, METH_VARARGS|METH_KEYWORDS, "setLocked(locked)\n\ntype: locked: bool" },
-    {(char *) "setName", (PyCFunction) _wrap_PyTiledLayer_setName, METH_VARARGS|METH_KEYWORDS, "setName(name)\n\ntype: name: QString" },
-    {(char *) "setOpacity", (PyCFunction) _wrap_PyTiledLayer_setOpacity, METH_VARARGS|METH_KEYWORDS, "setOpacity(opacity)\n\ntype: opacity: double" },
-    {(char *) "setPosition", (PyCFunction) _wrap_PyTiledLayer_setPosition, METH_VARARGS|METH_KEYWORDS, "setPosition(x, y)\n\ntype: x: int\ntype: y: int" },
-    {(char *) "setVisible", (PyCFunction) _wrap_PyTiledLayer_setVisible, METH_VARARGS|METH_KEYWORDS, "setVisible(visible)\n\ntype: visible: bool" },
-    {(char *) "setX", (PyCFunction) _wrap_PyTiledLayer_setX, METH_VARARGS|METH_KEYWORDS, "setX(x)\n\ntype: x: int" },
-    {(char *) "setY", (PyCFunction) _wrap_PyTiledLayer_setY, METH_VARARGS|METH_KEYWORDS, "setY(y)\n\ntype: y: int" },
+    {(char *) "setLocked", (PyCFunction) _wrap_PyTiledLayer_setLocked, METH_KEYWORDS|METH_VARARGS, "setLocked(locked)\n\ntype: locked: bool" },
+    {(char *) "setName", (PyCFunction) _wrap_PyTiledLayer_setName, METH_KEYWORDS|METH_VARARGS, "setName(name)\n\ntype: name: QString" },
+    {(char *) "setOpacity", (PyCFunction) _wrap_PyTiledLayer_setOpacity, METH_KEYWORDS|METH_VARARGS, "setOpacity(opacity)\n\ntype: opacity: double" },
+    {(char *) "setPosition", (PyCFunction) _wrap_PyTiledLayer_setPosition, METH_KEYWORDS|METH_VARARGS, "setPosition(x, y)\n\ntype: x: int\ntype: y: int" },
+    {(char *) "setVisible", (PyCFunction) _wrap_PyTiledLayer_setVisible, METH_KEYWORDS|METH_VARARGS, "setVisible(visible)\n\ntype: visible: bool" },
+    {(char *) "setX", (PyCFunction) _wrap_PyTiledLayer_setX, METH_KEYWORDS|METH_VARARGS, "setX(x)\n\ntype: x: int" },
+    {(char *) "setY", (PyCFunction) _wrap_PyTiledLayer_setY, METH_KEYWORDS|METH_VARARGS, "setY(y)\n\ntype: y: int" },
     {(char *) "x", (PyCFunction) _wrap_PyTiledLayer_x, METH_NOARGS, "x()\n\n" },
     {(char *) "y", (PyCFunction) _wrap_PyTiledLayer_y, METH_NOARGS, "y()\n\n" },
     {NULL, NULL, 0, NULL}
@@ -6031,44 +6025,44 @@ _wrap_PyTiledMap_width(PyTiledMap *self)
 }
 
 static PyMethodDef PyTiledMap_methods[] = {
-    {(char *) "addLayer", (PyCFunction) _wrap_PyTiledMap_addLayer, METH_VARARGS|METH_KEYWORDS, NULL },
-    {(char *) "addTileset", (PyCFunction) _wrap_PyTiledMap_addTileset, METH_VARARGS|METH_KEYWORDS, "addTileset(tileset)\n\ntype: tileset: SharedTileset" },
+    {(char *) "addLayer", (PyCFunction) _wrap_PyTiledMap_addLayer, METH_KEYWORDS|METH_VARARGS, NULL },
+    {(char *) "addTileset", (PyCFunction) _wrap_PyTiledMap_addTileset, METH_KEYWORDS|METH_VARARGS, "addTileset(tileset)\n\ntype: tileset: SharedTileset" },
     {(char *) "backgroundColor", (PyCFunction) _wrap_PyTiledMap_backgroundColor, METH_NOARGS, "backgroundColor()\n\n" },
     {(char *) "groupLayerCount", (PyCFunction) _wrap_PyTiledMap_groupLayerCount, METH_NOARGS, "groupLayerCount()\n\n" },
     {(char *) "height", (PyCFunction) _wrap_PyTiledMap_height, METH_NOARGS, "height()\n\n" },
     {(char *) "hexSideLength", (PyCFunction) _wrap_PyTiledMap_hexSideLength, METH_NOARGS, "hexSideLength()\n\n" },
     {(char *) "imageLayerCount", (PyCFunction) _wrap_PyTiledMap_imageLayerCount, METH_NOARGS, "imageLayerCount()\n\n" },
-    {(char *) "indexOfTileset", (PyCFunction) _wrap_PyTiledMap_indexOfTileset, METH_VARARGS|METH_KEYWORDS, "indexOfTileset(tileset)\n\ntype: tileset: SharedTileset const &" },
+    {(char *) "indexOfTileset", (PyCFunction) _wrap_PyTiledMap_indexOfTileset, METH_KEYWORDS|METH_VARARGS, "indexOfTileset(tileset)\n\ntype: tileset: SharedTileset const &" },
     {(char *) "infinite", (PyCFunction) _wrap_PyTiledMap_infinite, METH_NOARGS, "infinite()\n\n" },
-    {(char *) "insertTileset", (PyCFunction) _wrap_PyTiledMap_insertTileset, METH_VARARGS|METH_KEYWORDS, "insertTileset(pos, tileset)\n\ntype: pos: int\ntype: tileset: SharedTileset" },
-    {(char *) "isTilesetUsed", (PyCFunction) _wrap_PyTiledMap_isTilesetUsed, METH_VARARGS|METH_KEYWORDS, "isTilesetUsed(tileset)\n\ntype: tileset: Tileset const *" },
-    {(char *) "layerAt", (PyCFunction) _wrap_PyTiledMap_layerAt, METH_VARARGS|METH_KEYWORDS, "layerAt(index)\n\ntype: index: int" },
+    {(char *) "insertTileset", (PyCFunction) _wrap_PyTiledMap_insertTileset, METH_KEYWORDS|METH_VARARGS, "insertTileset(pos, tileset)\n\ntype: pos: int\ntype: tileset: SharedTileset" },
+    {(char *) "isTilesetUsed", (PyCFunction) _wrap_PyTiledMap_isTilesetUsed, METH_KEYWORDS|METH_VARARGS, "isTilesetUsed(tileset)\n\ntype: tileset: Tileset const *" },
+    {(char *) "layerAt", (PyCFunction) _wrap_PyTiledMap_layerAt, METH_KEYWORDS|METH_VARARGS, "layerAt(index)\n\ntype: index: int" },
     {(char *) "layerCount", (PyCFunction) _wrap_PyTiledMap_layerCount, METH_NOARGS, "layerCount()\n\n" },
     {(char *) "nextLayerId", (PyCFunction) _wrap_PyTiledMap_nextLayerId, METH_NOARGS, "nextLayerId()\n\n" },
     {(char *) "nextObjectId", (PyCFunction) _wrap_PyTiledMap_nextObjectId, METH_NOARGS, "nextObjectId()\n\n" },
     {(char *) "objectGroupCount", (PyCFunction) _wrap_PyTiledMap_objectGroupCount, METH_NOARGS, "objectGroupCount()\n\n" },
     {(char *) "orientation", (PyCFunction) _wrap_PyTiledMap_orientation, METH_NOARGS, "orientation()\n\n" },
-    {(char *) "removeTilesetAt", (PyCFunction) _wrap_PyTiledMap_removeTilesetAt, METH_VARARGS|METH_KEYWORDS, "removeTilesetAt(pos)\n\ntype: pos: int" },
+    {(char *) "removeTilesetAt", (PyCFunction) _wrap_PyTiledMap_removeTilesetAt, METH_KEYWORDS|METH_VARARGS, "removeTilesetAt(pos)\n\ntype: pos: int" },
     {(char *) "renderOrder", (PyCFunction) _wrap_PyTiledMap_renderOrder, METH_NOARGS, "renderOrder()\n\n" },
-    {(char *) "replaceTileset", (PyCFunction) _wrap_PyTiledMap_replaceTileset, METH_VARARGS|METH_KEYWORDS, "replaceTileset(oldTileset, newTileset)\n\ntype: oldTileset: SharedTileset\ntype: newTileset: SharedTileset" },
-    {(char *) "setBackgroundColor", (PyCFunction) _wrap_PyTiledMap_setBackgroundColor, METH_VARARGS|METH_KEYWORDS, "setBackgroundColor(col)\n\ntype: col: QColor" },
-    {(char *) "setHeight", (PyCFunction) _wrap_PyTiledMap_setHeight, METH_VARARGS|METH_KEYWORDS, "setHeight(h)\n\ntype: h: int" },
-    {(char *) "setHexSideLength", (PyCFunction) _wrap_PyTiledMap_setHexSideLength, METH_VARARGS|METH_KEYWORDS, "setHexSideLength(hexSideLength)\n\ntype: hexSideLength: int" },
-    {(char *) "setInfinite", (PyCFunction) _wrap_PyTiledMap_setInfinite, METH_VARARGS|METH_KEYWORDS, "setInfinite(infinite)\n\ntype: infinite: bool" },
-    {(char *) "setNextLayerId", (PyCFunction) _wrap_PyTiledMap_setNextLayerId, METH_VARARGS|METH_KEYWORDS, "setNextLayerId(nextLayerId)\n\ntype: nextLayerId: int" },
-    {(char *) "setNextObjectId", (PyCFunction) _wrap_PyTiledMap_setNextObjectId, METH_VARARGS|METH_KEYWORDS, "setNextObjectId(nextObjectId)\n\ntype: nextObjectId: int" },
-    {(char *) "setOrientation", (PyCFunction) _wrap_PyTiledMap_setOrientation, METH_VARARGS|METH_KEYWORDS, "setOrientation(orientation)\n\ntype: orientation: Tiled::Map::Orientation" },
-    {(char *) "setRenderOrder", (PyCFunction) _wrap_PyTiledMap_setRenderOrder, METH_VARARGS|METH_KEYWORDS, "setRenderOrder(renderOrder)\n\ntype: renderOrder: Tiled::Map::RenderOrder" },
-    {(char *) "setStaggerAxis", (PyCFunction) _wrap_PyTiledMap_setStaggerAxis, METH_VARARGS|METH_KEYWORDS, "setStaggerAxis(staggerAxis)\n\ntype: staggerAxis: Tiled::Map::StaggerAxis" },
-    {(char *) "setStaggerIndex", (PyCFunction) _wrap_PyTiledMap_setStaggerIndex, METH_VARARGS|METH_KEYWORDS, "setStaggerIndex(staggerIndex)\n\ntype: staggerIndex: Tiled::Map::StaggerIndex" },
-    {(char *) "setWidth", (PyCFunction) _wrap_PyTiledMap_setWidth, METH_VARARGS|METH_KEYWORDS, "setWidth(w)\n\ntype: w: int" },
+    {(char *) "replaceTileset", (PyCFunction) _wrap_PyTiledMap_replaceTileset, METH_KEYWORDS|METH_VARARGS, "replaceTileset(oldTileset, newTileset)\n\ntype: oldTileset: SharedTileset\ntype: newTileset: SharedTileset" },
+    {(char *) "setBackgroundColor", (PyCFunction) _wrap_PyTiledMap_setBackgroundColor, METH_KEYWORDS|METH_VARARGS, "setBackgroundColor(col)\n\ntype: col: QColor" },
+    {(char *) "setHeight", (PyCFunction) _wrap_PyTiledMap_setHeight, METH_KEYWORDS|METH_VARARGS, "setHeight(h)\n\ntype: h: int" },
+    {(char *) "setHexSideLength", (PyCFunction) _wrap_PyTiledMap_setHexSideLength, METH_KEYWORDS|METH_VARARGS, "setHexSideLength(hexSideLength)\n\ntype: hexSideLength: int" },
+    {(char *) "setInfinite", (PyCFunction) _wrap_PyTiledMap_setInfinite, METH_KEYWORDS|METH_VARARGS, "setInfinite(infinite)\n\ntype: infinite: bool" },
+    {(char *) "setNextLayerId", (PyCFunction) _wrap_PyTiledMap_setNextLayerId, METH_KEYWORDS|METH_VARARGS, "setNextLayerId(nextLayerId)\n\ntype: nextLayerId: int" },
+    {(char *) "setNextObjectId", (PyCFunction) _wrap_PyTiledMap_setNextObjectId, METH_KEYWORDS|METH_VARARGS, "setNextObjectId(nextObjectId)\n\ntype: nextObjectId: int" },
+    {(char *) "setOrientation", (PyCFunction) _wrap_PyTiledMap_setOrientation, METH_KEYWORDS|METH_VARARGS, "setOrientation(orientation)\n\ntype: orientation: Tiled::Map::Orientation" },
+    {(char *) "setRenderOrder", (PyCFunction) _wrap_PyTiledMap_setRenderOrder, METH_KEYWORDS|METH_VARARGS, "setRenderOrder(renderOrder)\n\ntype: renderOrder: Tiled::Map::RenderOrder" },
+    {(char *) "setStaggerAxis", (PyCFunction) _wrap_PyTiledMap_setStaggerAxis, METH_KEYWORDS|METH_VARARGS, "setStaggerAxis(staggerAxis)\n\ntype: staggerAxis: Tiled::Map::StaggerAxis" },
+    {(char *) "setStaggerIndex", (PyCFunction) _wrap_PyTiledMap_setStaggerIndex, METH_KEYWORDS|METH_VARARGS, "setStaggerIndex(staggerIndex)\n\ntype: staggerIndex: Tiled::Map::StaggerIndex" },
+    {(char *) "setWidth", (PyCFunction) _wrap_PyTiledMap_setWidth, METH_KEYWORDS|METH_VARARGS, "setWidth(w)\n\ntype: w: int" },
     {(char *) "staggerAxis", (PyCFunction) _wrap_PyTiledMap_staggerAxis, METH_NOARGS, "staggerAxis()\n\n" },
     {(char *) "staggerIndex", (PyCFunction) _wrap_PyTiledMap_staggerIndex, METH_NOARGS, "staggerIndex()\n\n" },
     {(char *) "tileHeight", (PyCFunction) _wrap_PyTiledMap_tileHeight, METH_NOARGS, "tileHeight()\n\n" },
     {(char *) "tileLayerCount", (PyCFunction) _wrap_PyTiledMap_tileLayerCount, METH_NOARGS, "tileLayerCount()\n\n" },
     {(char *) "tileSize", (PyCFunction) _wrap_PyTiledMap_tileSize, METH_NOARGS, "tileSize()\n\n" },
     {(char *) "tileWidth", (PyCFunction) _wrap_PyTiledMap_tileWidth, METH_NOARGS, "tileWidth()\n\n" },
-    {(char *) "tilesetAt", (PyCFunction) _wrap_PyTiledMap_tilesetAt, METH_VARARGS|METH_KEYWORDS, "tilesetAt(index)\n\ntype: index: int" },
+    {(char *) "tilesetAt", (PyCFunction) _wrap_PyTiledMap_tilesetAt, METH_KEYWORDS|METH_VARARGS, "tilesetAt(index)\n\ntype: index: int" },
     {(char *) "tilesetCount", (PyCFunction) _wrap_PyTiledMap_tilesetCount, METH_NOARGS, "tilesetCount()\n\n" },
     {(char *) "width", (PyCFunction) _wrap_PyTiledMap_width, METH_NOARGS, "width()\n\n" },
     {NULL, NULL, 0, NULL}
@@ -6480,7 +6474,7 @@ _wrap_PyTiledCell__copy__(PyTiledCell *self)
 
 static PyMethodDef PyTiledCell_methods[] = {
     {(char *) "isEmpty", (PyCFunction) _wrap_PyTiledCell_isEmpty, METH_NOARGS, "isEmpty()\n\n" },
-    {(char *) "setTile", (PyCFunction) _wrap_PyTiledCell_setTile, METH_VARARGS|METH_KEYWORDS, "setTile(tile)\n\ntype: tile: Tiled::Tile *" },
+    {(char *) "setTile", (PyCFunction) _wrap_PyTiledCell_setTile, METH_KEYWORDS|METH_VARARGS, "setTile(tile)\n\ntype: tile: Tiled::Tile *" },
     {(char *) "tile", (PyCFunction) _wrap_PyTiledCell_tile, METH_NOARGS, "tile()\n\n" },
     {(char *) "tileset", (PyCFunction) _wrap_PyTiledCell_tileset, METH_NOARGS, "tileset()\n\n" },
     {(char *) "__copy__", (PyCFunction) _wrap_PyTiledCell__copy__, METH_NOARGS, NULL},
@@ -6713,11 +6707,11 @@ _wrap_PyTiledTileLayer_width(PyTiledTileLayer *self)
 }
 
 static PyMethodDef PyTiledTileLayer_methods[] = {
-    {(char *) "cellAt", (PyCFunction) _wrap_PyTiledTileLayer_cellAt, METH_VARARGS|METH_KEYWORDS, "cellAt(x, y)\n\ntype: x: int\ntype: y: int" },
+    {(char *) "cellAt", (PyCFunction) _wrap_PyTiledTileLayer_cellAt, METH_KEYWORDS|METH_VARARGS, "cellAt(x, y)\n\ntype: x: int\ntype: y: int" },
     {(char *) "height", (PyCFunction) _wrap_PyTiledTileLayer_height, METH_NOARGS, "height()\n\n" },
     {(char *) "isEmpty", (PyCFunction) _wrap_PyTiledTileLayer_isEmpty, METH_NOARGS, "isEmpty()\n\n" },
-    {(char *) "referencesTileset", (PyCFunction) _wrap_PyTiledTileLayer_referencesTileset, METH_VARARGS|METH_KEYWORDS, "referencesTileset(ts)\n\ntype: ts: Tileset *" },
-    {(char *) "setCell", (PyCFunction) _wrap_PyTiledTileLayer_setCell, METH_VARARGS|METH_KEYWORDS, "setCell(x, y, c)\n\ntype: x: int\ntype: y: int\ntype: c: Cell" },
+    {(char *) "referencesTileset", (PyCFunction) _wrap_PyTiledTileLayer_referencesTileset, METH_KEYWORDS|METH_VARARGS, "referencesTileset(ts)\n\ntype: ts: Tileset *" },
+    {(char *) "setCell", (PyCFunction) _wrap_PyTiledTileLayer_setCell, METH_KEYWORDS|METH_VARARGS, "setCell(x, y, c)\n\ntype: x: int\ntype: y: int\ntype: c: Cell" },
     {(char *) "width", (PyCFunction) _wrap_PyTiledTileLayer_width, METH_NOARGS, "width()\n\n" },
     {NULL, NULL, 0, NULL}
 };
@@ -6893,8 +6887,8 @@ _wrap_PyTiledImageLayer_setImage(PyTiledImageLayer *self, PyObject *args, PyObje
 
 static PyMethodDef PyTiledImageLayer_methods[] = {
     {(char *) "image", (PyCFunction) _wrap_PyTiledImageLayer_image, METH_NOARGS, "image()\n\n" },
-    {(char *) "loadFromImage", (PyCFunction) _wrap_PyTiledImageLayer_loadFromImage, METH_VARARGS|METH_KEYWORDS, "loadFromImage(img, file)\n\ntype: img: QImage const &\ntype: file: QString" },
-    {(char *) "setImage", (PyCFunction) _wrap_PyTiledImageLayer_setImage, METH_VARARGS|METH_KEYWORDS, "setImage(image)\n\ntype: image: QPixmap const &" },
+    {(char *) "loadFromImage", (PyCFunction) _wrap_PyTiledImageLayer_loadFromImage, METH_KEYWORDS|METH_VARARGS, "loadFromImage(img, file)\n\ntype: img: QImage const &\ntype: file: QString" },
+    {(char *) "setImage", (PyCFunction) _wrap_PyTiledImageLayer_setImage, METH_KEYWORDS|METH_VARARGS, "setImage(image)\n\ntype: image: QPixmap const &" },
     {NULL, NULL, 0, NULL}
 };
 
@@ -7054,7 +7048,7 @@ _wrap_PyTiledGroupLayer_layerCount(PyTiledGroupLayer *self)
 }
 
 static PyMethodDef PyTiledGroupLayer_methods[] = {
-    {(char *) "layerAt", (PyCFunction) _wrap_PyTiledGroupLayer_layerAt, METH_VARARGS|METH_KEYWORDS, "layerAt(index)\n\ntype: index: int" },
+    {(char *) "layerAt", (PyCFunction) _wrap_PyTiledGroupLayer_layerAt, METH_KEYWORDS|METH_VARARGS, "layerAt(index)\n\ntype: index: int" },
     {(char *) "layerCount", (PyCFunction) _wrap_PyTiledGroupLayer_layerCount, METH_NOARGS, "layerCount()\n\n" },
     {NULL, NULL, 0, NULL}
 };
@@ -7295,12 +7289,12 @@ _wrap_PyTiledObjectGroup_removeObject(PyTiledObjectGroup *self, PyObject *args, 
 }
 
 static PyMethodDef PyTiledObjectGroup_methods[] = {
-    {(char *) "addObject", (PyCFunction) _wrap_PyTiledObjectGroup_addObject, METH_VARARGS|METH_KEYWORDS, "addObject(object)\n\ntype: object: MapObject *" },
-    {(char *) "insertObject", (PyCFunction) _wrap_PyTiledObjectGroup_insertObject, METH_VARARGS|METH_KEYWORDS, "insertObject(index, object)\n\ntype: index: int\ntype: object: MapObject *" },
-    {(char *) "objectAt", (PyCFunction) _wrap_PyTiledObjectGroup_objectAt, METH_VARARGS|METH_KEYWORDS, "objectAt(index)\n\ntype: index: int" },
+    {(char *) "addObject", (PyCFunction) _wrap_PyTiledObjectGroup_addObject, METH_KEYWORDS|METH_VARARGS, "addObject(object)\n\ntype: object: MapObject *" },
+    {(char *) "insertObject", (PyCFunction) _wrap_PyTiledObjectGroup_insertObject, METH_KEYWORDS|METH_VARARGS, "insertObject(index, object)\n\ntype: index: int\ntype: object: MapObject *" },
+    {(char *) "objectAt", (PyCFunction) _wrap_PyTiledObjectGroup_objectAt, METH_KEYWORDS|METH_VARARGS, "objectAt(index)\n\ntype: index: int" },
     {(char *) "objectCount", (PyCFunction) _wrap_PyTiledObjectGroup_objectCount, METH_NOARGS, "objectCount()\n\n" },
-    {(char *) "referencesTileset", (PyCFunction) _wrap_PyTiledObjectGroup_referencesTileset, METH_VARARGS|METH_KEYWORDS, "referencesTileset(ts)\n\ntype: ts: Tileset *" },
-    {(char *) "removeObject", (PyCFunction) _wrap_PyTiledObjectGroup_removeObject, METH_VARARGS|METH_KEYWORDS, "removeObject(object)\n\ntype: object: MapObject *" },
+    {(char *) "referencesTileset", (PyCFunction) _wrap_PyTiledObjectGroup_referencesTileset, METH_KEYWORDS|METH_VARARGS, "referencesTileset(ts)\n\ntype: ts: Tileset *" },
+    {(char *) "removeObject", (PyCFunction) _wrap_PyTiledObjectGroup_removeObject, METH_KEYWORDS|METH_VARARGS, "removeObject(object)\n\ntype: object: MapObject *" },
     {NULL, NULL, 0, NULL}
 };
 
@@ -7832,18 +7826,18 @@ static PyMethodDef PyTiledMapObject_methods[] = {
     {(char *) "name", (PyCFunction) _wrap_PyTiledMapObject_name, METH_NOARGS, "name()\n\n" },
     {(char *) "objectGroup", (PyCFunction) _wrap_PyTiledMapObject_objectGroup, METH_NOARGS, "objectGroup()\n\n" },
     {(char *) "rotation", (PyCFunction) _wrap_PyTiledMapObject_rotation, METH_NOARGS, "rotation()\n\n" },
-    {(char *) "setCell", (PyCFunction) _wrap_PyTiledMapObject_setCell, METH_VARARGS|METH_KEYWORDS, "setCell(c)\n\ntype: c: Tiled::Cell const" },
-    {(char *) "setHeight", (PyCFunction) _wrap_PyTiledMapObject_setHeight, METH_VARARGS|METH_KEYWORDS, "setHeight(h)\n\ntype: h: double" },
-    {(char *) "setName", (PyCFunction) _wrap_PyTiledMapObject_setName, METH_VARARGS|METH_KEYWORDS, "setName(n)\n\ntype: n: QString" },
-    {(char *) "setPosition", (PyCFunction) _wrap_PyTiledMapObject_setPosition, METH_VARARGS|METH_KEYWORDS, "setPosition(pos)\n\ntype: pos: QPointF" },
-    {(char *) "setRotation", (PyCFunction) _wrap_PyTiledMapObject_setRotation, METH_VARARGS|METH_KEYWORDS, "setRotation(r)\n\ntype: r: double" },
-    {(char *) "setShape", (PyCFunction) _wrap_PyTiledMapObject_setShape, METH_VARARGS|METH_KEYWORDS, "setShape(s)\n\ntype: s: Tiled::MapObject::Shape" },
-    {(char *) "setSize", (PyCFunction) _wrap_PyTiledMapObject_setSize, METH_VARARGS|METH_KEYWORDS, "setSize(size)\n\ntype: size: QSizeF" },
-    {(char *) "setType", (PyCFunction) _wrap_PyTiledMapObject_setType, METH_VARARGS|METH_KEYWORDS, "setType(n)\n\ntype: n: QString" },
-    {(char *) "setVisible", (PyCFunction) _wrap_PyTiledMapObject_setVisible, METH_VARARGS|METH_KEYWORDS, "setVisible(v)\n\ntype: v: bool" },
-    {(char *) "setWidth", (PyCFunction) _wrap_PyTiledMapObject_setWidth, METH_VARARGS|METH_KEYWORDS, "setWidth(w)\n\ntype: w: double" },
-    {(char *) "setX", (PyCFunction) _wrap_PyTiledMapObject_setX, METH_VARARGS|METH_KEYWORDS, "setX(x)\n\ntype: x: double" },
-    {(char *) "setY", (PyCFunction) _wrap_PyTiledMapObject_setY, METH_VARARGS|METH_KEYWORDS, "setY(y)\n\ntype: y: double" },
+    {(char *) "setCell", (PyCFunction) _wrap_PyTiledMapObject_setCell, METH_KEYWORDS|METH_VARARGS, "setCell(c)\n\ntype: c: Tiled::Cell const" },
+    {(char *) "setHeight", (PyCFunction) _wrap_PyTiledMapObject_setHeight, METH_KEYWORDS|METH_VARARGS, "setHeight(h)\n\ntype: h: double" },
+    {(char *) "setName", (PyCFunction) _wrap_PyTiledMapObject_setName, METH_KEYWORDS|METH_VARARGS, "setName(n)\n\ntype: n: QString" },
+    {(char *) "setPosition", (PyCFunction) _wrap_PyTiledMapObject_setPosition, METH_KEYWORDS|METH_VARARGS, "setPosition(pos)\n\ntype: pos: QPointF" },
+    {(char *) "setRotation", (PyCFunction) _wrap_PyTiledMapObject_setRotation, METH_KEYWORDS|METH_VARARGS, "setRotation(r)\n\ntype: r: double" },
+    {(char *) "setShape", (PyCFunction) _wrap_PyTiledMapObject_setShape, METH_KEYWORDS|METH_VARARGS, "setShape(s)\n\ntype: s: Tiled::MapObject::Shape" },
+    {(char *) "setSize", (PyCFunction) _wrap_PyTiledMapObject_setSize, METH_KEYWORDS|METH_VARARGS, "setSize(size)\n\ntype: size: QSizeF" },
+    {(char *) "setType", (PyCFunction) _wrap_PyTiledMapObject_setType, METH_KEYWORDS|METH_VARARGS, "setType(n)\n\ntype: n: QString" },
+    {(char *) "setVisible", (PyCFunction) _wrap_PyTiledMapObject_setVisible, METH_KEYWORDS|METH_VARARGS, "setVisible(v)\n\ntype: v: bool" },
+    {(char *) "setWidth", (PyCFunction) _wrap_PyTiledMapObject_setWidth, METH_KEYWORDS|METH_VARARGS, "setWidth(w)\n\ntype: w: double" },
+    {(char *) "setX", (PyCFunction) _wrap_PyTiledMapObject_setX, METH_KEYWORDS|METH_VARARGS, "setX(x)\n\ntype: x: double" },
+    {(char *) "setY", (PyCFunction) _wrap_PyTiledMapObject_setY, METH_KEYWORDS|METH_VARARGS, "setY(y)\n\ntype: y: double" },
     {(char *) "shape", (PyCFunction) _wrap_PyTiledMapObject_shape, METH_NOARGS, "shape()\n\n" },
     {(char *) "type", (PyCFunction) _wrap_PyTiledMapObject_type, METH_NOARGS, "type()\n\n" },
     {(char *) "width", (PyCFunction) _wrap_PyTiledMapObject_width, METH_NOARGS, "width()\n\n" },
@@ -7980,7 +7974,7 @@ _wrap_PyTiledLoggingInterface_log(PyTiledLoggingInterface *self, PyObject *args,
 }
 
 static PyMethodDef PyTiledLoggingInterface_methods[] = {
-    {(char *) "log", (PyCFunction) _wrap_PyTiledLoggingInterface_log, METH_VARARGS|METH_KEYWORDS, "log(type, msg)\n\ntype: type: Tiled::LoggingInterface::OutputType\ntype: msg: QString const" },
+    {(char *) "log", (PyCFunction) _wrap_PyTiledLoggingInterface_log, METH_KEYWORDS|METH_VARARGS, "log(type, msg)\n\ntype: type: Tiled::LoggingInterface::OutputType\ntype: msg: QString const" },
     {NULL, NULL, 0, NULL}
 };
 
@@ -8411,17 +8405,19 @@ PyObject *
 _wrap_tiled_loadTileset(PyObject * PYBINDGEN_UNUSED(dummy), PyObject *args, PyObject *kwargs)
 {
     PyObject *py_retval;
-    bool retval;
-    PyTiledSharedTileset *sts;
     const char *file;
     Py_ssize_t file_len;
-    const char *keywords[] = {"sts", "file", NULL};
+    const char *keywords[] = {"file", NULL};
+    PyTiledSharedTileset *py_SharedTileset;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "O!s#", (char **) keywords, &PyTiledSharedTileset_Type, &sts, &file, &file_len)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, (char *) "s#", (char **) keywords, &file, &file_len)) {
         return NULL;
     }
-    retval = loadTileset(*((PyTiledSharedTileset *) sts)->obj, QString::fromUtf8(file));
-    py_retval = Py_BuildValue((char *) "N", PyBool_FromLong(retval));
+    Tiled::SharedTileset retval = loadTileset(QString::fromUtf8(file));
+    py_SharedTileset = PyObject_New(PyTiledSharedTileset, &PyTiledSharedTileset_Type);
+    py_SharedTileset->flags = PYBINDGEN_WRAPPER_FLAG_NONE;
+    py_SharedTileset->obj = new Tiled::SharedTileset(retval);
+    py_retval = Py_BuildValue((char *) "N", py_SharedTileset);
     return py_retval;
 }
 PyObject * _wrap_tiled_loadTileset(PyObject * PYBINDGEN_UNUSED(dummy), PyObject *args, PyObject *kwargs);
@@ -8507,14 +8503,14 @@ _wrap_tiled_tileLayerAt(PyObject * PYBINDGEN_UNUSED(dummy), PyObject *args, PyOb
 PyObject * _wrap_tiled_tileLayerAt(PyObject * PYBINDGEN_UNUSED(dummy), PyObject *args, PyObject *kwargs);
 
 static PyMethodDef tiled_functions[] = {
-    {(char *) "imageLayerAt", (PyCFunction) _wrap_tiled_imageLayerAt, METH_VARARGS|METH_KEYWORDS, "imageLayerAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
-    {(char *) "isImageLayerAt", (PyCFunction) _wrap_tiled_isImageLayerAt, METH_VARARGS|METH_KEYWORDS, "isImageLayerAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
-    {(char *) "isObjectGroupAt", (PyCFunction) _wrap_tiled_isObjectGroupAt, METH_VARARGS|METH_KEYWORDS, "isObjectGroupAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
-    {(char *) "isTileLayerAt", (PyCFunction) _wrap_tiled_isTileLayerAt, METH_VARARGS|METH_KEYWORDS, "isTileLayerAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
-    {(char *) "loadTileset", (PyCFunction) _wrap_tiled_loadTileset, METH_VARARGS|METH_KEYWORDS, "loadTileset(sts, file)\n\ntype: sts: Tiled::SharedTileset &\ntype: file: QString" },
-    {(char *) "loadTilesetFromFile", (PyCFunction) _wrap_tiled_loadTilesetFromFile, METH_VARARGS|METH_KEYWORDS, "loadTilesetFromFile(ts, file)\n\ntype: ts: Tileset *\ntype: file: QString" },
-    {(char *) "objectGroupAt", (PyCFunction) _wrap_tiled_objectGroupAt, METH_VARARGS|METH_KEYWORDS, "objectGroupAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
-    {(char *) "tileLayerAt", (PyCFunction) _wrap_tiled_tileLayerAt, METH_VARARGS|METH_KEYWORDS, "tileLayerAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
+    {(char *) "imageLayerAt", (PyCFunction) _wrap_tiled_imageLayerAt, METH_KEYWORDS|METH_VARARGS, "imageLayerAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
+    {(char *) "isImageLayerAt", (PyCFunction) _wrap_tiled_isImageLayerAt, METH_KEYWORDS|METH_VARARGS, "isImageLayerAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
+    {(char *) "isObjectGroupAt", (PyCFunction) _wrap_tiled_isObjectGroupAt, METH_KEYWORDS|METH_VARARGS, "isObjectGroupAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
+    {(char *) "isTileLayerAt", (PyCFunction) _wrap_tiled_isTileLayerAt, METH_KEYWORDS|METH_VARARGS, "isTileLayerAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
+    {(char *) "loadTileset", (PyCFunction) _wrap_tiled_loadTileset, METH_KEYWORDS|METH_VARARGS, "loadTileset(file)\n\ntype: file: QString" },
+    {(char *) "loadTilesetFromFile", (PyCFunction) _wrap_tiled_loadTilesetFromFile, METH_KEYWORDS|METH_VARARGS, "loadTilesetFromFile(ts, file)\n\ntype: ts: Tileset *\ntype: file: QString" },
+    {(char *) "objectGroupAt", (PyCFunction) _wrap_tiled_objectGroupAt, METH_KEYWORDS|METH_VARARGS, "objectGroupAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
+    {(char *) "tileLayerAt", (PyCFunction) _wrap_tiled_tileLayerAt, METH_KEYWORDS|METH_VARARGS, "tileLayerAt(map, index)\n\ntype: map: Tiled::Map *\ntype: index: int" },
     {NULL, NULL, 0, NULL}
 };
 /* --- classes --- */
@@ -8618,7 +8614,7 @@ PyTypeObject PyPythonPythonScript_Type = {
     (getattrofunc)NULL,     /* tp_getattro */
     (setattrofunc)NULL,     /* tp_setattro */
     (PyBufferProcs*)NULL,  /* tp_as_buffer */
-    Py_TPFLAGS_HAVE_GC|Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,                      /* tp_flags */
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_HAVE_GC|Py_TPFLAGS_BASETYPE,                      /* tp_flags */
     "",                        /* Documentation string */
     (traverseproc)PyPythonPythonScript__tp_traverse,     /* tp_traverse */
     (inquiry)PyPythonPythonScript__tp_clear,             /* tp_clear */

--- a/src/plugins/python/tiledbinding.py
+++ b/src/plugins/python/tiledbinding.py
@@ -379,18 +379,12 @@ static bool loadTilesetFromFile(Tiled::Tileset *ts, const QString &file)
 }
 """)
 
-mod.add_function('loadTileset', 'bool', [('Tiled::SharedTileset&','sts'),('QString','file')])
+mod.add_function('loadTileset', 'Tiled::SharedTileset', [('QString','file')])
 
 mod.body.writeln("""
-static bool loadTileset(Tiled::SharedTileset& sts, const QString &file)
+static Tiled::SharedTileset loadTileset(const QString &file)
 {
-    auto result = Tiled::TilesetManager::instance()->loadTileset(file);
-    if (!result || result->status() == Tiled::LoadingStatus::LoadingError)
-    {
-        return false;
-    }
-    sts = result;
-    return true;
+    return Tiled::TilesetManager::instance()->loadTileset(file);
 }
 """)
 

--- a/src/plugins/python/tiledbinding.py
+++ b/src/plugins/python/tiledbinding.py
@@ -62,7 +62,7 @@ mod.add_include('"objectgroup.h"')
 mod.add_include('"tile.h"')
 mod.add_include('"tilelayer.h"')
 mod.add_include('"tileset.h"')
-mod.add_include('"mapreader.h"')
+mod.add_include('"tilesetmanager.h"')
 
 mod.header.writeln('#ifndef _MSC_VER')
 mod.header.writeln('#pragma GCC diagnostic ignored "-Wmissing-field-initializers"')
@@ -379,14 +379,13 @@ static bool loadTilesetFromFile(Tiled::Tileset *ts, const QString &file)
 }
 """)
 
-mod.add_function('loadSharedTilesetFromTsx', 'bool', [('Tiled::SharedTileset&','sts'),('QString','file')])
+mod.add_function('loadTileset', 'bool', [('Tiled::SharedTileset&','sts'),('QString','file')])
 
 mod.body.writeln("""
-static bool loadSharedTilesetFromTsx(Tiled::SharedTileset& sts, const QString &file)
+static bool loadTileset(Tiled::SharedTileset& sts, const QString &file)
 {
-    Tiled::MapReader reader;
-    Tiled::SharedTileset result = reader.readTileset(file);
-    if (result == 0)
+    auto result = Tiled::TilesetManager::instance()->loadTileset(file);
+    if (!result || result->status() == Tiled::LoadingStatus::LoadingError)
     {
         return false;
     }

--- a/src/plugins/python/tiledbinding.py
+++ b/src/plugins/python/tiledbinding.py
@@ -62,6 +62,7 @@ mod.add_include('"objectgroup.h"')
 mod.add_include('"tile.h"')
 mod.add_include('"tilelayer.h"')
 mod.add_include('"tileset.h"')
+mod.add_include('"mapreader.h"')
 
 mod.header.writeln('#ifndef _MSC_VER')
 mod.header.writeln('#pragma GCC diagnostic ignored "-Wmissing-field-initializers"')
@@ -85,6 +86,10 @@ cls_object.add_method('properties', retval('Tiled::Properties','p'), [])
 cls_object.add_method('propertyAsString', 'QString', [('QString','prop')])
 cls_object.add_method('setProperty', None,
     [('QString','prop'),('QString','val')])
+cls_object.add_method('setProperty', None,
+    [('QString','prop'),('int','val')])
+cls_object.add_method('setProperty', None,
+    [('QString','prop'),('bool','val')])
 
 cls_tile = tiled.add_class('Tile', cls_object)
 cls_tile.add_method('id', 'int', [])
@@ -371,6 +376,22 @@ static bool loadTilesetFromFile(Tiled::Tileset *ts, const QString &file)
 {
     QImage img(file);
     return ts->loadFromImage(img, file);
+}
+""")
+
+mod.add_function('loadSharedTilesetFromTsx', 'bool', [('Tiled::SharedTileset&','sts'),('QString','file')])
+
+mod.body.writeln("""
+static bool loadSharedTilesetFromTsx(Tiled::SharedTileset& sts, const QString &file)
+{
+    Tiled::MapReader reader;
+    Tiled::SharedTileset result = reader.readTileset(file);
+    if (result == 0)
+    {
+        return false;
+    }
+    sts = result;
+    return true;
 }
 """)
 


### PR DESCRIPTION
This pull request adds a method to the Python API, `loadSharedTilesetFromTsx`, which allows loading an existing TSX file as a tileset.

The use case I'm thinking of is embedding the path to a specific version of a TSX in a map format, then attempting to resolve it when the map is loaded in Tiled, and sharing the same TSX across multiple map files. The data system we have may support several groups of tiles loaded from outside sources like mods which can be enabled and disabled, so I was thinking about pregenerating a TSX for a single supported configuration of enabled/disabled mods, caching the tile images somewhere, and allowing them to be used in the editor.