### PR TITLE
auto-reload object types file when changed externally

### DIFF
--- a/src/tiled/objecttypeseditor.cpp
+++ b/src/tiled/objecttypeseditor.cpp
@@ -97,8 +97,6 @@ ObjectTypesEditor::ObjectTypesEditor(QWidget *parent)
     , mObjectTypesModel(new ObjectTypesModel(this))
     , mVariantManager(new VariantPropertyManager(this))
     , mGroupManager(new QtGroupPropertyManager(this))
-    , mUpdating(false)
-    , mSettingPrefObjectTypes(false)
 {
     mUi->setupUi(this);
     resize(Utils::dpiScaled(size()));

--- a/src/tiled/objecttypeseditor.cpp
+++ b/src/tiled/objecttypeseditor.cpp
@@ -98,6 +98,7 @@ ObjectTypesEditor::ObjectTypesEditor(QWidget *parent)
     , mVariantManager(new VariantPropertyManager(this))
     , mGroupManager(new QtGroupPropertyManager(this))
     , mUpdating(false)
+    , mSettingPrefObjectTypes(false)
 {
     mUi->setupUi(this);
     resize(Utils::dpiScaled(size()));
@@ -194,6 +195,9 @@ ObjectTypesEditor::ObjectTypesEditor(QWidget *parent)
 
     mObjectTypesModel->setObjectTypes(Object::objectTypes());
 
+    Preferences *prefs = Preferences::instance();
+    connect(prefs, &Preferences::objectTypesChanged, this, &ObjectTypesEditor::objectTypesChanged);
+
     retranslateUi();
 }
 
@@ -274,7 +278,9 @@ void ObjectTypesEditor::applyObjectTypes()
     auto &objectTypes = mObjectTypesModel->objectTypes();
 
     Preferences *prefs = Preferences::instance();
+    mSettingPrefObjectTypes = true;
     prefs->setObjectTypes(objectTypes);
+    mSettingPrefObjectTypes = false;
 
     QString objectTypesFile = prefs->objectTypesFile();
     QDir objectTypesDir = QFileInfo(objectTypesFile).dir();
@@ -289,6 +295,15 @@ void ObjectTypesEditor::applyObjectTypes()
                               .arg(prefs->objectTypesFile(),
                                    serializer.errorString()));
     }
+}
+
+void ObjectTypesEditor::objectTypesChanged()
+{
+    // ignore signal if ObjectTypesEditor caused it
+    if (mSettingPrefObjectTypes)
+        return;
+
+    mObjectTypesModel->setObjectTypes(Object::objectTypes());
 }
 
 void ObjectTypesEditor::applyPropertyToSelectedTypes(const QString &name, const QVariant &value)
@@ -349,7 +364,11 @@ void ObjectTypesEditor::chooseObjectTypesFile()
     }
 
     prefs->setObjectTypesFile(fileName);
+
+    mSettingPrefObjectTypes = true;
     prefs->setObjectTypes(objectTypes);
+    mSettingPrefObjectTypes = false;
+
     mObjectTypesModel->setObjectTypes(objectTypes);
 }
 

--- a/src/tiled/objecttypeseditor.h
+++ b/src/tiled/objecttypeseditor.h
@@ -59,6 +59,7 @@ private:
     void removeSelectedObjectTypes();
     void objectTypeIndexClicked(const QModelIndex &index);
     void applyObjectTypes();
+    void objectTypesChanged();
     void applyPropertyToSelectedTypes(const QString &name, const QVariant &value);
     void removePropertyFromSelectedTypes(const QString &name);
 
@@ -93,6 +94,7 @@ private:
 
     AggregatedProperties mProperties;
     bool mUpdating;
+    bool mSettingPrefObjectTypes;
 
     QAction *mAddObjectTypeAction;
     QAction *mRemoveObjectTypeAction;

--- a/src/tiled/objecttypeseditor.h
+++ b/src/tiled/objecttypeseditor.h
@@ -93,8 +93,8 @@ private:
     QHash<QString, QtVariantProperty *> mNameToProperty;
 
     AggregatedProperties mProperties;
-    bool mUpdating;
-    bool mSettingPrefObjectTypes;
+    bool mUpdating = false;
+    bool mSettingPrefObjectTypes = false;
 
     QAction *mAddObjectTypeAction;
     QAction *mRemoveObjectTypeAction;

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -818,17 +818,12 @@ void Preferences::setObjectTypesFile(const QString &fileName)
     emit stampsDirectoryChanged(fileName);
 }
 
