### PR TITLE
Fix build warnings on macOS with Qt 5.13.1

### DIFF
--- a/src/libtiled/logginginterface.h
+++ b/src/libtiled/logginginterface.h
@@ -48,8 +48,9 @@ class Object;
 class Tile;
 class Tileset;
 
-struct TILEDSHARED_EXPORT Issue
+class TILEDSHARED_EXPORT Issue
 {
+public:
     enum Severity {
         Error,
         Warning

--- a/src/libtiled/tileset.cpp
+++ b/src/libtiled/tileset.cpp
@@ -514,7 +514,11 @@ Terrain *Tileset::takeTerrainAt(int index)
  */
 void Tileset::swapTerrains(int index, int swapIndex)
 {
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
     mTerrainTypes.swap(index, swapIndex);
+#else
+    mTerrainTypes.swapItemsAt(index, swapIndex);
+#endif
 
     // Reassign terrain IDs
     mTerrainTypes.at(index)->mId = index;

--- a/src/libtiled/wangset.cpp
+++ b/src/libtiled/wangset.cpp
@@ -593,7 +593,7 @@ void WangSet::removeWangTile(const WangTile &wangTile)
 QList<WangTile> WangSet::sortedWangTiles() const
 {
     QList<WangTile> wangTiles = mWangIdToWangTile.values();
-    qStableSort(wangTiles.begin(), wangTiles.end());
+    std::stable_sort(wangTiles.begin(), wangTiles.end());
     return wangTiles;
 }
 

--- a/src/tiled/changepolygon.h
+++ b/src/tiled/changepolygon.h
@@ -97,7 +97,6 @@ private:
     std::unique_ptr<AddMapObjects> mAddSecondPolyline;
 
     int mEdgeIndex;
-    int mObjectIndex;
     bool mOldChangeState;
 };
 

--- a/src/tiled/commanddatamodel.cpp
+++ b/src/tiled/commanddatamodel.cpp
@@ -486,7 +486,11 @@ bool CommandDataModel::move(int commandIndex, int newIndex)
 
     if (commandIndex - newIndex == 1 || newIndex - commandIndex == 1)
         // Swapping is probably more efficient than removing/inserting
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
         mCommands.swap(commandIndex, newIndex);
+#else
+        mCommands.swapItemsAt(commandIndex, newIndex);
+#endif
     else {
         const Command command = mCommands.at(commandIndex);
         mCommands.removeAt(commandIndex);

--- a/src/tiled/tiledproxystyle.cpp
+++ b/src/tiled/tiledproxystyle.cpp
@@ -123,7 +123,7 @@ static void qt_fusion_draw_arrow(Qt::ArrowType type, QPainter *painter, const QS
     QString cacheKey = uniqueName(QLatin1String("fusion-arrow"), option, rect.size())
             % HexString<uint>(type)
             % HexString<uint>(color.rgba());
-    if (!QPixmapCache::find(cacheKey, cachePixmap)) {
+    if (!QPixmapCache::find(cacheKey, &cachePixmap)) {
         cachePixmap = styleCachePixmap(rect.size());
         cachePixmap.fill(Qt::transparent);
         QPainter cachePainter(&cachePixmap);
@@ -370,7 +370,7 @@ void TiledProxyStyle::drawPrimitive(PrimitiveElement element,
             int state = option->state;
 
             QColor pressedColor = mergedColors(option->palette.base().color(),
-                                               option->palette.foreground().color(), 85);
+                                               option->palette.windowText().color(), 85);
             painter->setBrush(Qt::NoBrush);
 
             // Gradient fill
@@ -878,7 +878,7 @@ void TiledProxyStyle::drawComplexControl(ComplexControl control,
             QColor alphaOutline = outline;
             alphaOutline.setAlpha(180);
 
-            QColor arrowColor = option->palette.foreground().color();
+            QColor arrowColor = option->palette.windowText().color();
             arrowColor.setAlpha(220);
 
             const QColor bgColor = mPalette.color(QPalette::Base);


### PR DESCRIPTION
- src/libtiled/tileset.cpp:517:19: warning: 'swap' is deprecated: Use QList<T>::swapItemsAt() [-Wdeprecated-declarations]
- src/libtiled/wangset.cpp:596:5: warning: 'qStableSort<QList<Tiled::WangTile>::iterator>' is deprecated: Use std::stable_sort [-Wdeprecated-declarations]
- src/libtiled/logginginterface.h:51:1: warning: 'Issue' defined as a struct here but previously declared as a class [-Wmismatched-tags]
- src/tiled/commanddatamodel.cpp:489:19: warning: 'swap' is deprecated: Use QList<T>::swapItemsAt() [-Wdeprecated-declarations]
- src/tiled/changepolygon.h:100:9: warning: private field 'mObjectIndex' is not used [-Wunused-private-field]
- src/tiled/tiledproxystyle.cpp:126:24: warning: 'find' is deprecated: Use bool find(const QString &, QPixmap *) instead [-Wdeprecated-declarations]
- src/tiled/tiledproxystyle.cpp:373:64: warning: 'foreground' is deprecated: Use QPalette::windowText() instead [-Wdeprecated-declarations]
- src/tiled/tiledproxystyle.cpp:881:49: warning: 'foreground' is deprecated: Use QPalette::windowText() instead [-Wdeprecated-declarations]
- src/libtiled/logginginterface.h:51:1: warning: 'Issue' defined as a struct here but previously declared as a class [-Wmismatched-tags]
- src/tiled/issuesdock.h:31:1: warning: class 'Issue' was previously declared as a struct [-Wmismatched-tags]