### PR TITLE
Add "source" field for Tileset object

### DIFF
--- a/docs/reference/json-map-format.rst
+++ b/docs/reference/json-map-format.rst
@@ -475,6 +475,8 @@ Tileset
 +------------------+----------+-----------------------------------------------------+
 | properties       | array    | A list of properties (name, value, type).           |
 +------------------+----------+-----------------------------------------------------+
+| source           | string   | The external file that contains this tilesets data. |
++------------------+----------+-----------------------------------------------------+
 | spacing          | int      | Spacing between adjacent tiles in image (pixels)    |
 +------------------+----------+-----------------------------------------------------+
 | terrains         | array    | Array of :ref:`Terrains <json-terrain>` (optional)  |


### PR DESCRIPTION
If you reference an external tileset and then save as JSON, there's a `source` field but it's not mentioned in the docs (which means if you code-gen from the spec, you don't have it :-)).

I didn't copy the whole description of this from the XML spec as it'd get a bit messy in this table, but it miht be easier to do that if this file changes to using the CSV format.