### PR TITLE
Added layer tint color

### DIFF
--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -33,6 +33,7 @@
 #include "tile.h"
 #include "tilelayer.h"
 #include "tileset.h"
+#include "objectgroup.h"
 
 #include <QtMath>
 
@@ -304,7 +305,7 @@ void IsometricRenderer::drawTileLayer(QPainter *painter,
     // Determine whether the current row is shifted half a tile to the right
     bool shifted = inUpperHalf ^ inLeftHalf;
 
-    CellRenderer renderer(painter, this);
+    CellRenderer renderer(painter, this, layer->tintColor());
 
     for (int y = startPos.y() * 2; y - tileHeight * 2 < rect.bottom() * 2;
          y += tileHeight)
@@ -372,7 +373,7 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
         const QSizeF size = object->size();
         const QPointF pos = pixelToScreenCoords(object->position());
 
-        CellRenderer(painter, this).render(cell, pos, size,
+        CellRenderer(painter, this, object->objectGroup()->tintColor()).render(cell, pos, size,
                                            CellRenderer::BottomCenter);
 
         if (testFlag(ShowTileObjectOutlines)) {

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -305,7 +305,7 @@ void IsometricRenderer::drawTileLayer(QPainter *painter,
     // Determine whether the current row is shifted half a tile to the right
     bool shifted = inUpperHalf ^ inLeftHalf;
 
-    CellRenderer renderer(painter, this, layer->tintColor());
+    CellRenderer renderer(painter, this, layer->effectiveTintColor());
 
     for (int y = startPos.y() * 2; y - tileHeight * 2 < rect.bottom() * 2;
          y += tileHeight)
@@ -373,7 +373,7 @@ void IsometricRenderer::drawMapObject(QPainter *painter,
         const QSizeF size = object->size();
         const QPointF pos = pixelToScreenCoords(object->position());
 
-        CellRenderer(painter, this, object->objectGroup()->tintColor()).render(cell, pos, size,
+        CellRenderer(painter, this, object->objectGroup()->effectiveTintColor()).render(cell, pos, size,
                                            CellRenderer::BottomCenter);
 
         if (testFlag(ShowTileObjectOutlines)) {

--- a/src/libtiled/layer.cpp
+++ b/src/libtiled/layer.cpp
@@ -37,6 +37,20 @@
 
 namespace Tiled {
 
+static QColor multiplyColors(QColor color1, QColor color2)
+{
+    QColor multiplied;
+
+    multiplied.setRgbF(
+        color1.redF() * color2.redF()
+        ,color1.greenF() * color2.greenF()
+        ,color1.blueF() * color2.blueF()
+        ,color1.alphaF() * color2.alphaF()
+    );
+
+    return multiplied;
+}
+
 Layer::Layer(TypeFlag type, const QString &name, int x, int y) :
     Object(LayerType),
     mName(name),
@@ -45,6 +59,7 @@ Layer::Layer(TypeFlag type, const QString &name, int x, int y) :
     mX(x),
     mY(y),
     mOpacity(1.0),
+    mTintColor(QColor(255, 255, 255, 255)),
     mVisible(true),
     mMap(nullptr),
     mParentLayer(nullptr),
@@ -80,6 +95,20 @@ qreal Layer::effectiveOpacity() const
     while ((layer = layer->parentLayer()))
         opacity *= layer->opacity();
     return opacity;
+}
+
+/**
+ * Returns the effective tint color, which is the tint color multiplied by the
+ * tint color of any parent layers.
+ */
+QColor Layer::effectiveTintColor() const
+{
+    auto tintColor = mTintColor;
+    const Layer *layer = this;
+    while ((layer = layer->parentLayer()))
+        tintColor = multiplyColors(tintColor, layer->tintColor());
+
+    return tintColor;
 }
 
 /**

--- a/src/libtiled/layer.cpp
+++ b/src/libtiled/layer.cpp
@@ -194,6 +194,7 @@ Layer *Layer::initializeClone(Layer *clone) const
     clone->mId = mId;
     clone->mOffset = mOffset;
     clone->mOpacity = mOpacity;
+    clone->mTintColor = mTintColor;
     clone->mVisible = mVisible;
     clone->setProperties(properties());
     return clone;

--- a/src/libtiled/layer.cpp
+++ b/src/libtiled/layer.cpp
@@ -39,16 +39,10 @@ namespace Tiled {
 
 static QColor multiplyColors(QColor color1, QColor color2)
 {
-    QColor multiplied;
-
-    multiplied.setRgbF(
-        color1.redF() * color2.redF()
-        ,color1.greenF() * color2.greenF()
-        ,color1.blueF() * color2.blueF()
-        ,color1.alphaF() * color2.alphaF()
-    );
-
-    return multiplied;
+    return QColor::fromRgbF(color1.redF() * color2.redF(),
+                            color1.greenF() * color2.greenF(),
+                            color1.blueF() * color2.blueF(),
+                            color1.alphaF() * color2.alphaF());
 }
 
 Layer::Layer(TypeFlag type, const QString &name, int x, int y) :
@@ -59,7 +53,6 @@ Layer::Layer(TypeFlag type, const QString &name, int x, int y) :
     mX(x),
     mY(y),
     mOpacity(1.0),
-    mTintColor(QColor(255, 255, 255, 255)),
     mVisible(true),
     mMap(nullptr),
     mParentLayer(nullptr),
@@ -103,10 +96,13 @@ qreal Layer::effectiveOpacity() const
  */
 QColor Layer::effectiveTintColor() const
 {
-    auto tintColor = mTintColor;
+    auto tintColor = mTintColor.isValid() ? mTintColor
+                                          : QColor(255, 255, 255, 255);
+
     const Layer *layer = this;
     while ((layer = layer->parentLayer()))
-        tintColor = multiplyColors(tintColor, layer->tintColor());
+        if (layer->tintColor().isValid())
+            tintColor = multiplyColors(tintColor, layer->tintColor());
 
     return tintColor;
 }

--- a/src/libtiled/layer.h
+++ b/src/libtiled/layer.h
@@ -55,6 +55,7 @@ class TILEDSHARED_EXPORT Layer : public Object
 
     Q_PROPERTY(QString name READ name)
     Q_PROPERTY(qreal opacity READ opacity)
+    Q_PROPERTY(QColor tintColor READ tintColor WRITE setTintColor)
     Q_PROPERTY(bool visible READ isVisible)
     Q_PROPERTY(bool locked READ isLocked)
     Q_PROPERTY(QPointF offset READ offset)
@@ -81,6 +82,9 @@ public:
     int id() const { return mId; }
     void setId(int id) { mId = id; }
     void resetIds();
+
+    const QColor &tintColor() const { return mTintColor; }
+    void setTintColor(const QColor &tintColor) { mTintColor = tintColor; }
 
     /**
      * Returns the type of this layer.
@@ -255,6 +259,7 @@ protected:
     int mY;
     QPointF mOffset;
     qreal mOpacity;
+    QColor mTintColor;
     bool mVisible;
     Map *mMap;
     GroupLayer *mParentLayer;

--- a/src/libtiled/layer.h
+++ b/src/libtiled/layer.h
@@ -111,7 +111,15 @@ public:
      */
     void setOpacity(qreal opacity) { mOpacity = opacity; }
 
+    /**
+     * Returns the effective opacity of this layer
+     */
     qreal effectiveOpacity() const;
+
+    /**
+     * Returns the effective tint color of this layer
+     */
+    QColor effectiveTintColor() const;
 
     /**
      * Returns the visibility of this layer.

--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -776,6 +776,10 @@ static void readLayerAttributes(Layer &layer,
     if (ok)
         layer.setOpacity(opacity);
 
+    const QString color = atts.value(QLatin1String("tintcolor")).toString();
+        if (!color.isEmpty())
+            layer.setTintColor(color);
+
     const int visible = visibleRef.toInt(&ok);
     if (ok)
         layer.setVisible(visible);

--- a/src/libtiled/mapreader.cpp
+++ b/src/libtiled/mapreader.cpp
@@ -776,9 +776,9 @@ static void readLayerAttributes(Layer &layer,
     if (ok)
         layer.setOpacity(opacity);
 
-    const QString color = atts.value(QLatin1String("tintcolor")).toString();
-        if (!color.isEmpty())
-            layer.setTintColor(color);
+    const QStringRef tintColor = atts.value(QLatin1String("tintcolor"));
+    if (!tintColor.isEmpty())
+        layer.setTintColor(QColor(tintColor.toString()));
 
     const int visible = visibleRef.toInt(&ok);
     if (ok)

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -115,6 +115,7 @@ void MapRenderer::drawImageLayer(QPainter *painter,
 {
     Q_UNUSED(exposed)
 
+    // TODO: Support layer tint color
     painter->drawPixmap(QPointF(), imageLayer->image());
 }
 

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -115,8 +115,7 @@ void MapRenderer::drawImageLayer(QPainter *painter,
 {
     Q_UNUSED(exposed)
 
-    // TODO: Support layer tint color
-    painter->drawPixmap(QPointF(), imageLayer->image());
+    painter->drawPixmap(QPointF(), tinted(imageLayer->image(), imageLayer->effectiveTintColor()));
 }
 
 void MapRenderer::drawPointObject(QPainter *painter, const QColor &color) const

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -48,6 +48,35 @@
 
 using namespace Tiled;
 
+static QPixmap tinted(const QPixmap &pixmap, const QColor &color)
+{
+    if (!color.isValid() || color == QColor(255, 255, 255, 255))
+        return pixmap;
+
+    QPixmap resultImage = pixmap;
+    QPainter painter(&resultImage);
+
+    QColor fullOpacity = color;
+    fullOpacity.setAlpha(255);
+    // tint the final color (this will will mess up the alpha which we will fix
+    // in the next lines)
+    painter.setCompositionMode(QPainter::CompositionMode_Multiply);
+    painter.fillRect(resultImage.rect(), fullOpacity);
+
+    // apply the original alpha to the final image
+    painter.setCompositionMode(QPainter::CompositionMode_DestinationIn);
+    painter.drawPixmap(0, 0, pixmap);
+
+    // apply the alpha of the tint color so that we can use it to make the image
+    // transparent instead of just increasing or decreasing the tint effect
+    painter.setCompositionMode(QPainter::CompositionMode_DestinationIn);
+    painter.fillRect(resultImage.rect(), color);
+
+    painter.end();
+
+    return resultImage;
+}
+
 MapRenderer::~MapRenderer()
 {}
 
@@ -223,12 +252,13 @@ static bool hasOpenGLEngine(const QPainter *painter)
             type == QPaintEngine::OpenGL2);
 }
 
-CellRenderer::CellRenderer(QPainter *painter, const MapRenderer *renderer, CellType cellType)
+CellRenderer::CellRenderer(QPainter *painter, const MapRenderer *renderer, const QColor &tintColor, CellType cellType)
     : mPainter(painter)
     , mRenderer(renderer)
     , mTile(nullptr)
     , mIsOpenGL(hasOpenGLEngine(painter))
     , mCellType(cellType)
+    , mTintColor(tintColor)
 {
 }
 
@@ -335,7 +365,7 @@ void CellRenderer::render(const Cell &cell, const QPointF &pos, const QSizeF &si
     const QRectF source(0, 0, fragment.width, fragment.height);
 
     mPainter->setTransform(transform);
-    mPainter->drawPixmap(target, image, source);
+    mPainter->drawPixmap(target, tinted(image, mTintColor), source);
     mPainter->setTransform(oldTransform);
 
     // A bit of a hack to still draw tile collision shapes when requested
@@ -360,7 +390,7 @@ void CellRenderer::flush()
 
     mPainter->drawPixmapFragments(mFragments.constData(),
                                   mFragments.size(),
-                                  mTile->image());
+                                  tinted(mTile->image(), mTintColor));
 
     if (mRenderer->flags().testFlag(ShowTileCollisionShapes)
             && mTile->objectGroup()

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -300,7 +300,7 @@ public:
     };
 
     explicit CellRenderer(QPainter *painter, const MapRenderer *renderer,
-                          CellType cellType = OrthogonalCells);
+                          const QColor &tintColor, CellType cellType = OrthogonalCells);
 
     ~CellRenderer() { flush(); }
 
@@ -316,6 +316,7 @@ private:
     QVector<QPainter::PixmapFragment> mFragments;
     const bool mIsOpenGL;
     const CellType mCellType;
+    const QColor mTintColor;
 };
 
 } // namespace Tiled

--- a/src/libtiled/maptovariantconverter.cpp
+++ b/src/libtiled/maptovariantconverter.cpp
@@ -743,6 +743,9 @@ void MapToVariantConverter::addLayerAttributes(QVariantMap &layerVariant,
         layerVariant[QLatin1String("offsety")] = offset.y();
     }
 
+    if (layer.tintColor().isValid())
+        layerVariant[QLatin1String("tintcolor")] = colorToString(layer.tintColor());
+
     addProperties(layerVariant, layer.properties());
 }
 

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -710,6 +710,9 @@ void MapWriterPrivate::writeLayerAttributes(QXmlStreamWriter &w,
         w.writeAttribute(QLatin1String("locked"), QLatin1String("1"));
     if (opacity != qreal(1))
         w.writeAttribute(QLatin1String("opacity"), QString::number(opacity));
+    if (layer.tintColor().isValid())
+            w.writeAttribute(QLatin1String("tintcolor"),
+                             colorToString(layer.tintColor()));
 
     const QPointF offset = layer.offset();
     if (!offset.isNull()) {

--- a/src/libtiled/mapwriter.cpp
+++ b/src/libtiled/mapwriter.cpp
@@ -710,9 +710,10 @@ void MapWriterPrivate::writeLayerAttributes(QXmlStreamWriter &w,
         w.writeAttribute(QLatin1String("locked"), QLatin1String("1"));
     if (opacity != qreal(1))
         w.writeAttribute(QLatin1String("opacity"), QString::number(opacity));
-    if (layer.tintColor().isValid())
-            w.writeAttribute(QLatin1String("tintcolor"),
-                             colorToString(layer.tintColor()));
+    if (layer.tintColor().isValid()) {
+        w.writeAttribute(QLatin1String("tintcolor"),
+                         colorToString(layer.tintColor()));
+    }
 
     const QPointF offset = layer.offset();
     if (!offset.isNull()) {

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -312,7 +312,7 @@ void OrthogonalRenderer::drawTileLayer(QPainter *painter,
     const QTransform savedTransform = painter->transform();
     painter->translate(layerPos);
 
-    CellRenderer renderer(painter, this, layer->tintColor());
+    CellRenderer renderer(painter, this, layer->effectiveTintColor());
 
     Map::RenderOrder renderOrder = map()->renderOrder();
 
@@ -392,7 +392,7 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
 
     if (!cell.isEmpty()) {
         const QSizeF size = object->size();
-        CellRenderer(painter, this, object->objectGroup()->tintColor()).render(cell, QPointF(), size,
+        CellRenderer(painter, this, object->objectGroup()->effectiveTintColor()).render(cell, QPointF(), size,
                                            CellRenderer::BottomLeft);
 
         if (testFlag(ShowTileObjectOutlines)) {

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -33,6 +33,7 @@
 #include "tile.h"
 #include "tilelayer.h"
 #include "tileset.h"
+#include "objectgroup.h"
 
 #include <QtCore/qmath.h>
 
@@ -311,7 +312,7 @@ void OrthogonalRenderer::drawTileLayer(QPainter *painter,
     const QTransform savedTransform = painter->transform();
     painter->translate(layerPos);
 
-    CellRenderer renderer(painter, this);
+    CellRenderer renderer(painter, this, layer->tintColor());
 
     Map::RenderOrder renderOrder = map()->renderOrder();
 
@@ -391,7 +392,7 @@ void OrthogonalRenderer::drawMapObject(QPainter *painter,
 
     if (!cell.isEmpty()) {
         const QSizeF size = object->size();
-        CellRenderer(painter, this).render(cell, QPointF(), size,
+        CellRenderer(painter, this, object->objectGroup()->tintColor()).render(cell, QPointF(), size,
                                            CellRenderer::BottomLeft);
 
         if (testFlag(ShowTileObjectOutlines)) {

--- a/src/libtiled/varianttomapconverter.cpp
+++ b/src/libtiled/varianttomapconverter.cpp
@@ -494,6 +494,9 @@ std::unique_ptr<Layer> VariantToMapConverter::toLayer(const QVariant &variant)
 
     if (layer) {
         layer->setId(variantMap[QLatin1String("id")].toInt());
+        layer->setOpacity(variantMap[QLatin1String("opacity")].toReal());
+        layer->setVisible(variantMap[QLatin1String("visible")].toBool());
+        layer->setTintColor(variantMap[QLatin1String("tintcolor")].value<QColor>());
         layer->setProperties(extractProperties(variantMap));
 
         const QPointF offset(variantMap[QLatin1String("offsetx")].toDouble(),
@@ -518,12 +521,6 @@ std::unique_ptr<TileLayer> VariantToMapConverter::toTileLayer(const QVariantMap 
                                          variantMap[QLatin1String("x")].toInt(),
                                          variantMap[QLatin1String("y")].toInt(),
                                          width, height));
-
-    const qreal opacity = variantMap[QLatin1String("opacity")].toReal();
-    const bool visible = variantMap[QLatin1String("visible")].toBool();
-
-    tileLayer->setOpacity(opacity);
-    tileLayer->setVisible(visible);
 
     const QString encoding = variantMap[QLatin1String("encoding")].toString();
     const QString compression = variantMap[QLatin1String("compression")].toString();
@@ -578,12 +575,6 @@ std::unique_ptr<ObjectGroup> VariantToMapConverter::toObjectGroup(const QVariant
     ObjectGroupPtr objectGroup(new ObjectGroup(variantMap[QLatin1String("name")].toString(),
                                                variantMap[QLatin1String("x")].toInt(),
                                                variantMap[QLatin1String("y")].toInt()));
-
-    const qreal opacity = variantMap[QLatin1String("opacity")].toReal();
-    const bool visible = variantMap[QLatin1String("visible")].toBool();
-
-    objectGroup->setOpacity(opacity);
-    objectGroup->setVisible(visible);
 
     objectGroup->setColor(variantMap.value(QLatin1String("color")).value<QColor>());
 
@@ -703,12 +694,6 @@ std::unique_ptr<ImageLayer> VariantToMapConverter::toImageLayer(const QVariantMa
                                             variantMap[QLatin1String("x")].toInt(),
                                             variantMap[QLatin1String("y")].toInt()));
 
-    const qreal opacity = variantMap[QLatin1String("opacity")].toReal();
-    const bool visible = variantMap[QLatin1String("visible")].toBool();
-
-    imageLayer->setOpacity(opacity);
-    imageLayer->setVisible(visible);
-
     const QString trans = variantMap[QLatin1String("transparentcolor")].toString();
     if (!trans.isEmpty() && QColor::isValidColor(trans))
         imageLayer->setTransparentColor(QColor(trans));
@@ -728,13 +713,8 @@ std::unique_ptr<GroupLayer> VariantToMapConverter::toGroupLayer(const QVariantMa
     const QString name = variantMap[QLatin1String("name")].toString();
     const int x = variantMap[QLatin1String("x")].toInt();
     const int y = variantMap[QLatin1String("y")].toInt();
-    const qreal opacity = variantMap[QLatin1String("opacity")].toReal();
-    const bool visible = variantMap[QLatin1String("visible")].toBool();
 
     auto groupLayer = std::make_unique<GroupLayer>(name, x, y);
-
-    groupLayer->setOpacity(opacity);
-    groupLayer->setVisible(visible);
 
     const auto layerVariants = variantMap[QLatin1String("layers")].toList();
     for (const QVariant &layerVariant : layerVariants) {

--- a/src/plugins/lua/luaplugin.cpp
+++ b/src/plugins/lua/luaplugin.cpp
@@ -87,6 +87,7 @@ public:
                          QSize chunkSize);
     void writeMapObject(const Tiled::MapObject *);
 
+    void writeLayerProperties(const Tiled::Layer *);
     void writePolygon(const Tiled::MapObject *);
     void writeTextProperties(const Tiled::MapObject *);
     void writeColor(const char *name, const QColor &color);
@@ -330,7 +331,7 @@ void LuaWriter::writeTileset(const Tileset &tileset,
 
     if (tileset.transparentColor().isValid()) {
         mWriter.writeKeyAndValue("transparentcolor",
-                                tileset.transparentColor().name());
+                                 tileset.transparentColor().name());
     }
 
     const QColor &backgroundColor = tileset.backgroundColor();
@@ -464,19 +465,12 @@ void LuaWriter::writeTileLayer(const TileLayer *tileLayer,
     mWriter.writeStartTable();
 
     mWriter.writeKeyAndValue("type", "tilelayer");
-    mWriter.writeKeyAndValue("id", tileLayer->id());
-    mWriter.writeKeyAndValue("name", tileLayer->name());
     mWriter.writeKeyAndValue("x", tileLayer->x());
     mWriter.writeKeyAndValue("y", tileLayer->y());
     mWriter.writeKeyAndValue("width", tileLayer->width());
     mWriter.writeKeyAndValue("height", tileLayer->height());
-    mWriter.writeKeyAndValue("visible", tileLayer->isVisible());
-    mWriter.writeKeyAndValue("opacity", tileLayer->opacity());
 
-    const QPointF offset = tileLayer->offset();
-    mWriter.writeKeyAndValue("offsetx", offset.x());
-    mWriter.writeKeyAndValue("offsety", offset.y());
-
+    writeLayerProperties(tileLayer);
     writeProperties(tileLayer->properties());
 
     switch (format) {
@@ -570,18 +564,9 @@ void LuaWriter::writeObjectGroup(const ObjectGroup *objectGroup,
         mWriter.writeStartTable(key);
 
     mWriter.writeKeyAndValue("type", "objectgroup");
-    if (objectGroup->id() != 0)
-        mWriter.writeKeyAndValue("id", objectGroup->id());
-    mWriter.writeKeyAndValue("name", objectGroup->name());
-    mWriter.writeKeyAndValue("visible", objectGroup->isVisible());
-    mWriter.writeKeyAndValue("opacity", objectGroup->opacity());
-
-    const QPointF offset = objectGroup->offset();
-    mWriter.writeKeyAndValue("offsetx", offset.x());
-    mWriter.writeKeyAndValue("offsety", offset.y());
-
     mWriter.writeKeyAndValue("draworder", drawOrderToString(objectGroup->drawOrder()));
 
+    writeLayerProperties(objectGroup);
     writeProperties(objectGroup->properties());
 
     mWriter.writeStartTable("objects");
@@ -597,23 +582,16 @@ void LuaWriter::writeImageLayer(const ImageLayer *imageLayer)
     mWriter.writeStartTable();
 
     mWriter.writeKeyAndValue("type", "imagelayer");
-    mWriter.writeKeyAndValue("id", imageLayer->id());
-    mWriter.writeKeyAndValue("name", imageLayer->name());
-    mWriter.writeKeyAndValue("visible", imageLayer->isVisible());
-    mWriter.writeKeyAndValue("opacity", imageLayer->opacity());
-
-    const QPointF offset = imageLayer->offset();
-    mWriter.writeKeyAndValue("offsetx", offset.x());
-    mWriter.writeKeyAndValue("offsety", offset.y());
 
     const QString rel = toFileReference(imageLayer->imageSource(), mDir);
     mWriter.writeKeyAndValue("image", rel);
 
     if (imageLayer->transparentColor().isValid()) {
         mWriter.writeKeyAndValue("transparentcolor",
-                                imageLayer->transparentColor().name());
+                                 imageLayer->transparentColor().name());
     }
 
+    writeLayerProperties(imageLayer);
     writeProperties(imageLayer->properties());
 
     mWriter.writeEndTable();
@@ -627,15 +605,8 @@ void LuaWriter::writeGroupLayer(const GroupLayer *groupLayer,
     mWriter.writeStartTable();
 
     mWriter.writeKeyAndValue("type", "group");
-    mWriter.writeKeyAndValue("id", groupLayer->id());
-    mWriter.writeKeyAndValue("name", groupLayer->name());
-    mWriter.writeKeyAndValue("visible", groupLayer->isVisible());
-    mWriter.writeKeyAndValue("opacity", groupLayer->opacity());
 
-    const QPointF offset = groupLayer->offset();
-    mWriter.writeKeyAndValue("offsetx", offset.x());
-    mWriter.writeKeyAndValue("offsety", offset.y());
-
+    writeLayerProperties(groupLayer);
     writeProperties(groupLayer->properties());
 
     writeLayers(groupLayer->layers(), format, compressionLevel, chunkSize);
@@ -705,6 +676,22 @@ void LuaWriter::writeMapObject(const Tiled::MapObject *mapObject)
     }
 
     mWriter.writeEndTable();
+}
+
+void LuaWriter::writeLayerProperties(const Layer *layer)
+{
+    if (layer->id() != 0)
+        mWriter.writeKeyAndValue("id", layer->id());
+    mWriter.writeKeyAndValue("name", layer->name());
+    mWriter.writeKeyAndValue("visible", layer->isVisible());
+    mWriter.writeKeyAndValue("opacity", layer->opacity());
+
+    const QPointF offset = layer->offset();
+    mWriter.writeKeyAndValue("offsetx", offset.x());
+    mWriter.writeKeyAndValue("offsety", offset.y());
+
+    if (layer->tintColor().isValid())
+        writeColor("tintcolor", layer->tintColor());
 }
 
 void LuaWriter::writePolygon(const MapObject *mapObject)

--- a/src/tiled/changeevents.h
+++ b/src/tiled/changeevents.h
@@ -60,6 +60,7 @@ public:
         VisibleProperty         = 1 << 2,
         LockedProperty          = 1 << 3,
         OffsetProperty          = 1 << 4,
+        TintColorProperty       = 1 << 5,
         AllProperties           = 0xFF
     };
 

--- a/src/tiled/changelayer.cpp
+++ b/src/tiled/changelayer.cpp
@@ -109,6 +109,36 @@ void SetLayerLocked::swap()
 }
 
 
+SetLayerTintColor::SetLayerTintColor(Document *document,
+                                 Layer *layer,
+                                 QColor tintColor)
+    : mDocument(document)
+    , mLayer(layer)
+    , mOldTintColor(layer->tintColor())
+    , mNewTintColor(tintColor)
+{
+    setText(QCoreApplication::translate("Undo Commands",
+                                        "Change Layer Tint Color"));
+}
+
+bool SetLayerTintColor::mergeWith(const QUndoCommand *other)
+{
+    const SetLayerTintColor *o = static_cast<const SetLayerTintColor*>(other);
+    if (!(mDocument == o->mDocument &&
+          mLayer == o->mLayer))
+        return false;
+
+    mNewTintColor = o->mNewTintColor;
+    return true;
+}
+
+void SetLayerTintColor::setTintColor(QColor tintColor)
+{
+    mLayer->setTintColor(tintColor);
+    emit mDocument->changed(LayerChangeEvent(mLayer, LayerChangeEvent::TintColorProperty));
+}
+
+
 SetLayerOpacity::SetLayerOpacity(Document *document,
                                  Layer *layer,
                                  qreal opacity)
@@ -158,6 +188,7 @@ void SetLayerOffset::setOffset(const QPointF &offset)
     mLayer->setOffset(offset);
     emit mDocument->changed(LayerChangeEvent(mLayer, LayerChangeEvent::OffsetProperty));
 }
+
 
 SetTileLayerSize::SetTileLayerSize(Document *document,
                                    TileLayer *tileLayer,

--- a/src/tiled/changelayer.h
+++ b/src/tiled/changelayer.h
@@ -25,6 +25,7 @@
 #include <QPointF>
 #include <QSize>
 #include <QUndoCommand>
+#include <QColor>
 
 namespace Tiled {
 
@@ -118,6 +119,29 @@ private:
     Layer *mLayer;
     qreal mOldOpacity;
     qreal mNewOpacity;
+};
+
+class SetLayerTintColor : public QUndoCommand
+{
+public:
+    SetLayerTintColor(Document *document,
+                    Layer *layer,
+                    QColor tintColor);
+
+    void undo() override { setTintColor(mOldTintColor); }
+    void redo() override { setTintColor(mNewTintColor); }
+
+    int id() const override { return Cmd_ChangeLayerTintColor; }
+
+    bool mergeWith(const QUndoCommand *other) override;
+
+private:
+    void setTintColor(QColor tintColor);
+
+    Document *mDocument;
+    Layer *mLayer;
+    QColor mOldTintColor;
+    QColor mNewTintColor;
 };
 
 /**

--- a/src/tiled/mapitem.cpp
+++ b/src/tiled/mapitem.cpp
@@ -366,7 +366,7 @@ void MapItem::documentChanged(const ChangeEvent &change)
 {
     switch (change.type) {
     case ChangeEvent::LayerChanged:
-        layerChanged(static_cast<const LayerChangeEvent&>(change).layer);
+        layerChanged(static_cast<const LayerChangeEvent&>(change));
         break;
     case ChangeEvent::MapObjectsAboutToBeRemoved:
         deleteObjectItems(static_cast<const MapObjectsEvent&>(change).mapObjects);
@@ -442,11 +442,15 @@ void MapItem::layerRemoved(Layer *layer)
  * A layer has changed. This can mean that the layer visibility, opacity or
  * offset changed.
  */
-void MapItem::layerChanged(Layer *layer)
+void MapItem::layerChanged(const LayerChangeEvent &change)
 {
+    Layer *layer = change.layer;
     Preferences *prefs = Preferences::instance();
     QGraphicsItem *layerItem = mLayerItems.value(layer);
     Q_ASSERT(layerItem);
+
+    if (change.properties & LayerChangeEvent::TintColorProperty)
+        layerItem->update();
 
     layerItem->setVisible(layer->isVisible());
 

--- a/src/tiled/mapitem.cpp
+++ b/src/tiled/mapitem.cpp
@@ -449,8 +449,22 @@ void MapItem::layerChanged(const LayerChangeEvent &change)
     QGraphicsItem *layerItem = mLayerItems.value(layer);
     Q_ASSERT(layerItem);
 
-    if (change.properties & LayerChangeEvent::TintColorProperty)
-        layerItem->update();
+    if (change.properties & LayerChangeEvent::TintColorProperty) {
+        switch (layer->layerType()) {
+        case Layer::TileLayerType:
+            layerItem->update();
+            break;
+        case Layer::ObjectGroupType:
+            for (MapObject *mapObject : static_cast<const ObjectGroup&>(*layer)) {
+                if (mapObject->isTileObject())
+                    mObjectItems.value(mapObject)->update();
+            }
+            break;
+        case Layer::ImageLayerType:
+        case Layer::GroupLayerType:
+            break;
+        }
+    }
 
     layerItem->setVisible(layer->isVisible());
 

--- a/src/tiled/mapitem.h
+++ b/src/tiled/mapitem.h
@@ -38,6 +38,7 @@ class TileLayer;
 class Tileset;
 
 class BorderItem;
+class LayerChangeEvent;
 class LayerItem;
 class MapObjectItem;
 class ObjectSelectionItem;
@@ -96,7 +97,7 @@ private:
 
     void layerAdded(Layer *layer);
     void layerRemoved(Layer *layer);
-    void layerChanged(Layer *layer);
+    void layerChanged(const LayerChangeEvent &change);
 
     void imageLayerChanged(ImageLayer *imageLayer);
 

--- a/src/tiled/mapitem.h
+++ b/src/tiled/mapitem.h
@@ -98,6 +98,7 @@ private:
     void layerAdded(Layer *layer);
     void layerRemoved(Layer *layer);
     void layerChanged(const LayerChangeEvent &change);
+    void layerTintColorChanged(Layer *layer);
 
     void imageLayerChanged(ImageLayer *imageLayer);
 

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -733,6 +733,7 @@ void PropertyBrowser::addLayerProperties(QtProperty *parent)
     opacityProperty->setAttribute(QLatin1String("minimum"), 0.0);
     opacityProperty->setAttribute(QLatin1String("maximum"), 1.0);
     opacityProperty->setAttribute(QLatin1String("singleStep"), 0.1);
+    addProperty(TintColorProperty, QVariant::Color, tr("Tint Color"), parent);
 
     addProperty(OffsetXProperty, QVariant::Double, tr("Horizontal Offset"), parent);
     addProperty(OffsetYProperty, QVariant::Double, tr("Vertical Offset"), parent);
@@ -1173,6 +1174,9 @@ QUndoCommand *PropertyBrowser::applyLayerValueTo(PropertyBrowser::PropertyId id,
     case OpacityProperty:
         command = new SetLayerOpacity(mMapDocument, layer, val.toDouble());
         break;
+    case TintColorProperty:
+        command = new SetLayerTintColor(mMapDocument, layer, val.value<QColor>());
+        break;
     case OffsetXProperty:
     case OffsetYProperty: {
         QPointF offset = layer->offset();
@@ -1586,6 +1590,8 @@ void PropertyBrowser::addProperties()
         setExpanded(items(colorProperty).constFirst(), false);
     if (QtProperty *fontProperty = mIdToProperty.value(FontProperty))
         setExpanded(items(fontProperty).constFirst(), false);
+    if (QtProperty *tintColorProperty = mIdToProperty.value(TintColorProperty))
+        setExpanded(items(tintColorProperty).constFirst(), false);
 
     // Add a node for the custom properties
     mCustomPropertiesGroup = mGroupManager->addProperty(tr("Custom Properties"));
@@ -1695,6 +1701,7 @@ void PropertyBrowser::updateProperties()
         mIdToProperty[VisibleProperty]->setValue(layer->isVisible());
         mIdToProperty[LockedProperty]->setValue(layer->isLocked());
         mIdToProperty[OpacityProperty]->setValue(layer->opacity());
+        mIdToProperty[TintColorProperty]->setValue(layer->tintColor());
         mIdToProperty[OffsetXProperty]->setValue(layer->offset().x());
         mIdToProperty[OffsetYProperty]->setValue(layer->offset().y());
 

--- a/src/tiled/propertybrowser.h
+++ b/src/tiled/propertybrowser.h
@@ -144,7 +144,8 @@ private:
         TemplateProperty,
         CompressionLevelProperty,
         ChunkWidthProperty,
-        ChunkHeightProperty
+        ChunkHeightProperty,
+        TintColorProperty
     };
 
     void addMapProperties();

--- a/src/tiled/undocommands.h
+++ b/src/tiled/undocommands.h
@@ -35,7 +35,8 @@ enum UndoCommands {
     Cmd_ChangeTileWangId,
     Cmd_ChangeTilesetTileOffset,
     Cmd_EraseTiles,
-    Cmd_PaintTileLayer
+    Cmd_PaintTileLayer,
+    Cmd_ChangeLayerTintColor
 };
 
 /**


### PR DESCRIPTION
Initial implementation for tinting a tile layer. the matter of stacking the tint of group layers in the same manner it happens with opacity in the current version of tiled was not handled. Also, tinting non tile layers was also not handled.

Closes #2683 