### PR TITLE
Link zstd static library instead of dynamic library on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,6 @@ build_script:
   - cd zstd/lib
   - set CC=gcc
   - mingw32-make -j2 libzstd.a
-  - ls -lR
   - cd ../../
   - qbs --version
   - qbs setup-toolchains --detect

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,8 @@ build_script:
   - git clone --depth 1 -b master https://github.com/facebook/zstd.git
   - cd zstd/lib
   - set CC=gcc
-  - mingw32-make -j2
+  - mingw32-make -j2 lib-release
+  - ls -lR .
   - cd ../../
   - qbs --version
   - qbs setup-toolchains --detect

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,8 +44,9 @@ build_script:
   - git clone --depth 1 -b master https://github.com/facebook/zstd.git
   - cd zstd/lib
   - set CC=gcc
-  - mingw32-make -j2 lib-release
-  - ls -lR .
+  - mingw32-make -j2 lib-zstd.a
+  - rm dll/libzstd.dll dll/libzstd.lib
+  - ls -l dll
   - cd ../../
   - qbs --version
   - qbs setup-toolchains --detect

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,7 @@ build_script:
   - cd zstd/lib
   - set CC=gcc
   - mingw32-make -j2 libzstd.a
-  - ls -l dll
+  - ls -lR
   - cd ../../
   - qbs --version
   - qbs setup-toolchains --detect

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,6 @@ build_script:
   - cd zstd/lib
   - set CC=gcc
   - mingw32-make -j2 libzstd.a
-  - rm dll/libzstd.dll dll/libzstd.lib
   - ls -l dll
   - cd ../../
   - qbs --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ build_script:
   - git clone --depth 1 -b master https://github.com/facebook/zstd.git
   - cd zstd/lib
   - set CC=gcc
-  - mingw32-make -j2 lib-zstd.a
+  - mingw32-make -j2 libzstd.a
   - rm dll/libzstd.dll dll/libzstd.lib
   - ls -l dll
   - cd ../../

--- a/src/libtiled/libtiled.qbs
+++ b/src/libtiled/libtiled.qbs
@@ -149,10 +149,7 @@ DynamicLibrary {
             submodules: ["gui"]
         }
 
-        cpp.includePaths: [
-            ".",
-            "../../zstd/lib"
-        ]
+        cpp.includePaths: "."
     }
 
     Group {

--- a/src/libtiled/libtiled.qbs
+++ b/src/libtiled/libtiled.qbs
@@ -11,12 +11,6 @@ DynamicLibrary {
         cpp.dynamicLibraries: base.concat(["z"])
     }
 
-    Properties {
-        condition: qbs.toolchain.contains("mingw") && project.enableZstd
-        cpp.staticLibraries: ["libzstd"]
-        cpp.libraryPaths: ["../../zstd/lib/dll"]
-    }
-
     cpp.cxxLanguageVersion: "c++14"
     cpp.visibility: "minimal"
     cpp.defines: {
@@ -42,7 +36,7 @@ DynamicLibrary {
     }
 
     Properties {
-        condition: qbs.targetOS.contains("macos") && project.enableZstd
+        condition: project.enableZstd
         cpp.staticLibraries: ["zstd"]
         cpp.libraryPaths: ["../../zstd/lib"]
     }


### PR DESCRIPTION
For some reason, cpp.staticLibraries also looks for dynamic libraries. Made it so that the dynamic library does not get build on windows, so it cannot be linked. Turns out that there's no need to differentiate between platforms anymore.