### PR TITLE
Add technical details for font display

### DIFF
--- a/docs/reference/tmx-map-format.rst
+++ b/docs/reference/tmx-map-format.rst
@@ -587,6 +587,16 @@ object.
 Used to mark an object as a text object. Contains the actual text as
 character data.
 
+For alignment purposes, the bottom of the text is the descender height of
+the font, and the top of the text is the ascent height of the font. For
+example, ``bottom`` alignment of the word "cat" will leave some space below
+the text, even though it is unused for this word with most fonts. Similarly,
+``top`` alignment of the word "cat" will leave some space above the "t" with
+most fonts, because this space is used for diacritics.
+
+If the text is larger than the object's bounds, it is clipped to the bounds
+of the object.
+
 .. _tmx-imagelayer:
 
 <imagelayer>

--- a/docs/reference/tmx-map-format.rst
+++ b/docs/reference/tmx-map-format.rst
@@ -588,7 +588,7 @@ Used to mark an object as a text object. Contains the actual text as
 character data.
 
 For alignment purposes, the bottom of the text is the descender height of
-the font, and the top of the text is the ascent height of the font. For
+the font, and the top of the text is the ascender height of the font. For
 example, ``bottom`` alignment of the word "cat" will leave some space below
 the text, even though it is unused for this word with most fonts. Similarly,
 ``top`` alignment of the word "cat" will leave some space above the "t" with


### PR DESCRIPTION
Explain in detail how fonts are laid out in the object. Also note in the documentation that fonts are clipped outside of the bounds of their object.

These details were determined from how Tiled handles text objects.

For a quick explanation of font terminology, see this image: https://i.stack.imgur.com/ntg5f.png