### PR TITLE
issuescounter.cpp: Use %n for plural translations

### DIFF
--- a/src/tiled/issuescounter.cpp
+++ b/src/tiled/issuescounter.cpp
@@ -106,8 +106,8 @@ void IssuesCounter::updateLabels()
     mErrorIcon->setPixmap(issuesModel.errorIcon().pixmap(iconSize, errorIconMode));
     mWarningIcon->setPixmap(issuesModel.warningIcon().pixmap(iconSize, warningIconMode));
 
-    const QString errorText = tr("%1 error(s)", "", errorCount).arg(errorCount);
-    const QString warningText = tr("%1 warning(s)", "", warningCount).arg(warningCount);
+    const QString errorText = tr("%n error(s)", "", errorCount);
+    const QString warningText = tr("%n warning(s)", "", warningCount);
 
     setToolTip(QString(QLatin1String("%1, %2")).arg(errorText, warningText));
 }


### PR DESCRIPTION
With `tr("%1...", "", n)`, Qt looks for two markers in the translation: `%1` for the argument and `%n` to select the right plural.
Qt Linguist flags translations that don't have `%n` and `%1`.
But, it makes sense to only have the number once in the translation.