### PR TITLE
Speed up first-draw by reducing initial map size

### DIFF
--- a/src/tiled/mapview.cpp
+++ b/src/tiled/mapview.cpp
@@ -126,9 +126,15 @@ void MapView::fitMapInView()
     if (rect.isEmpty())
         return;
 
-    // Scale and center map to fit in view
+    // Scale and center map to fit in view. For extremely large maps (by pixels), avoid going below
+    // 1% scale. For extremely large maps (by tiles), avoid putting more than 4,000 tiles within the
+    // view. Approximated to 4096 tiles, 64 * 64.
     centerOn(rect.center());
-    setScale(std::min(width() / rect.width(), height() / rect.height()) * 0.95);
+    qreal pixelScale = std::min(width() / rect.width(), height() / rect.height()) * 0.95;
+    auto tileSize = mapScene()->mapDocument()->map()->tileSize();
+    qreal minimumScale = std::min(width() / (64.0 * tileSize.width()), height() / (64.0 * tileSize.height()));
+    qreal scale = std::max(pixelScale, minimumScale);
+    setScale(std::max(scale, 0.01));
 }
 
 void MapView::adjustScale(qreal scale)

--- a/src/tiled/mapview.cpp
+++ b/src/tiled/mapview.cpp
@@ -126,15 +126,18 @@ void MapView::fitMapInView()
     if (rect.isEmpty())
         return;
 
-    // Scale and center map to fit in view. For extremely large maps (by pixels), avoid going below
-    // 1% scale. For extremely large maps (by tiles), avoid putting more than 66,000 tiles within the
-    // view. Approximated to 65536 tiles, 256 * 256.
+    // Scale and center map to fit in view, while avoiding to go below the
+    // minimum scale. For extremely large maps, avoid putting more than about
+    // 256 * 256 tiles within the view for performance reasons.
+    qreal desiredScale = std::min(width() / rect.width(),
+                                  height() / rect.height()) * 0.95;
+
+    auto tileSize = mMapDocument->map()->tileSize();
+    qreal scale256 = std::min(width() / (256.0 * tileSize.width()),
+                              height() / (256.0 * tileSize.height()));
+
     centerOn(rect.center());
-    qreal pixelScale = std::min(width() / rect.width(), height() / rect.height()) * 0.95;
-    auto tileSize = mapScene()->mapDocument()->map()->tileSize();
-    qreal minimumScale = std::min(width() / (256.0 * tileSize.width()), height() / (256.0 * tileSize.height()));
-    qreal scale = std::max(pixelScale, minimumScale);
-    setScale(std::max(scale, 0.01));
+    setScale(std::max(std::max(desiredScale, scale256), 0.015625));
 }
 
 void MapView::adjustScale(qreal scale)

--- a/src/tiled/mapview.cpp
+++ b/src/tiled/mapview.cpp
@@ -127,12 +127,12 @@ void MapView::fitMapInView()
         return;
 
     // Scale and center map to fit in view. For extremely large maps (by pixels), avoid going below
-    // 1% scale. For extremely large maps (by tiles), avoid putting more than 4,000 tiles within the
-    // view. Approximated to 4096 tiles, 64 * 64.
+    // 1% scale. For extremely large maps (by tiles), avoid putting more than 66,000 tiles within the
+    // view. Approximated to 65536 tiles, 256 * 256.
     centerOn(rect.center());
     qreal pixelScale = std::min(width() / rect.width(), height() / rect.height()) * 0.95;
     auto tileSize = mapScene()->mapDocument()->map()->tileSize();
-    qreal minimumScale = std::min(width() / (64.0 * tileSize.width()), height() / (64.0 * tileSize.height()));
+    qreal minimumScale = std::min(width() / (256.0 * tileSize.width()), height() / (256.0 * tileSize.height()));
     qreal scale = std::max(pixelScale, minimumScale);
     setScale(std::max(scale, 0.01));
 }


### PR DESCRIPTION
Previously, loading a large map initialized the zoom to arbitrarily small
scales. During my testing, a 3000x3000 map would load in at 0.06% zoom.
Rendering all those tiles made the first draw and any user actions,
including zooming back in, very very slow.

This commit caps the number of tiles on screen to about 4,000 for the first
draw. The user is still free to zoom out, but the app will start out much
more responsive.

Split off from #2701 