### PR TITLE
Clarify the meaning of the "staggered" orientation

### DIFF
--- a/docs/reference/tmx-map-format.rst
+++ b/docs/reference/tmx-map-format.rst
@@ -73,6 +73,9 @@ the only type, and are simply called ``layer``, object layers have the
 order in which these layers appear is the order in which the layers are
 rendered by Tiled.
 
+The ``staggered`` orientation refers to an isometric map using staggered
+axes.
+
 Can contain: :ref:`tmx-properties`, :ref:`tmx-tileset`,
 :ref:`tmx-layer`, :ref:`tmx-objectgroup`,
 :ref:`tmx-imagelayer`, :ref:`tmx-group` (since 1.0)


### PR DESCRIPTION
There are three uses of staggered tiles: Staggered Isometric, Staggered Hexagonal, and Staggered Orthogonal (which is normal squares, but each tile has 6 neighbors instead of 9). So the name `staggered` could refer to either the Isometric or the Orthogonal meanings (hexagonal is clearly documented as using staggered axes in addition to the `staggered` orientation).