### PR TITLE
Preferences dialog: Stretch the wheelZoomsByDefault checkbox label

### DIFF
--- a/src/tiled/preferencesdialog.ui
+++ b/src/tiled/preferencesdialog.ui
@@ -225,7 +225,7 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
+          <item row="6" column="0" colspan="4">
            <widget class="QCheckBox" name="wheelZoomsByDefault">
             <property name="text">
              <string>Mouse wheel &amp;zooms by default</string>


### PR DESCRIPTION
If the translation is long, it would stretch the dialog.

This makes the label the same size as the accelerated rendering one.