### PR TITLE
Try to keep layer by name in worlds (#2065)

### DIFF
--- a/src/tiled/abstracttiletool.cpp
+++ b/src/tiled/abstracttiletool.cpp
@@ -131,12 +131,8 @@ void AbstractTileTool::mousePressed(QGraphicsSceneMouseEvent *event)
             }
         }
 
-        if (!layers.isEmpty()) {
-            mapDocument()->setSelectedLayers(layers);
-
-            if (!layers.contains(mapDocument()->currentLayer()))
-                mapDocument()->setCurrentLayer(layers.first());
-        }
+        if (!layers.isEmpty())
+            mapDocument()->switchSelectedLayers(layers);
 
         return;
     }

--- a/src/tiled/editablelayer.cpp
+++ b/src/tiled/editablelayer.cpp
@@ -155,14 +155,14 @@ void EditableLayer::setSelected(bool selected)
         if (!document->selectedLayers().contains(layer())) {
             auto layers = document->selectedLayers();
             layers.append(layer());
-            document->setSelectedLayers(layers);
+            document->switchSelectedLayers(layers);
         }
     } else {
         int index = document->selectedLayers().indexOf(layer());
         if (index != -1) {
             auto layers = document->selectedLayers();
             layers.removeAt(index);
-            document->setSelectedLayers(layers);
+            document->switchSelectedLayers(layers);
         }
     }
 }

--- a/src/tiled/editablemap.cpp
+++ b/src/tiled/editablemap.cpp
@@ -318,15 +318,11 @@ void EditableMap::setLayerDataFormat(Map::LayerDataFormat value)
 
 void EditableMap::setCurrentLayer(EditableLayer *layer)
 {
-    auto document = mapDocument();
-    if (!document)
-        return;
+    QList<QObject*> layers;
+    if (layer)
+        layers.append(layer);
 
-    document->setCurrentLayer(layer ? layer->layer() : nullptr);
-
-    // Automatically select the layer if it isn't already
-    if (layer && !document->selectedLayers().contains(layer->layer()))
-        document->setSelectedLayers({ layer->layer() });
+    setSelectedLayers(layers);
 }
 
 void EditableMap::setSelectedLayers(const QList<QObject *> &layers)
@@ -347,11 +343,7 @@ void EditableMap::setSelectedLayers(const QList<QObject *> &layers)
         plainLayers.append(editableLayer->layer());
     }
 
-    document->setSelectedLayers(plainLayers);
-
-    // Automatically make sure the current layer is one of the selected ones
-    if (!plainLayers.contains(document->currentLayer()))
-        document->setCurrentLayer(plainLayers.isEmpty() ? nullptr : plainLayers.first());
+    document->switchSelectedLayers(plainLayers);
 }
 
 void EditableMap::setSelectedObjects(const QList<QObject *> &objects)

--- a/src/tiled/layerdock.h
+++ b/src/tiled/layerdock.h
@@ -106,9 +106,10 @@ private slots:
     void layerRemoved(Layer *layer);
 
 private:
-    MapDocument *mMapDocument;
+    MapDocument *mMapDocument = nullptr;
     QAbstractProxyModel *mProxyModel;
-    bool mUpdatingSelectedLayers;
+    bool mUpdatingSelectedLayers = false;
+    bool mUpdatingViewSelection = false;
 };
 
 } // namespace Tiled

--- a/src/tiled/layermodel.cpp
+++ b/src/tiled/layermodel.cpp
@@ -410,7 +410,10 @@ void LayerModel::replaceLayer(Layer *layer, Layer *replacement)
     Q_ASSERT(layer->map() == mMapDocument->map());
     Q_ASSERT(!replacement->map());
 
-    auto currentLayer = mMapDocument->currentLayer();
+    auto selectedLayers = mMapDocument->selectedLayers();
+
+    const bool wasCurrentLayer = mMapDocument->currentLayer() == layer;
+    const int indexInSelectedLayers = selectedLayers.indexOf(layer);
 
     auto parentLayer = layer->parentLayer();
     auto index = layer->siblingIndex();
@@ -418,8 +421,13 @@ void LayerModel::replaceLayer(Layer *layer, Layer *replacement)
     takeLayerAt(parentLayer, index);
     insertLayer(parentLayer, index, replacement);
 
-    if (layer == currentLayer)
+    if (wasCurrentLayer)
         mMapDocument->setCurrentLayer(replacement);
+
+    if (indexInSelectedLayers != -1) {
+        selectedLayers.replace(indexInSelectedLayers, replacement);
+        mMapDocument->setSelectedLayers(selectedLayers);
+    }
 }
 
 void LayerModel::moveLayer(GroupLayer *parentLayer, int index, GroupLayer *toParentLayer, int toIndex)

