### PR TITLE
Travis CI: Compile only the static libzstd.a for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,7 @@ matrix:
     - source ./dist/linux/setup-qbs.sh
     - git clone --depth 1 -b master https://github.com/facebook/zstd.git
     - cd zstd/lib
-    - make
+    - make libzstd.a
     - cd ../../
     script:
     - qbs --version


### PR DESCRIPTION
Attempt to fix issue #2174.