### PR TITLE
Add possible renderorder values to spec

### DIFF
--- a/docs/reference/json-map-format.rst
+++ b/docs/reference/json-map-format.rst
@@ -37,7 +37,8 @@ Map
 +-------------------+----------+----------------------------------------------------------+
 | properties        | array    | A list of properties (name, value, type).                |
 +-------------------+----------+----------------------------------------------------------+
-| renderorder       | string   | Rendering direction (orthogonal maps only)               |
+| renderorder       | string   | ``right-down`` (the default), ``right-up``, ``left-down``|
+|                   |          | or ``left-up`` (orthogonal maps only)                    |
 +-------------------+----------+----------------------------------------------------------+
 | staggeraxis       | string   | ``x`` or ``y`` (staggered / hexagonal maps only)         |
 +-------------------+----------+----------------------------------------------------------+


### PR DESCRIPTION
This makes it easier to convert to an enum if generated classes from this spec.