### PR TITLE
single JAXBContext instance for Tiles and AnimatedTiles

### DIFF
--- a/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapReader.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapReader.java
@@ -98,7 +98,10 @@ public class TMXMapReader {
     private TreeMap<Integer, TileSet> tilesetPerFirstGid;
     public final TMXMapReaderSettings settings = new TMXMapReaderSettings();
     private final HashMap<String, TileSet> cachedTilesets = new HashMap<>();
-
+  
+    private static JAXBContext tileContext;
+    private static JAXBContext animatedTileContext;
+    
     public static final class TMXMapReaderSettings {
 
         public boolean reuseCachedTilesets = false;
@@ -154,12 +157,9 @@ public class TMXMapReader {
         }
     }
 
-    
-    private JAXBContext tileContext;
-    private JAXBContext animatedTileContext;
-
     private <T> T unmarshalClass(Node node, Class<T> type) throws JAXBException {
         JAXBContext context;
+        
         if (type == Tile.class) {
             if (tileContext == null) tileContext = JAXBContext.newInstance(Tile.class);
             context = tileContext;

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapReader.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapReader.java
@@ -154,10 +154,21 @@ public class TMXMapReader {
         }
     }
 
-    private <T> T unmarshalClass(Node node, Class<T> type) throws JAXBException {
-        JAXBContext context = JAXBContext.newInstance(type);
-        Unmarshaller unmarshaller = context.createUnmarshaller();
+    
+    private JAXBContext tileContext;
+    private JAXBContext animatedTileContext;
 
+    private <T> T unmarshalClass(Node node, Class<T> type) throws JAXBException {
+        JAXBContext context;
+        if (type == Tile.class) {
+            context = (tileContext == null) ? JAXBContext.newInstance(Tile.class) : tileContext;
+        } else if (type == AnimatedTile.class) {
+            context = (animatedTileContext == null) ? JAXBContext.newInstance(AnimatedTile.class) : animatedTileContext;
+        } else {
+            context = JAXBContext.newInstance(type);
+        }
+        
+        Unmarshaller unmarshaller = context.createUnmarshaller();
         JAXBElement<T> element = unmarshaller.unmarshal(node, type);
         return element.getValue();
     }

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapReader.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapReader.java
@@ -161,9 +161,11 @@ public class TMXMapReader {
     private <T> T unmarshalClass(Node node, Class<T> type) throws JAXBException {
         JAXBContext context;
         if (type == Tile.class) {
-            context = (tileContext == null) ? JAXBContext.newInstance(Tile.class) : tileContext;
+            if (tileContext == null) tileContext = JAXBContext.newInstance(Tile.class);
+            context = tileContext;
         } else if (type == AnimatedTile.class) {
-            context = (animatedTileContext == null) ? JAXBContext.newInstance(AnimatedTile.class) : animatedTileContext;
+            if (animatedTileContext == null) animatedTileContext = JAXBContext.newInstance(AnimatedTile.class);
+            context = animatedTileContext;
         } else {
             context = JAXBContext.newInstance(type);
         }


### PR DESCRIPTION
Greatly increases loading time in case of a lot of tile properties.