--- a/src/tiled/mapdocument.h
+++ b/src/tiled/mapdocument.h
@@ -132,6 +132,9 @@ public:
     const QList<Layer*> &selectedLayers() const { return mSelectedLayers; }
     void setSelectedLayers(const QList<Layer*> &layers);
 
+    void switchCurrentLayer(Layer *layer);
+    void switchSelectedLayers(const QList<Layer*> &layers);
+
     /**
      * Resize this map to the given \a size, while at the same time shifting
      * the contents by \a offset. If \a removeObjects is true then all objects

--- a/src/tiled/mapdocumentactionhandler.cpp
+++ b/src/tiled/mapdocumentactionhandler.cpp
@@ -653,7 +653,7 @@ void MapDocumentActionHandler::layerVia(MapDocumentActionHandler::LayerViaVarian
         undoStack->endMacro();
     }
 
-    mMapDocument->setCurrentLayer(newLayer);
+    mMapDocument->switchCurrentLayer(newLayer);
 
     if (!newObjects.isEmpty())
         mMapDocument->setSelectedObjects(newObjects);
@@ -688,10 +688,8 @@ void MapDocumentActionHandler::selectPreviousLayer()
     if (!mMapDocument)
         return;
 
-    if (Layer *previousLayer = LayerIterator(mMapDocument->currentLayer()).previous()) {
-        mMapDocument->setCurrentLayer(previousLayer);
-        mMapDocument->setSelectedLayers({ previousLayer });
-    }
+    if (Layer *previousLayer = LayerIterator(mMapDocument->currentLayer()).previous())
+        mMapDocument->switchSelectedLayers({ previousLayer });
 }
 
 void MapDocumentActionHandler::selectNextLayer()
@@ -699,10 +697,8 @@ void MapDocumentActionHandler::selectNextLayer()
     if (!mMapDocument)
         return;
 
-    if (Layer *nextLayer = LayerIterator(mMapDocument->currentLayer()).next()) {
-        mMapDocument->setCurrentLayer(nextLayer);
-        mMapDocument->setSelectedLayers({ nextLayer });
-    }
+    if (Layer *nextLayer = LayerIterator(mMapDocument->currentLayer()).next())
+        mMapDocument->switchSelectedLayers({ nextLayer });
 }
 
 void MapDocumentActionHandler::moveLayersUp()

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -365,7 +365,7 @@ void MapEditor::addDocument(Document *document)
 
         int layerIndex = mapState.value(QLatin1String("selectedLayer")).toInt();
         if (Layer *layer = layerAtGlobalIndex(mapDocument->map(), layerIndex))
-            mapDocument->setCurrentLayer(layer);
+            mapDocument->switchCurrentLayer(layer);
     }
 }
 
@@ -800,7 +800,7 @@ void MapEditor::layerComboActivated()
     if (!layer)
         return;
 
-    mCurrentMapDocument->setCurrentLayer(layer);
+    mCurrentMapDocument->switchCurrentLayer(layer);
 }
 
 void MapEditor::updateLayerComboIndex()
@@ -960,12 +960,12 @@ void MapEditor::showTileCollisionShapesChanged(bool enabled)
         mapView->mapScene()->setShowTileCollisionShapes(enabled);
 }
 
-void MapEditor::setCurrentTileset(SharedTileset tileset)
+void MapEditor::setCurrentTileset(const SharedTileset &tileset)
 {
     mTilesetDock->setCurrentTileset(tileset);
 }
 
-Tileset *MapEditor::currentTileset()
+SharedTileset MapEditor::currentTileset() const
 {
     return mTilesetDock->currentTileset();
 }

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -960,4 +960,14 @@ void MapEditor::showTileCollisionShapesChanged(bool enabled)
         mapView->mapScene()->setShowTileCollisionShapes(enabled);
 }
 
+void MapEditor::setCurrentTileset(SharedTileset tileset)
+{
+    mTilesetDock->setCurrentTileset(tileset);
+}
+
+Tileset *MapEditor::currentTileset()
+{
+    return mTilesetDock->currentTileset();
+}
+
 } // namespace Tiled

--- a/src/tiled/mapeditor.h
+++ b/src/tiled/mapeditor.h
@@ -101,8 +101,8 @@ public:
 
     void showMessage(const QString &text, int timeout = 0);
 
-    void setCurrentTileset(SharedTileset tileset);
-    Tileset *currentTileset();
+    void setCurrentTileset(const SharedTileset &tileset);
+    SharedTileset currentTileset() const;
 
 public slots:
     void setSelectedTool(AbstractTool *tool);

--- a/src/tiled/mapeditor.h
+++ b/src/tiled/mapeditor.h
@@ -101,6 +101,9 @@ public:
 
     void showMessage(const QString &text, int timeout = 0);
 
+    void setCurrentTileset(SharedTileset tileset);
+    Tileset *currentTileset();
+
 public slots:
     void setSelectedTool(AbstractTool *tool);
 

--- a/src/tiled/objectsview.cpp
+++ b/src/tiled/objectsview.cpp
@@ -171,7 +171,7 @@ void ObjectsView::mousePressEvent(QMouseEvent *event)
 
     } else if (Layer *layer = mapObjectModel()->toLayer(index)) {
         mMapDocument->setCurrentObject(layer);
-        mMapDocument->setCurrentLayer(layer);
+        mMapDocument->switchSelectedLayers({ layer });
     }
 
     QTreeView::mousePressEvent(event);

--- a/src/tiled/reparentlayers.cpp
+++ b/src/tiled/reparentlayers.cpp
@@ -49,7 +49,9 @@ ReparentLayers::ReparentLayers(MapDocument *mapDocument,
 void ReparentLayers::undo()
 {
     auto layerModel = mMapDocument->layerModel();
-    auto currentLayer = mMapDocument->currentLayer();
+
+    const auto currentLayer = mMapDocument->currentLayer();
+    const auto selectedLayers = mMapDocument->selectedLayers();
 
     for (int i = mUndoInfo.size() - 1; i >= 0; --i) {
         auto& undoInfo = mUndoInfo.at(i);
@@ -62,12 +64,15 @@ void ReparentLayers::undo()
     mUndoInfo.clear();
 
     mMapDocument->setCurrentLayer(currentLayer);
+    mMapDocument->setSelectedLayers(selectedLayers);
 }
 
 void ReparentLayers::redo()
 {
     auto layerModel = mMapDocument->layerModel();
-    auto currentLayer = mMapDocument->currentLayer();
+
+    const auto currentLayer = mMapDocument->currentLayer();
+    const auto selectedLayers = mMapDocument->selectedLayers();
 
     Q_ASSERT(mUndoInfo.isEmpty());
     mUndoInfo.reserve(mLayers.size());
@@ -94,6 +99,7 @@ void ReparentLayers::redo()
     }
 
     mMapDocument->setCurrentLayer(currentLayer);
+    mMapDocument->setSelectedLayers(selectedLayers);
 }
 
 } // namespace Tiled

--- a/src/tiled/templatesdock.cpp
+++ b/src/tiled/templatesdock.cpp
@@ -237,7 +237,7 @@ void TemplatesDock::setTemplate(ObjectTemplate *objectTemplate)
 
             mDummyMapDocument = MapDocumentPtr::create(std::move(map));
             mDummyMapDocument->setAllowHidingObjects(false);
-            mDummyMapDocument->setCurrentLayer(objectGroup);
+            mDummyMapDocument->switchCurrentLayer(objectGroup);
 
             ourDummyDocuments.insert(objectTemplate, mDummyMapDocument);
         }

--- a/src/tiled/tilecollisiondock.cpp
+++ b/src/tiled/tilecollisiondock.cpp
@@ -295,8 +295,7 @@ void TileCollisionDock::setTile(Tile *tile)
         mDummyMapDocument = MapDocumentPtr::create(std::move(map));
         mDummyMapDocument->setAllowHidingObjects(false);
         mDummyMapDocument->setAllowTileObjects(false);
-        mDummyMapDocument->setCurrentLayer(objectGroup);
-        mDummyMapDocument->setSelectedLayers({objectGroup});
+        mDummyMapDocument->switchCurrentLayer(objectGroup);
 
         mMapScene->setMapDocument(mDummyMapDocument.data());
         mObjectsView->setMapDocument(mDummyMapDocument.data());
@@ -397,8 +396,7 @@ void TileCollisionDock::tileObjectGroupChanged(Tile *tile)
     objectGroup->setDrawOrder(ObjectGroup::IndexOrder);
 
     layerModel->insertLayer(nullptr, 1, objectGroup);
-    mDummyMapDocument->setCurrentLayer(objectGroup);
-    mDummyMapDocument->setSelectedLayers({objectGroup});
+    mDummyMapDocument->switchCurrentLayer(objectGroup);
     mObjectsView->setRootIndex(mObjectsView->layerViewIndex(objectGroup));
 
     mToolManager->selectTool(selectedTool);

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -832,6 +832,13 @@ void TilesetDock::tabContextMenuRequested(const QPoint &pos)
     menu.exec(mTabBar->mapToGlobal(pos));
 }
 
+void TilesetDock::setCurrentTileset(SharedTileset tileset)
+{
+    const int index = mTilesets.indexOf(tileset);
+    if (index != -1)
+        mTabBar->setCurrentIndex(index);
+}
+
 Tileset *TilesetDock::currentTileset() const
 {
     const int index = mTabBar->currentIndex();

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -832,20 +832,20 @@ void TilesetDock::tabContextMenuRequested(const QPoint &pos)
     menu.exec(mTabBar->mapToGlobal(pos));
 }
 
-void TilesetDock::setCurrentTileset(SharedTileset tileset)
+void TilesetDock::setCurrentTileset(const SharedTileset &tileset)
 {
     const int index = mTilesets.indexOf(tileset);
     if (index != -1)
         mTabBar->setCurrentIndex(index);
 }
 
-Tileset *TilesetDock::currentTileset() const
+SharedTileset TilesetDock::currentTileset() const
 {
     const int index = mTabBar->currentIndex();
     if (index == -1)
-        return nullptr;
+        return {};
 
-    return mTilesets.at(index).data();
+    return mTilesets.at(index);
 }
 
 TilesetView *TilesetDock::currentTilesetView() const
@@ -873,24 +873,24 @@ void TilesetDock::setupTilesetModel(TilesetView *view, Tileset *tileset)
 
 void TilesetDock::editTileset()
 {
-    Tileset *tileset = currentTileset();
+    auto tileset = currentTileset();
     if (!tileset)
         return;
 
     DocumentManager *documentManager = DocumentManager::instance();
-    documentManager->openTileset(tileset->sharedPointer());
+    documentManager->openTileset(tileset);
 }
 
 void TilesetDock::exportTileset()
 {
-    Tileset *tileset = currentTileset();
+    auto tileset = currentTileset();
     if (!tileset)
         return;
 
     if (tileset->isExternal())
         return;
 
-    int mapTilesetIndex = mMapDocument->map()->tilesets().indexOf(tileset->sharedPointer());
+    int mapTilesetIndex = mMapDocument->map()->tilesets().indexOf(tileset);
     if (mapTilesetIndex == -1)
         return;
 
@@ -952,7 +952,7 @@ void TilesetDock::exportTileset()
 
 void TilesetDock::embedTileset()
 {
-    Tileset *tileset = currentTileset();
+    auto tileset = currentTileset();
     if (!tileset)
         return;
 
@@ -964,7 +964,7 @@ void TilesetDock::embedTileset()
     SharedTileset embeddedTileset = tileset->clone();
 
     QUndoStack *undoStack = mMapDocument->undoStack();
-    int mapTilesetIndex = mMapDocument->map()->tilesets().indexOf(tileset->sharedPointer());
+    int mapTilesetIndex = mMapDocument->map()->tilesets().indexOf(tileset);
 
     // Tileset may not be part of the map yet
     if (mapTilesetIndex == -1)

--- a/src/tiled/tilesetdock.h
+++ b/src/tiled/tilesetdock.h
@@ -68,7 +68,7 @@ public:
      */
     TilesetDock(QWidget *parent = nullptr);
 