-void Preferences::objectTypesFileChangedOnDisk(const QString &fileName)
+void Preferences::objectTypesFileChangedOnDisk()
 {
     ObjectTypesSerializer objectTypesSerializer;
     ObjectTypes objectTypes;
     bool success = objectTypesSerializer.readObjectTypes(objectTypesFile(), objectTypes);
 
-    if (!fileName.isEmpty())
-        mWatcher.removePath(fileName);
-
     if (success)
         setObjectTypes(objectTypes);
-
-    mWatcher.addPath(fileName);
 }

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -53,6 +53,9 @@ void Preferences::deleteInstance()
 Preferences::Preferences()
     : mSettings(new QSettings(this))
 {
+    connect(&mWatcher, &FileSystemWatcher::fileChanged,
+            this, &Preferences::objectTypesFileChangedOnDisk);
+
     // Retrieve storage settings
     mSettings->beginGroup(QLatin1String("Storage"));
     mLayerDataFormat = static_cast<Map::LayerDataFormat>
@@ -134,6 +137,8 @@ Preferences::Preferences()
         }
     } else {
         mSettings->remove(QLatin1String("ObjectTypes"));
+
+        mWatcher.addPath(objectTypesFile());
     }
 
     Object::setObjectTypes(objectTypes);
@@ -802,8 +807,28 @@ void Preferences::setObjectTypesFile(const QString &fileName)
     if (mObjectTypesFile == fileName)
         return;
 
+    if (!mObjectTypesFile.isEmpty())
+        mWatcher.removePath(mObjectTypesFile);
+
     mObjectTypesFile = fileName;
     mSettings->setValue(QLatin1String("Storage/ObjectTypesFile"), fileName);
 
+    mWatcher.addPath(mObjectTypesFile);
+
     emit stampsDirectoryChanged(fileName);
+}
+
+void Preferences::objectTypesFileChangedOnDisk(const QString &fileName)
+{
+    ObjectTypesSerializer objectTypesSerializer;
+    ObjectTypes objectTypes;
+    bool success = objectTypesSerializer.readObjectTypes(objectTypesFile(), objectTypes);
+
+    if (!fileName.isEmpty())
+        mWatcher.removePath(fileName);
+
+    if (success)
+        setObjectTypes(objectTypes);
+
+    mWatcher.addPath(fileName);
 }

--- a/src/tiled/preferences.cpp
+++ b/src/tiled/preferences.cpp
@@ -822,8 +822,7 @@ void Preferences::objectTypesFileChangedOnDisk()
 {
     ObjectTypesSerializer objectTypesSerializer;
     ObjectTypes objectTypes;
-    bool success = objectTypesSerializer.readObjectTypes(objectTypesFile(), objectTypes);
 
-    if (success)
+    if (objectTypesSerializer.readObjectTypes(objectTypesFile(), objectTypes))
         setObjectTypes(objectTypes);
 }

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -247,7 +247,7 @@ private:
     int intValue(const char *key, int defaultValue) const;
     qreal realValue(const char *key, qreal defaultValue) const;
 
-    void objectTypesFileChangedOnDisk(const QString &fileName);
+    void objectTypesFileChangedOnDisk();
 
     FileSystemWatcher mWatcher;
 

--- a/src/tiled/preferences.h
+++ b/src/tiled/preferences.h
@@ -25,6 +25,7 @@
 #include <QDate>
 #include <QObject>
 
+#include "filesystemwatcher.h"
 #include "map.h"
 #include "objecttypes.h"
 
@@ -245,6 +246,10 @@ private:
     QString stringValue(const char *key, const QString &def = QString()) const;
     int intValue(const char *key, int defaultValue) const;
     qreal realValue(const char *key, qreal defaultValue) const;
+
+    void objectTypesFileChangedOnDisk(const QString &fileName);
+
+    FileSystemWatcher mWatcher;
 
     QSettings *mSettings;
 


### PR DESCRIPTION
related to issue #1816 

I added a FileSystemWatcher to Preferences to watch the objecttypes.xml for changes.  When the file changes, it calls setObjectTypes() which emits the objectTypesChanged.

I also had to modify the ObjectTypesEditor to listen for the Preferences::objectTypesChanged signal so it will also update for external changes.

