### PR TITLE
Change documentation to reflect the addition of new features

### DIFF
--- a/docs/manual/automapping.rst
+++ b/docs/manual/automapping.rst
@@ -183,10 +183,39 @@ MatchOutsideMap
    region falls partially outside of a map. By default it is ``false`` for
    bounded maps and ``true`` for infinite maps. In some cases it can be useful
    to enable this also for bounded maps. Tiles outside of the map boundaries
-   are simply considered empty.
+   are simply considered empty unless one of either **OverflowBorder** or
+   **WrapBorder** are also true.
 
    Tiled 1.0 and 1.1 behaved as if this property was ``true``, whereas older
    versions of Tiled have behaved as if this property was ``false``.
+
+.. raw:: html
+
+   <div class="new">New in Tiled 1.3</div>
+
+OverflowBorder
+   This map property customizes the behavior intended by the **MatchOutsideMap**
+   property. When this property is ``true``, tiles outside of the map boundaries
+   are considered as if they were copies of the nearest inbound tiles, effectively
+   "overflowing" the map's borders to the outside region.
+
+   When that property is ``true``, it also implies **MatchOutsideMap**. Please note that
+   this property has no effect on infinite maps (since there is no notion of border).
+
+.. raw:: html
+
+   <div class="new">New in Tiled 1.3</div>
+
+WrapBorder
+   This map property customizes the behavior intended by the **MatchOutsideMap**
+   property. When this property is ``true``, the map effectively "wraps" around itself,
+   making tiles on one border of the map influence the regions on the other border and
+   vice versa.
+
+   When that property is ``true``, it also implies MatchOutsideMap. Please note that
+   this property has no effect on infinite maps (since there is no notion of border).
+   If both **WrapBorder** and **OverflowBorder** are ``true``, **WrapBorder** takes precedence
+   over **OverflowBorder**.
 
 NoOverlappingRules
    This map property is a boolean property:

--- a/docs/manual/automapping.rst
+++ b/docs/manual/automapping.rst
@@ -199,7 +199,7 @@ OverflowBorder
    are considered as if they were copies of the nearest inbound tiles, effectively
    "overflowing" the map's borders to the outside region.
 
-   When that property is ``true``, it also implies **MatchOutsideMap**. Please note that
+   When this property is ``true``, it implies **MatchOutsideMap**. Note that
    this property has no effect on infinite maps (since there is no notion of border).
 
 .. raw:: html
@@ -212,10 +212,11 @@ WrapBorder
    making tiles on one border of the map influence the regions on the other border and
    vice versa.
 
-   When that property is ``true``, it also implies MatchOutsideMap. Please note that
+   When this property is ``true``, it implies **MatchOutsideMap**. Note that
    this property has no effect on infinite maps (since there is no notion of border).
-   If both **WrapBorder** and **OverflowBorder** are ``true``, **WrapBorder** takes precedence
-   over **OverflowBorder**.
+
+   If both **WrapBorder** and **OverflowBorder** are ``true``, **WrapBorder** takes
+   precedence over **OverflowBorder**.
 
 NoOverlappingRules
    This map property is a boolean property:


### PR DESCRIPTION
This pull request add the features `OverflowBorder` and `WrapBorder` mentioned in #2141 to the automapping documentation. It should look like this:

![image](https://user-images.githubusercontent.com/13079799/59860935-25283600-9380-11e9-93e1-daaf5aec21a0.png)