### PR TITLE
Possibly fixes issue #44 -- Improves how file system watcher handles replaced files 

### DIFF
--- a/src/libtiled/filesystemwatcher.cpp
+++ b/src/libtiled/filesystemwatcher.cpp
@@ -100,8 +100,6 @@ void FileSystemWatcher::clear()
 
 void FileSystemWatcher::onFileChanged(const QString &path)
 {
-
-
     mChangedFiles.insert(path);
     mChangedFilesTimer.start();
 
@@ -115,19 +113,19 @@ void FileSystemWatcher::onDirectoryChanged(const QString &path)
 
 void FileSystemWatcher::filesChangedTimeout()
 {
-    emit filesChanged(mChangedFiles.toList());
+    const auto changedFiles = mChangedFiles.toList();
 
     // If the file was replaced, the watcher is automatically removed and needs
     // to be re-added to keep watching it for changes. This happens commonly
     // with applications that do atomic saving.
-    QSetIterator<QString> changedFilesIterator(mChangedFiles);
-    while (changedFilesIterator.hasNext()) {
-        QString path = changedFilesIterator.next();
-        if (!mWatcher->files().contains(path))
+    for (const QString &path : changedFiles) {
+        if (mWatchCount.contains(path) && !mWatcher->files().contains(path)) {
             if (QFile::exists(path))
                 mWatcher->addPath(path);
+        }
     }
 
+    emit filesChanged(changedFiles);
     mChangedFiles.clear();
 }
 

--- a/src/libtiled/filesystemwatcher.cpp
+++ b/src/libtiled/filesystemwatcher.cpp
@@ -100,12 +100,7 @@ void FileSystemWatcher::clear()
 
 void FileSystemWatcher::onFileChanged(const QString &path)
 {
-    // If the file was replaced, the watcher is automatically removed and needs
-    // to be re-added to keep watching it for changes. This happens commonly
-    // with applications that do atomic saving.
-    if (!mWatcher->files().contains(path))
-        if (QFile::exists(path))
-            mWatcher->addPath(path);
+
 
     mChangedFiles.insert(path);
     mChangedFilesTimer.start();
@@ -121,6 +116,18 @@ void FileSystemWatcher::onDirectoryChanged(const QString &path)
 void FileSystemWatcher::filesChangedTimeout()
 {
     emit filesChanged(mChangedFiles.toList());
+
+    // If the file was replaced, the watcher is automatically removed and needs
+    // to be re-added to keep watching it for changes. This happens commonly
+    // with applications that do atomic saving.
+    QSetIterator<QString> changedFilesIterator(mChangedFiles);
+    while (changedFilesIterator.hasNext()) {
+        QString path = changedFilesIterator.next();
+        if (!mWatcher->files().contains(path))
+            if (QFile::exists(path))
+                mWatcher->addPath(path);
+    }
+
     mChangedFiles.clear();
 }
 


### PR DESCRIPTION
It appears that when this bug  ( https://github.com/bjorn/tiled/issues/44 ) happens, the watcher starts handling the filesystem change before the file actually gets recreated. So the new version of the file doesn't exist, and never gets added back to the watcher.

This PR moves the functionality of re-adding the file to the watcher into the timeout handler. In my tests, this gives it enough time for the file to exist again, and thus gets re-added.

I'm not well-versed in QT, so if I should be handling the iteration with a different type of Iterator, or use a different style here, please let me know.