### PR TITLE
Add options to customize "MatchOutsideMap" behavior

### DIFF
--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -618,7 +618,8 @@ static bool layerMatchesConditions(const TileLayer &setLayer,
                                    const InputConditions &conditions,
                                    const QRegion &ruleRegion,
                                    const QPoint offset,
-                                   const AutoMapper::Options &options)
+                                   const AutoMapper::Options &options,
+                                   bool isMapInfinite)
 {
     const auto &listYes = conditions.listYes;
     const auto &listNo = conditions.listNo;
@@ -643,18 +644,21 @@ static bool layerMatchesConditions(const TileLayer &setLayer,
 
                 int xd = x + offset.x();
                 int yd = y + offset.y();
-                if (options.wrapBorder) {
-                    int width = setLayer.size().width();
-                    int height = setLayer.size().height();
-                    xd = (xd % width + width) % width;
-                    yd = (yd % height + height) % height;
-                } else if (options.overflowBorder) {
-                    if (xd < 0) xd = 0;
-                    else if (xd >= setLayer.size().width())
-                        xd = setLayer.size().width() - 1;
-                    if (yd < 0) yd = 0;
-                    else if (yd >= setLayer.size().height())
-                        yd = setLayer.size().height() - 1;
+
+                if (!isMapInfinite) {
+                    if (options.wrapBorder) {
+                        int width = setLayer.size().width();
+                        int height = setLayer.size().height();
+                        xd = (xd % width + width) % width;
+                        yd = (yd % height + height) % height;
+                    } else if (options.overflowBorder) {
+                        if (xd < 0) xd = 0;
+                        else if (xd >= setLayer.size().width())
+                            xd = setLayer.size().width() - 1;
+                        if (yd < 0) yd = 0;
+                        else if (yd >= setLayer.size().height())
+                            yd = setLayer.size().height() - 1;
+                    }
                 }
 
                 const Cell &setCell = setLayer.cellAt(xd, yd);
@@ -747,7 +751,7 @@ QRect AutoMapper::applyRule(int ruleIndex, const QRect &where)
                 const int i = mMapWork->indexOfLayer(name, Layer::TileLayerType);
                 const TileLayer &setLayer = (i >= 0) ? *mMapWork->layerAt(i)->asTileLayer() : dummy;
 
-                if (!layerMatchesConditions(setLayer, conditions, ruleInputRegion, QPoint(x, y), mOptions)) {
+                if (!layerMatchesConditions(setLayer, conditions, ruleInputRegion, QPoint(x, y), mOptions, mMapWork->infinite())) {
                     allLayerNamesMatch = false;
                     break;
                 }

--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -43,7 +43,7 @@
 using namespace Tiled;
 
 // Should i leave this function here?
-inline static int wrap(int value, int bound)
+static int wrap(int value, int bound)
 {
     return (value % bound + bound) % bound;
 }

--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -42,7 +42,6 @@
 
 using namespace Tiled;
 
-// Should i leave this function here?
 static int wrap(int value, int bound)
 {
     return (value % bound + bound) % bound;
@@ -657,8 +656,7 @@ static bool layerMatchesConditions(const TileLayer &setLayer,
                 int xd = x + offset.x();
                 int yd = y + offset.y();
 
-                if (!options.matchOutsideMap &&
-                        !setLayer.contains(xd, yd))
+                if (!options.matchOutsideMap && !setLayer.contains(xd, yd))
                     return false;
 
                 // Those two options are guaranteed to be false if the map is infinite,

--- a/src/tiled/automapper.cpp
+++ b/src/tiled/automapper.cpp
@@ -43,7 +43,8 @@
 using namespace Tiled;
 
 // Should i leave this function here?
-inline int wrap(int value, int bound) {
+inline static int wrap(int value, int bound)
+{
     return (value % bound + bound) % bound;
 }
 

--- a/src/tiled/automapper.h
+++ b/src/tiled/automapper.h
@@ -96,6 +96,18 @@ public:
         bool matchOutsideMap = true;
 
         /**
+         * If "matchOutsideMap" is true, treat the out-of-bounds tiles as if they
+         * were the nearest inbound tile possible
+         */
+        bool overflowBorder = false;
+
+        /**
+         * If "matchOutsideMap" is true, wrap the map in the edges to apply the
+         * automapping rules
+         */
+        bool wrapBorder = false;
+
+        /**
          * Determines if a rule is allowed to overlap itself.
          */
         bool noOverlappingRules = false;


### PR DESCRIPTION
I decided to edit Tiled's source code after viewing [this discussion about the behavior of automapping near the map's edges](https://discourse.mapeditor.org/t/automapper-ignore-the-empty-void-beyond-the-perimeter-of-map/) and I was not satified with the state of the art of automapping near the borders.

Normally, when you try to automap near the edges, the edges are seen as empty tiles, failing to apply, for example, Remex's auto-generated rules (the ones originated from RPG Maker):
![image](https://user-images.githubusercontent.com/13079799/59556438-d3b82980-8fc2-11e9-807a-e8d29156d446.png)

This pull request add two options (as map properties) to customize the behavior of automapping near the edges.
- **OverflowBorder**: this option makes the automapper treats the out-of-bounds areas of the map as if they were prolongations of the border tiles, thus applying the rules along the borders as if they used the same tiles as the nearest inbound tile. This is actually the default behavior of every RPG Maker since XP.
![image](https://user-images.githubusercontent.com/13079799/59556472-36a9c080-8fc3-11e9-927a-03aac9e293dc.png)
- **WrapBorder**: this option makes the automapper wrap the map around the edges, effectively applying the rules also to the other side of the border; this can be useful to create looped maps, to make it seamless around the borders:
![image](https://user-images.githubusercontent.com/13079799/59556501-af108180-8fc3-11e9-9a99-8f66ec73219b.png)

I coded those two features so that if both **OverflowBorder** and **WrapBorder** are true, **WrapBorder** takes precedence. And, of course, it will not work with infinite maps, since the notion of "border" in them has no sense.