### PR TITLE
Fix QVariantMap linker error

### DIFF
--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -341,8 +341,8 @@ QVariant MapToVariantConverter::toVariant(const Properties &properties) const
 {
     QVariantMap variantMap;
 
-    Properties::const_iterator it = properties.constBegin();
-    Properties::const_iterator it_end = properties.constEnd();
+    auto it = properties.map().constBegin();
+    const auto it_end = properties.map().constEnd();
     for (; it != it_end; ++it) {
         const QVariant value = toExportValue(it.value(), mDir);
         variantMap[it.key()] = value;
@@ -355,8 +355,8 @@ QVariant MapToVariantConverter::propertyTypesToVariant(const Properties &propert
 {
     QVariantMap variantMap;
 
-    Properties::const_iterator it = properties.constBegin();
-    Properties::const_iterator it_end = properties.constEnd();
+    auto it = properties.map().constBegin();
+    const auto it_end = properties.map().constEnd();
     for (; it != it_end; ++it)
         variantMap[it.key()] = typeToName(it.value().userType());
 
@@ -763,8 +763,8 @@ void MapToVariantConverter::addProperties(QVariantMap &variantMap,
         QVariantMap propertiesMap;
         QVariantMap propertyTypesMap;
 
-        Properties::const_iterator it = properties.constBegin();
-        Properties::const_iterator it_end = properties.constEnd();
+        auto it = properties.map().constBegin();
+        const auto it_end = properties.map().constEnd();
         for (; it != it_end; ++it) {
             int type = it.value().userType();
             const QVariant value = toExportValue(it.value(), mDir);
@@ -778,8 +778,8 @@ void MapToVariantConverter::addProperties(QVariantMap &variantMap,
     } else {
         QVariantList propertiesVariantList;
 
-        Properties::const_iterator it = properties.constBegin();
-        Properties::const_iterator it_end = properties.constEnd();
+        auto it = properties.map().constBegin();
+        const auto it_end = properties.map().constEnd();
         for (; it != it_end; ++it) {
             int type = it.value().userType();
             const QVariant value = toExportValue(it.value(), mDir);

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -953,8 +953,8 @@ void MapWriterPrivate::writeProperties(QXmlStreamWriter &w,
 
     w.writeStartElement(QLatin1String("properties"));
 
-    Properties::const_iterator it = properties.constBegin();
-    Properties::const_iterator it_end = properties.constEnd();
+    auto it = properties.map().constBegin();
+    auto it_end = properties.map().constEnd();
     for (; it != it_end; ++it) {
         w.writeStartElement(QLatin1String("property"));
         w.writeAttribute(QLatin1String("name"), it.key());

--- a/src/libtiled/objecttypes.cpp
+++ b/src/libtiled/objecttypes.cpp
@@ -59,7 +59,7 @@ static QJsonObject toJson(const ObjectType &objectType, const QDir &fileDir)
 
     QJsonArray propertiesJson;
 
-    QMapIterator<QString,QVariant> it(objectType.defaultProperties);
+    QMapIterator<QString,QVariant> it(objectType.defaultProperties.map());
     while (it.hasNext()) {
         it.next();
 
@@ -138,7 +138,7 @@ static void writeObjectTypesXml(QFileDevice *device,
         writer.writeAttribute(QLatin1String("name"), objectType.name);
         writer.writeAttribute(QLatin1String("color"), objectType.color.name());
 
-        QMapIterator<QString,QVariant> it(objectType.defaultProperties);
+        QMapIterator<QString,QVariant> it(objectType.defaultProperties.map());
         while (it.hasNext()) {
             it.next();
 

--- a/src/libtiled/properties.cpp
+++ b/src/libtiled/properties.cpp
@@ -35,23 +35,68 @@
 
 namespace Tiled {
 
+Properties::Properties(const QVariantMap &variantMap) :
+    mMap(variantMap)
+{
+}
+
+QVariant &Properties::operator[](const QString &key)
+{
+    return mMap[key];
+}
+
+const QVariant Properties::operator[](const QString &key) const
+{
+    return mMap[key];
+}
+
+bool Properties::contains(const QString &key) const
+{
+    return mMap.contains(key);
+}
+
+QVariant Properties::value(const QString &key, const QVariant &defaultValue) const
+{
+    return mMap.value(key, defaultValue);
+}
+
+QVariantMap::iterator Properties::insert(const QString &key, const QVariant &value)
+{
+    return mMap.insert(key, value);
+}
+
+int Properties::remove(const QString &key)
+{
+    return mMap.remove(key);
+}
+
+void Properties::clear()
+{
+    mMap.clear();
+}
+
 void Properties::merge(const Properties &other)
 {
     // Based on QMap::unite, but using insert instead of insertMulti
-    const_iterator it = other.constEnd();
-    const const_iterator b = other.constBegin();
+    QVariantMap::const_iterator it = other.mMap.constEnd();
+    const QVariantMap::const_iterator b = other.mMap.constBegin();
     while (it != b) {
         --it;
         insert(it.key(), it.value());
     }
 }
 
+QVariantMap Properties::map() const
+{
+    return mMap;
+}
+
 QJsonArray Properties::toJson() const
 {
     QJsonArray json;
 
-    const_iterator it = begin();
-    const const_iterator it_end = end();
+    auto it = mMap.constBegin();
+    const auto it_end = mMap.constEnd();
     for (; it != it_end; ++it) {
         const QString &name = it.key();
         const QJsonValue value = QJsonValue::fromVariant(toExportValue(it.value()));
@@ -89,8 +134,8 @@ Properties Properties::fromJson(const QJsonArray &json)
 
 void AggregatedProperties::aggregate(const Properties &properties)
 {
-    auto it = properties.constEnd();
-    const auto b = properties.constBegin();
+    auto it = properties.map().constEnd();
+    const auto b = properties.map().constBegin();
     while (it != b) {
         --it;
 

--- a/src/libtiled/properties.h
+++ b/src/libtiled/properties.h
@@ -45,19 +45,34 @@ struct FilePath {
 /**
  * Collection of properties and their values.
  */
-class TILEDSHARED_EXPORT Properties : public QVariantMap
+class TILEDSHARED_EXPORT Properties
 {
 public:
     Properties() = default;
     Properties(const Properties &) = default;
-    Properties(const QVariantMap &variantMap) : QVariantMap(variantMap) {}
+    Properties(const QVariantMap &variantMap);
 
     Properties &operator=(const Properties &other) = default;
 
+    QVariant &operator[](const QString &key);
+    const QVariant operator[](const QString &key) const;
+
+    inline bool isEmpty() const { return mMap.isEmpty(); }
+    bool contains(const QString &key) const;
+    QVariant value(const QString &key, const QVariant &defaultValue = QVariant()) const;
+    QVariantMap::iterator insert(const QString &key, const QVariant &value);
+    int remove(const QString &key);
+    void clear();
+
     void merge(const Properties &other);
+
+    QVariantMap map() const;
 
     QJsonArray toJson() const;
     static Properties fromJson(const QJsonArray &json);
+
+private:
+    QVariantMap mMap;
 };
 
 class TILEDSHARED_EXPORT AggregatedPropertyData


### PR DESCRIPTION
https://wiki.qt.io/Coding_Conventions says not to derive from template/tool classes.

The error message was:

tiled.lib(tiled.dll) : error LNK2005: "public: __cdecl QMap<class QString,class QVariant>::~QMap<class QString,class QVariant>(void)" (??1?$QMap@VQString@@VQVariant@@@@QEAA@XZ) already defined in SpriteSequence.cpp.obj
   Creating library C:\dev\tshnm-iso-qt5_14_d-Debug\Debug\libisle.7c81f238\isle.lib and object C:\dev\tshnm-iso-qt5_14_d-Debug\Debug\libisle.7c81f238\isle.exp
C:\dev\tshnm-iso-qt5_14_d-Debug\Debug\libisle.7c81f238\isle.dll : fatal error LNK1169: one or more multiply defined symbols found