### PR TITLE
libtiled-java - Tiled editor parity

### DIFF
--- a/util/java/libtiled-java/src/main/java/org/mapeditor/core/MapObject.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/core/MapObject.java
@@ -59,6 +59,9 @@ public class MapObject extends MapObjectData implements Cloneable {
     private Image image;
     private Image scaledImage;
     private Tile tile;
+    private boolean flipHorizontal;
+    private boolean flipVertical;
+    private boolean flipDiagonal;
 
     /**
      * <p>Constructor for MapObject.</p>
@@ -66,9 +69,11 @@ public class MapObject extends MapObjectData implements Cloneable {
     public MapObject() {
         super();
         this.properties = new Properties();
-        this.name = "Object";
+        this.name = "";
         this.type = "";
         this.imageSource = "";
+        this.flipHorizontal = false;
+        this.flipVertical = false;
     }
 
     /**
@@ -207,6 +212,15 @@ public class MapObject extends MapObjectData implements Cloneable {
     public void setTile(Tile tile) {
         this.tile = tile;
     }
+
+    public boolean getFlipHorizontal() { return flipHorizontal; }
+    public void setFlipHorizontal(boolean flip) { this.flipHorizontal = flip; }
+
+    public boolean getFlipVertical() { return flipVertical; }
+    public void setFlipVertical(boolean flip) { this.flipVertical = flip; }
+
+    public boolean getFlipDiagonal() { return flipDiagonal; }
+    public void setFlipDiagonal(boolean flip) { this.flipDiagonal = flip; }
 
     /**
      * Returns the image to be used when drawing this object. This image is

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/core/TileLayer.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/core/TileLayer.java
@@ -534,7 +534,7 @@ public class TileLayer extends TileLayerData {
      * @param y Tile-space y coordinate
      * @return <code>true</code> if tile at (x, y) is flipped horizontally
      */
-    public boolean isFlippedHorizontaly(int x, int y) {
+    public boolean isFlippedHorizontally(int x, int y) {
         return getBounds().contains(x, y) &&
                 (flags[y][x] & (int)TMXMapReader.FLIPPED_HORIZONTALLY_FLAG) != 0;
     }
@@ -558,7 +558,7 @@ public class TileLayer extends TileLayerData {
      * @param y Tile-space y coordinate
      * @return <code>true</code> if tile at (x, y) is flipped diagonally
      */
-    public boolean isFlippedDiagonaly(int x, int y) {
+    public boolean isFlippedDiagonally(int x, int y) {
         return getBounds().contains(x, y) &&
                 (flags[y][x] & (int)TMXMapReader.FLIPPED_DIAGONALLY_FLAG) != 0;
     }

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapReader.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapReader.java
@@ -530,10 +530,7 @@ public class TMXMapReader {
             g.setLocked(1);
         }
 
-        g.getGroup().clear();
-        g.getLayer().clear();
-        g.getObjectgroup().clear();
-        g.getImagelayer();
+        g.getLayers().clear();
 
         // Load the layers and objectgroups
         for (Node sibs = t.getFirstChild(); sibs != null;
@@ -541,22 +538,22 @@ public class TMXMapReader {
             if ("group".equals(sibs.getNodeName())) {
                 Group group = unmarshalGroup(sibs);
                 if (group != null) {
-                    g.getGroup().add(group);
+                    g.getLayers().add(group);
                 }
             } else if ("layer".equals(sibs.getNodeName())) {
                 TileLayer layer = readLayer(sibs);
                 if (layer != null) {
-                    g.getLayer().add(layer);
+                    g.getLayers().add(layer);
                 }
             } else if ("objectgroup".equals(sibs.getNodeName())) {
                 ObjectGroup group = unmarshalObjectGroup(sibs);
                 if (group != null) {
-                    g.getObjectgroup().add(group);
+                    g.getLayers().add(group);
                 }
             } else if ("imagelayer".equals(sibs.getNodeName())) {
                 ImageLayer imageLayer = unmarshalImageLayer(sibs);
                 if (imageLayer != null) {
-                    g.getImagelayer().add(imageLayer);
+                    g.getLayers().add(imageLayer);
                 }
             }
         }
@@ -820,7 +817,7 @@ public class TMXMapReader {
             map.addTileset(tileset);
         }
 
-        // Load the layers and objectgroups
+        // Load the layers and groups
         for (Node sibs = mapNode.getFirstChild(); sibs != null;
                 sibs = sibs.getNextSibling()) {
             if ("group".equals(sibs.getNodeName())) {

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapReader.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapReader.java
@@ -629,19 +629,6 @@ public class TMXMapReader {
                             String gid = csvTileIds[x + y * ml.getWidth()];
                             long tileId = Long.parseLong(gid);
 
-                            if (tileId > Integer.MAX_VALUE) {
-                                // Read out the flags
-                                // TODO: Save these flags somewhere
-                                long flippedHorizontally = tileId & FLIPPED_HORIZONTALLY_FLAG;
-                                long flippedVertically = tileId & FLIPPED_VERTICALLY_FLAG;
-                                long flippedDiagonally = tileId & FLIPPED_DIAGONALLY_FLAG;
-
-                                // Clear the flags
-                                tileId &= ~(FLIPPED_HORIZONTALLY_FLAG
-                                        | FLIPPED_VERTICALLY_FLAG
-                                        | FLIPPED_DIAGONALLY_FLAG);
-                            }
-
                             setTileAtFromTileId(ml, y, x, (int) tileId);
                         }
                     }

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapReader.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapReader.java
@@ -79,9 +79,9 @@ import org.xml.sax.SAXException;
  */
 public class TMXMapReader {
 
-    public static long FLIPPED_HORIZONTALLY_FLAG = 0xFFFFFFFF80000000L;
-    public static long FLIPPED_VERTICALLY_FLAG = 0xFFFFFFFF40000000L;
-    public static long FLIPPED_DIAGONALLY_FLAG = 0xFFFFFFFF20000000L;
+    public static long FLIPPED_HORIZONTALLY_FLAG =  0x0000000080000000L;
+    public static long FLIPPED_VERTICALLY_FLAG =    0x0000000040000000L;
+    public static long FLIPPED_DIAGONALLY_FLAG =    0x0000000020000000L;
 
     public static long ALL_FLAGS = FLIPPED_HORIZONTALLY_FLAG
             | FLIPPED_VERTICALLY_FLAG
@@ -357,12 +357,15 @@ public class TMXMapReader {
         }
         if (gid != null) {
             long tileId = Long.parseLong(gid);
-            if (tileId > Integer.MAX_VALUE) {
+            if ((tileId & ALL_FLAGS) != 0) {
                 // Read out the flags
-                // TODO: Save these flags somewhere
                 long flippedHorizontally = tileId & FLIPPED_HORIZONTALLY_FLAG;
                 long flippedVertically = tileId & FLIPPED_VERTICALLY_FLAG;
                 long flippedDiagonally = tileId & FLIPPED_DIAGONALLY_FLAG;
+
+                obj.setFlipHorizontal(flippedHorizontally != 0);
+                obj.setFlipVertical(flippedVertically != 0);
+                obj.setFlipDiagonal(flippedDiagonally != 0);
 
                 // Clear the flags
                 tileId &= ~(FLIPPED_HORIZONTALLY_FLAG

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapReader.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapReader.java
@@ -33,6 +33,7 @@ package org.mapeditor.io;
 import java.awt.Color;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Path2D;
+import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
@@ -408,6 +409,8 @@ public class TMXMapReader {
                 shape.closePath();
                 obj.setShape(shape);
                 obj.setBounds((Rectangle2D.Double) shape.getBounds2D());
+            } else if ("point".equalsIgnoreCase(child.getNodeName())) {
+                obj.setPoint(new Point());
             }
         }
 
@@ -508,6 +511,11 @@ public class TMXMapReader {
         final int offsetY = getAttribute(t, "y", 0);
         og.setOffset(offsetX, offsetY);
 
+        final int locked = getAttribute(t, "locked", 0);
+        if (locked != 0) {
+            og.setLocked(1);
+        }
+
         // Manually parse the objects in object group
         og.getObjects().clear();
 
@@ -542,10 +550,13 @@ public class TMXMapReader {
      * @throws Exception
      */
     private TileLayer readLayer(Node t) throws Exception {
+        final int layerId = getAttribute(t, "id", 0);
         final int layerWidth = getAttribute(t, "width", map.getWidth());
         final int layerHeight = getAttribute(t, "height", map.getHeight());
 
         TileLayer ml = new TileLayer(layerWidth, layerHeight);
+
+        ml.setId(layerId);
 
         final int offsetX = getAttribute(t, "x", 0);
         final int offsetY = getAttribute(t, "y", 0);
@@ -681,6 +692,11 @@ public class TMXMapReader {
         // todo: Shouldn't this be just a user interface feature, rather than
         // todo: something to keep in mind at this level?
         ml.setVisible(visible == 1);
+
+        final int locked = getAttribute(t, "locked", 0);
+        if (locked != 0) {
+            ml.setLocked(1);
+        }
 
         return ml;
     }

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapReader.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapReader.java
@@ -334,6 +334,7 @@ public class TMXMapReader {
     }
 
     private MapObject readMapObject(Node t) throws Exception {
+        final int id = getAttribute(t, "id", 0);
         final String name = getAttributeValue(t, "name");
         final String type = getAttributeValue(t, "type");
         final String gid = getAttributeValue(t, "gid");
@@ -345,6 +346,9 @@ public class TMXMapReader {
 
         MapObject obj = new MapObject(x, y, width, height, rotation);
         obj.setShape(obj.getBounds());
+        if (id != 0) {
+            obj.setId(id);
+        }
         if (name != null) {
             obj.setName(name);
         }

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapWriter.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapWriter.java
@@ -56,6 +56,7 @@ import org.mapeditor.core.MapLayer;
 import org.mapeditor.core.Map;
 import org.mapeditor.core.MapObject;
 import org.mapeditor.core.ObjectGroup;
+import org.mapeditor.core.Group;
 import org.mapeditor.core.Orientation;
 import org.mapeditor.core.Properties;
 import org.mapeditor.core.Sprite;
@@ -219,9 +220,36 @@ public class TMXMapWriter {
                 writeMapLayer((TileLayer) layer, w, wp);
             } else if (layer instanceof ObjectGroup) {
                 writeObjectGroup((ObjectGroup) layer, w, wp);
+            } else if (layer instanceof Group) {
+                writeGroup((Group) layer, w, wp);
             }
         }
         firstGidPerTileset = null;
+
+        w.endElement();
+    }
+
+    private void writeGroup(Group group, XMLWriter w, String wp) throws IOException {
+        w.startElement("group");
+
+        if (group.getColor() != null && group.getColor().isEmpty()) {
+            w.writeAttribute("color", group.getColor());
+        }
+        if (group.getDraworder() != null && !group.getDraworder().equalsIgnoreCase("topdown")) {
+            w.writeAttribute("draworder", group.getDraworder());
+        }
+        writeLayerAttributes(group, w);
+        writeProperties(group.getProperties(), w);
+
+        for (MapLayer layer : group.getLayers()) {
+            if (layer instanceof TileLayer) {
+                writeMapLayer((TileLayer) layer, w, wp);
+            } else if (layer instanceof ObjectGroup) {
+                writeObjectGroup((ObjectGroup) layer, w, wp);
+            } else if (layer instanceof Group) {
+                writeGroup((Group) layer, w, wp);
+            } // TODO: Image Layer writing
+        }
 
         w.endElement();
     }

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapWriter.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapWriter.java
@@ -571,7 +571,10 @@ public class TMXMapWriter {
             throws IOException {
         w.startElement("object");
         w.writeAttribute("id", mapObject.getId());
-        w.writeAttribute("name", mapObject.getName());
+
+        if (!mapObject.getName().isEmpty()) {
+            w.writeAttribute("name", mapObject.getName());
+        }
 
         if (mapObject.getType().length() != 0) {
             w.writeAttribute("type", mapObject.getType());

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapWriter.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapWriter.java
@@ -570,6 +570,7 @@ public class TMXMapWriter {
     private void writeMapObject(MapObject mapObject, XMLWriter w, String wp)
             throws IOException {
         w.startElement("object");
+        w.writeAttribute("id", mapObject.getId());
         w.writeAttribute("name", mapObject.getName());
 
         if (mapObject.getType().length() != 0) {

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapWriter.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapWriter.java
@@ -175,17 +175,26 @@ public class TMXMapWriter {
     }
 
     private void writeMap(Map map, XMLWriter w, String wp) throws IOException {
-        w.writeDocType("map", null, "http://mapeditor.org/dtd/1.0/map.dtd");
+//        w.writeDocType("map", null, "http://mapeditor.org/dtd/1.0/map.dtd");
         w.startElement("map");
 
-        w.writeAttribute("version", "1.0");
+        w.writeAttribute("version", "1.2");
+
+        if (!map.getTiledversion().isEmpty()) {
+            w.writeAttribute("tiledversion", map.getTiledversion());
+        }
 
         Orientation orientation = map.getOrientation();
         w.writeAttribute("orientation", orientation.value());
+        w.writeAttribute("renderorder", map.getRenderorder().value());
         w.writeAttribute("width", map.getWidth());
         w.writeAttribute("height", map.getHeight());
         w.writeAttribute("tilewidth", map.getTileWidth());
         w.writeAttribute("tileheight", map.getTileHeight());
+        w.writeAttribute("infinite", map.getInfinite());
+
+        w.writeAttribute("nextlayerid", map.getNextlayerid());
+        w.writeAttribute("nextobjectid", map.getNextobjectid());
 
         switch (orientation) {
             case HEXAGONAL:
@@ -376,6 +385,9 @@ public class TMXMapWriter {
      */
     private void writeLayerAttributes(MapLayer l, XMLWriter w) throws IOException {
         Rectangle bounds = l.getBounds();
+
+        w.writeAttribute("id", l.getId());
+
         w.writeAttribute("name", l.getName());
         if (l instanceof TileLayer) {
             if (bounds.width != 0) {
@@ -406,6 +418,10 @@ public class TMXMapWriter {
         }
         if (l.getOffsetY() != null && l.getOffsetY() != 0) {
             w.writeAttribute("offsety", l.getOffsetY());
+        }
+
+        if (l.getLocked() != null && l.getLocked() != 0) {
+            w.writeAttribute("locked", l.getLocked());
         }
     }
 
@@ -572,24 +588,6 @@ public class TMXMapWriter {
         w.startElement("object");
         w.writeAttribute("id", mapObject.getId());
 
-        if (!mapObject.getName().isEmpty()) {
-            w.writeAttribute("name", mapObject.getName());
-        }
-
-        if (mapObject.getType().length() != 0) {
-            w.writeAttribute("type", mapObject.getType());
-        }
-
-        w.writeAttribute("x", mapObject.getX());
-        w.writeAttribute("y", mapObject.getY());
-
-        if (mapObject.getWidth() != 0) {
-            w.writeAttribute("width", mapObject.getWidth());
-        }
-        if (mapObject.getHeight() != 0) {
-            w.writeAttribute("height", mapObject.getHeight());
-        }
-
         long gid = 0;
         if (mapObject.getTile() != null) {
             Tile t = mapObject.getTile();
@@ -610,7 +608,35 @@ public class TMXMapWriter {
             gid |= TMXMapReader.FLIPPED_DIAGONALLY_FLAG;
         }
 
-        w.writeAttribute("gid", gid);
+        if (gid != 0) {
+            w.writeAttribute("gid", gid);
+        }
+
+        if (!mapObject.getName().isEmpty()) {
+            w.writeAttribute("name", mapObject.getName());
+        }
+
+        if (mapObject.getType().length() != 0) {
+            w.writeAttribute("type", mapObject.getType());
+        }
+
+        w.writeAttribute("x", mapObject.getX());
+        w.writeAttribute("y", mapObject.getY());
+
+        // TODO: Implement Polygon, Ellipse & Polyline too
+        boolean isPoint = mapObject.getPoint() != null;
+        if (isPoint) {
+            w.startElement("point");
+            w.endElement();
+        }
+        else {
+            if (mapObject.getWidth() != 0) {
+                w.writeAttribute("width", mapObject.getWidth());
+            }
+            if (mapObject.getHeight() != 0) {
+                w.writeAttribute("height", mapObject.getHeight());
+            }
+        }
 
         if (mapObject.getRotation() != 0) {
             w.writeAttribute("rotation", mapObject.getRotation());

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapWriter.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapWriter.java
@@ -469,6 +469,7 @@ public class TMXMapWriter {
 
                     if (tile != null) {
                         gid = getGid(tile);
+                        gid |= tl.getFlagsAt(x, y);
                     }
 
                     out.write(gid & LAST_BYTE);

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapWriter.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapWriter.java
@@ -590,12 +590,27 @@ public class TMXMapWriter {
             w.writeAttribute("height", mapObject.getHeight());
         }
 
+        long gid = 0;
         if (mapObject.getTile() != null) {
             Tile t = mapObject.getTile();
-            w.writeAttribute("gid", firstGidPerTileset.get(t.getTileSet()) + t.getId());
+            gid = firstGidPerTileset.get(t.getTileSet()) + t.getId();
         } else if (mapObject.getGid() != null) {
-            w.writeAttribute("gid", mapObject.getGid());
+            gid = mapObject.getGid();
         }
+
+        if (mapObject.getFlipHorizontal()) {
+            gid |= TMXMapReader.FLIPPED_HORIZONTALLY_FLAG;
+        }
+
+        if (mapObject.getFlipVertical()) {
+            gid |= TMXMapReader.FLIPPED_VERTICALLY_FLAG;
+        }
+
+        if (mapObject.getFlipDiagonal()) {
+            gid |= TMXMapReader.FLIPPED_DIAGONALLY_FLAG;
+        }
+
+        w.writeAttribute("gid", gid);
 
         if (mapObject.getRotation() != 0) {
             w.writeAttribute("rotation", mapObject.getRotation());

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapWriter.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/io/TMXMapWriter.java
@@ -594,6 +594,10 @@ public class TMXMapWriter {
             w.writeAttribute("gid", mapObject.getGid());
         }
 
+        if (mapObject.getRotation() != 0) {
+            w.writeAttribute("rotation", mapObject.getRotation());
+        }
+
         writeProperties(mapObject.getProperties(), w);
 
         if (mapObject.getImageSource().length() > 0) {

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/io/xml/XMLWriter.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/io/xml/XMLWriter.java
@@ -270,7 +270,14 @@ public class XMLWriter {
      */
     public void writeAttribute(String name, double content)
             throws IOException, XMLWriterException {
-        writeAttribute(name, String.valueOf(content));
+        //TODO: Tiled omits the decimals if it's '.0' so this is for parity
+        long longContent = (long)content;
+        if (longContent == content) {
+            writeAttribute(name, String.valueOf(longContent));
+        }
+        else {
+            writeAttribute(name, String.valueOf(content));
+        }
     }
 
     /**

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/io/xml/XMLWriter.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/io/xml/XMLWriter.java
@@ -238,6 +238,19 @@ public class XMLWriter {
      * <p>writeAttribute.</p>
      *
      * @param name a {@link java.lang.String} object.
+     * @param content a long.
+     * @throws java.io.IOException if any.
+     * @throws org.mapeditor.io.xml.XMLWriterException if any.
+     */
+    public void writeAttribute(String name, long content)
+            throws IOException, XMLWriterException {
+        writeAttribute(name, String.valueOf(content));
+    }
+
+    /**
+     * <p>writeAttribute.</p>
+     *
+     * @param name a {@link java.lang.String} object.
      * @param content a float.
      * @throws java.io.IOException if any.
      * @throws org.mapeditor.io.xml.XMLWriterException if any.

--- a/util/java/libtiled-java/src/main/resources/bindings.xjb
+++ b/util/java/libtiled-java/src/main/resources/bindings.xjb
@@ -38,19 +38,6 @@
 
         <jxb:globalBindings choiceContentProperty="true"/>
 
-        <jxb:bindings node="xs:complexType[@name='Group']">
-            <jxb:bindings node="xs:attribute[@name='x']">
-                <annox:annotate target="setter">@java.lang.Deprecated</annox:annotate>
-                <annox:annotate target="getter">@java.lang.Deprecated</annox:annotate>
-                <annox:annotate target="field">@java.lang.Deprecated</annox:annotate>
-            </jxb:bindings>
-            <jxb:bindings node="xs:attribute[@name='y']">
-                <annox:annotate target="setter">@java.lang.Deprecated</annox:annotate>
-                <annox:annotate target="getter">@java.lang.Deprecated</annox:annotate>
-                <annox:annotate target="field">@java.lang.Deprecated</annox:annotate>
-            </jxb:bindings>
-        </jxb:bindings>
-
         <jxb:bindings node="xs:complexType[@name='Image']">
             <jxb:class name="ImageData" />
             <jxb:bindings node="xs:attribute[@name='id']">

--- a/util/java/libtiled-java/src/main/resources/bindings.xjb
+++ b/util/java/libtiled-java/src/main/resources/bindings.xjb
@@ -109,6 +109,18 @@
             </jxb:bindings>
         </jxb:bindings>
 
+        <jxb:bindings node="xs:complexType[@name='Group']">
+            <jxb:class name="Group"/>
+
+            <jxb:bindings node="xs:complexContent/xs:extension">
+                <jxb:bindings node="xs:sequence">
+                    <jxb:bindings node="xs:choice">
+                        <jxb:property name="layers"/>
+                    </jxb:bindings>
+                </jxb:bindings>
+            </jxb:bindings>
+        </jxb:bindings>
+
         <jxb:bindings node="xs:complexType[@name='Map']">
             <jxb:class name="MapData" implClass="Map"/>
 

--- a/util/java/libtiled-java/src/main/resources/map.dtd
+++ b/util/java/libtiled-java/src/main/resources/map.dtd
@@ -129,6 +129,7 @@
 
 <!ELEMENT layer (properties?, data)>
 <!ATTLIST layer
+  id          CDATA   #REQUIRED
   name        CDATA   #REQUIRED
   width       CDATA   #REQUIRED
   height      CDATA   #REQUIRED
@@ -140,6 +141,7 @@
 
 <!ELEMENT objectgroup (properties?, object*)>
 <!ATTLIST objectgroup
+  id          CDATA   #REQUIRED
   name        CDATA   #REQUIRED
   width       CDATA   #IMPLIED
   height      CDATA   #IMPLIED
@@ -151,6 +153,7 @@
 
 <!ELEMENT object (properties?)>
 <!ATTLIST object
+  id          CDATA   #REQUIRED
   name        CDATA   #IMPLIED
   type        CDATA   #IMPLIED
   x           CDATA   #REQUIRED

--- a/util/java/libtiled-java/src/main/resources/map.dtd
+++ b/util/java/libtiled-java/src/main/resources/map.dtd
@@ -161,4 +161,5 @@
   width       CDATA   #IMPLIED
   height      CDATA   #IMPLIED
   gid         CDATA   #IMPLIED
+  rotation    CDATA   #IMPLIED
 >

--- a/util/java/libtiled-java/src/main/resources/map.dtd
+++ b/util/java/libtiled-java/src/main/resources/map.dtd
@@ -56,6 +56,8 @@
     staggeraxis CDATA #IMPLIED
     staggerindex CDATA #IMPLIED
     backgroundcolor CDATA #IMPLIED
+    infinite CDATA #IMPLIED
+    nextlayerid ID #IMPLIED
     nextobjectid ID #IMPLIED
 >
 
@@ -137,6 +139,7 @@
   y           CDATA   #IMPLIED
   opacity     CDATA   #IMPLIED
   visible     (0 | 1) #IMPLIED
+  locked      CDATA   #IMPLIED
 >
 
 <!ELEMENT objectgroup (properties?, object*)>

--- a/util/java/libtiled-java/src/main/resources/map.xsd
+++ b/util/java/libtiled-java/src/main/resources/map.xsd
@@ -164,10 +164,12 @@ POSSIBILITY OF SUCH DAMAGE.
         <xs:complexContent>
             <xs:extension base="Layer">
                 <xs:sequence>
-                    <xs:element name="layer" type="TileLayer" maxOccurs="unbounded"/>
-                    <xs:element name="objectgroup" type="ObjectGroup" maxOccurs="unbounded"/>
-                    <xs:element name="imagelayer" type="ImageLayer" maxOccurs="unbounded"/>
-                    <xs:element name="group" type="Group" maxOccurs="unbounded"/>
+                    <xs:choice>
+                        <xs:element name="layer" type="TileLayer" maxOccurs="unbounded"/>
+                        <xs:element name="objectgroup" type="ObjectGroup" maxOccurs="unbounded"/>
+                        <xs:element name="imagelayer" type="ImageLayer" maxOccurs="unbounded"/>
+                        <xs:element name="group" type="Group" maxOccurs="unbounded"/>
+                    </xs:choice>
                 </xs:sequence>
 
                 <xs:attribute name="color" type="xs:string">

--- a/util/java/libtiled-java/src/main/resources/map.xsd
+++ b/util/java/libtiled-java/src/main/resources/map.xsd
@@ -161,71 +161,33 @@ POSSIBILITY OF SUCH DAMAGE.
             </xs:documentation>
         </xs:annotation>
 
-        <xs:sequence>
-            <xs:element name="properties" type="Properties"/>
-            <xs:element name="layer" type="TileLayer" maxOccurs="unbounded"/>
-            <xs:element name="objectgroup" type="ObjectGroup" maxOccurs="unbounded"/>
-            <xs:element name="imagelayer" type="ImageLayer" maxOccurs="unbounded"/>
-            <xs:element name="group" type="Group" maxOccurs="unbounded"/>
-        </xs:sequence>
+        <xs:complexContent>
+            <xs:extension base="Layer">
+                <xs:sequence>
+                    <xs:element name="layer" type="TileLayer" maxOccurs="unbounded"/>
+                    <xs:element name="objectgroup" type="ObjectGroup" maxOccurs="unbounded"/>
+                    <xs:element name="imagelayer" type="ImageLayer" maxOccurs="unbounded"/>
+                    <xs:element name="group" type="Group" maxOccurs="unbounded"/>
+                </xs:sequence>
 
-        <xs:attribute name="name" type="xs:string">
-            <xs:annotation>
-                <xs:documentation>
-                    The name of the group layer.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="offsetx" type="xs:int">
-            <xs:annotation>
-                <xs:documentation>
-                    Rendering offset of the group layer in pixels.
-                    Defaults to 0.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="offsety" type="xs:int">
-            <xs:annotation>
-                <xs:documentation>
-                    Rendering offset of the group layer in pixels.
-                    Defaults to 0.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="x" type="xs:int">
-            <xs:annotation>
-                <xs:documentation>
-                    The x position of the group layer in pixels.
-
-                    @deprecated since 0.15
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="y" type="xs:int">
-            <xs:annotation>
-                <xs:documentation>
-                    The y position of the group layer in pixels.
-
-                    @deprecated since 0.15
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="opacity" type="xs:double">
-            <xs:annotation>
-                <xs:documentation>
-                    The opacity of the layer as a value from 0 to 1.
-                    Defaults to 1.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="visible" type="xs:boolean">
-            <xs:annotation>
-                <xs:documentation>
-                    Whether the layer is shown (1) or hidden (0).
-                    Defaults to 1.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
+                <xs:attribute name="color" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The color used to display the objects in this group.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="draworder" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether the objects are drawn according to the order
+                            of appearance ("index") or sorted by their
+                            y-coordinate ("topdown"). Defaults to "topdown".
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
     </xs:complexType>
 
     <xs:complexType name="Image">
@@ -446,14 +408,8 @@ POSSIBILITY OF SUCH DAMAGE.
                 <xs:element name="layer" type="TileLayer" maxOccurs="unbounded"/>
                 <xs:element name="objectgroup" type="ObjectGroup" maxOccurs="unbounded"/>
                 <xs:element name="imagelayer" type="ImageLayer" maxOccurs="unbounded"/>
+                <xs:element name="group" type="Group" maxOccurs="unbounded"/>
             </xs:choice>
-            <xs:element name="group" type="Group" maxOccurs="unbounded">
-                <xs:annotation>
-                    <xs:documentation>
-                        @since 1.0
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
         </xs:sequence>
 
         <xs:attribute name="version" type="xs:string" fixed="1.0">

--- a/util/java/libtiled-java/src/main/resources/map.xsd
+++ b/util/java/libtiled-java/src/main/resources/map.xsd
@@ -327,6 +327,13 @@ POSSIBILITY OF SUCH DAMAGE.
             <xs:element name="properties" type="Properties" minOccurs="0" maxOccurs="1"/>
         </xs:sequence>
 
+        <xs:attribute name="id" type="xs:int" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Map-unique ID of the layer.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="name" type="xs:string" use="required">
             <xs:annotation>
                 <xs:documentation>
@@ -404,6 +411,13 @@ POSSIBILITY OF SUCH DAMAGE.
                     Rendering offset for this layer in pixels. Defaults to 0.
 
                     @since 0.14
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="locked" type="xs:int">
+            <xs:annotation>
+                <xs:documentation>
+                    Locking flag of the layer (used by Tiled).
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -547,6 +561,24 @@ POSSIBILITY OF SUCH DAMAGE.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="infinite" type="xs:int" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Defines if the map infinite.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="nextlayerid" type="xs:int">
+            <xs:annotation>
+                <xs:documentation>
+                    Stores the next available ID for new layers. This number
+                    is stored to prevent reuse of the same ID after objects
+                    have been removed.
+
+                    @since 0.12
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="nextobjectid" type="xs:int">
             <xs:annotation>
                 <xs:documentation>
@@ -582,6 +614,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
         <xs:sequence>
             <xs:element name="properties" type="Properties"/>
+            <xs:element name="point" type="Point"/>
             <xs:element name="ellipse" type="Ellipse">
                 <xs:annotation>
                     <xs:documentation>
@@ -715,6 +748,15 @@ POSSIBILITY OF SUCH DAMAGE.
                 </xs:attribute>
             </xs:extension>
         </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="Point">
+        <xs:annotation>
+            <xs:documentation source="http://doc.mapeditor.org/reference/tmx-map-format/#point">
+                Used to mark an object as a point.
+                The existing x and y attributes are used to determine the position of the point.
+            </xs:documentation>
+        </xs:annotation>
     </xs:complexType>
 
     <xs:complexType name="Polygon">

--- a/util/java/libtiled-java/src/test/java/org/mapeditor/io/MapReaderTest.java
+++ b/util/java/libtiled-java/src/test/java/org/mapeditor/io/MapReaderTest.java
@@ -32,7 +32,6 @@ package org.mapeditor.io;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import javax.imageio.IIOException;
 
 import static org.junit.Assert.*;
 import org.junit.Test;
@@ -42,7 +41,6 @@ import org.mapeditor.core.ObjectGroup;
 import org.mapeditor.core.Orientation;
 import org.mapeditor.core.StaggerAxis;
 import org.mapeditor.core.StaggerIndex;
-import org.mapeditor.core.Tile;
 import org.mapeditor.core.TileLayer;
 import org.mapeditor.core.TileSet;
 
@@ -270,21 +268,21 @@ public class MapReaderTest {
         TileLayer layer = (TileLayer) map.getLayer(0);
         assertNotNull(layer.getTileAt(0, 0));
 
-        assertTrue(layer.isFlippedHorizontaly(0, 0));
+        assertTrue(layer.isFlippedHorizontally(0, 0));
         assertFalse(layer.isFlippedVertically(0, 0));
-        assertFalse(layer.isFlippedDiagonaly(0, 0));
+        assertFalse(layer.isFlippedDiagonally(0, 0));
 
-        assertFalse(layer.isFlippedHorizontaly(1, 0));
+        assertFalse(layer.isFlippedHorizontally(1, 0));
         assertTrue(layer.isFlippedVertically(1, 0));
-        assertFalse(layer.isFlippedDiagonaly(1, 0));
+        assertFalse(layer.isFlippedDiagonally(1, 0));
 
-        assertTrue(layer.isFlippedHorizontaly(2, 0));
+        assertTrue(layer.isFlippedHorizontally(2, 0));
         assertTrue(layer.isFlippedVertically(2, 0));
-        assertFalse(layer.isFlippedDiagonaly(2, 0));
+        assertFalse(layer.isFlippedDiagonally(2, 0));
 
-        assertFalse(layer.isFlippedHorizontaly(3, 0));
+        assertFalse(layer.isFlippedHorizontally(3, 0));
         assertFalse(layer.isFlippedVertically(3, 0));
-        assertFalse(layer.isFlippedDiagonaly(3, 0));
+        assertFalse(layer.isFlippedDiagonally(3, 0));
     }
 
     private URL getUrlFromResources(String filename) {


### PR DESCRIPTION
I've been making modifications to the libtiled-java in order to use it for automated processing/modifying of Tiled maps.

It's very much based on my current needs, so the features added to reading&writing the map files are features I've noticed end up with differences (or missing data altogether) in the map files.

I'm opening this PR mostly in case someone else has a need to touch the map files programmatically while maintaining the same file structure (the goal is to have no changes if you just do read/write with the Java lib).

Hoping to get this clean enough to be mergeable in the future.