### PR TITLE
Fix console warning about Tiled::Issue

### DIFF
--- a/src/libtiled/logginginterface.cpp
+++ b/src/libtiled/logginginterface.cpp
@@ -55,6 +55,7 @@ Issue::Issue(Issue::Severity severity,
     , mContext(context)
     , mId(mNextIssueId++)
 {
+    qRegisterMetaType<Issue>();
 }
 
 void Issue::setCallback(std::function<void ()> callback)


### PR DESCRIPTION
It was declared as a metatype, but wasn't registered as a metatype at
runtime.