-    ~TilesetDock();
+    ~TilesetDock() override;
 
     /**
      * Sets the map for which the tilesets should be displayed.
@@ -80,8 +80,8 @@ public:
      */
     Tile *currentTile() const { return mCurrentTile; }
 
-    void setCurrentTileset(SharedTileset tileset);
-    Tileset *currentTileset() const;
+    void setCurrentTileset(const SharedTileset &tileset);
+    SharedTileset currentTileset() const;
 
     void selectTilesInStamp(const TileStamp &);
 

--- a/src/tiled/tilesetdock.h
+++ b/src/tiled/tilesetdock.h
@@ -80,6 +80,9 @@ public:
      */
     Tile *currentTile() const { return mCurrentTile; }
 
+    void setCurrentTileset(SharedTileset tileset);
+    Tileset *currentTileset() const;
+
     void selectTilesInStamp(const TileStamp &);
 
 signals:
@@ -146,7 +149,6 @@ private:
     void onTabMoved(int from, int to);
     void tabContextMenuRequested(const QPoint &pos);
 
-    Tileset *currentTileset() const;
     TilesetView *currentTilesetView() const;
     TilesetView *tilesetViewAt(int index) const;
 


### PR DESCRIPTION
I was working on #2065 and I added a method `setCurrentLayerByName` to `MapDocument` so that after `DocumentEditor` switches documents within a world, it can try to also change the layer to one with an identical name, as the original issue requested.

I was not able to reproduce the second request in the original issue. Changing the active tileset already persists between maps for me.