### PR TITLE
Create XML scripting API

### DIFF
--- a/docs/reference/scripting.rst
+++ b/docs/reference/scripting.rst
@@ -1678,3 +1678,127 @@ BinaryFile.commit() : void
 BinaryFile.close() : void
     Closes the file. It is recommended to always call this function as soon as
     you are finished with the file.
+
+XmlFile
+~~~~~~~
+
+**Properties**
+
+.. csv-table::
+    :widths: 1, 2
+
+    **root** : XmlFile |ro|, A reference to itself (useful for algorithms)
+    **children** : XmlList |ro|, A special kind of list with all the direct children of this element
+
+**Functions**
+
+new XmlFile(text : string)
+    Creates a new Xml document by parsing `text`.
+
+new XmlFile(source : TextFile)
+    Convenience function; same as `new XmlFile(source.readAll())`
+
+XmlFile.childByName(name : string) : XmlElement
+    Find the first child with the given tag name. Returns null if no
+    child was found.
+
+XmlFile.childrenByName(name : string) : [XmlElement]
+    Find all children with the given tag name.
+
+XmlFile.writeToString() : string
+    Returns this XML document represented as a string.
+
+XmlElement
+~~~~~~~~~~
+
+**Properties**
+
+.. csv-table::
+    :widths: 1, 2
+
+    **root** : XmlFile |ro|, The XML file this element belongs to
+    **children** : XmlList |ro|, A special kind of list with all the direct children of this element
+    **attributes** : XmlAttributes |ro|, The attributes on this element
+    **name** : string, The tag name of this element
+    **parent** : XmlElement or XmlFile |ro|, The direct parent of this element
+    **isTextOnly** : bool |ro|, Whether this element represents text between other elements
+    **value** : string, The text inside this element, or "" if there are child elements
+
+**Functions**
+
+new XmlElement([name : string = ""])
+    Creates a new element with the given name.
+
+XmlList
+~~~~~~~
+
+For technical reasons, we can't use plain JS arrays for XML data.
+
+**Properties**
+
+.. csv-table::
+    :widths: 1, 2
+
+    **length** : int, The length of this list
+
+**Functions**
+
+XmlList.get(index : int) : XmlElement
+    Get the element at the given index.
+
+XmlList.set(index : int, element : XmlElement) : void
+    Replace the element at the given index.
+
+XmlList.insert(index : int, element : XmlElement) : void
+    Insert the element at the given index, shifting the rest up by one.
+
+XmlList.append(element : XmlElement) : void
+    Add a new element to the end of the list.
+
+XmlList.push(element : XmlElement) : void
+    Same as append; provided for convenience.
+
+XmlList.remove(index : int) : void
+    Delete the element at the given index.
+
+XmlList.clear() : void
+    Delete all elements from this list.
+
+XmlList.find(element : XmlElement) : int or undefined
+    Find the index of an element in the list. Uses C++ reference equality
+    (which may be different than XmlElement === XmlElement)
+
+XmlList.toRaw() : [XmlElement]
+    Create a normal array representation of this list. Changes to the array will
+    not change this object.
+
+XmlAttributes
+~~~~~~~~~~~~~
+
+**Properties**
+
+.. csv-table::
+    :widths: 1, 2
+
+    **length** : int, The number of unique attributes
+    **keys** : [string], All the attribute names
+    **values** : [string], All the attribute values
+
+**Functions**
+
+XmlAttributes.get(name : string) : string or undefined
+    Returns the value of the attribute, if it exists. Returns undefined otherwise.
+
+XmlAttributes.set(name : string, value : string) : void
+    Sets the value for the given attribute, creating it if it didn't already exist.
+
+XmlAttributes.remove(name : string) : void
+    Removes the given attribute.
+
+XmlAttributes.merge(other : object) : void
+    Merge all key-value pairs of `other` as attributes. Values will be converted to
+    strings.
+
+XmlAttributes.toRaw() : object
+    The attributes as a plain JS object. Changes to the raw object will not change
+    this object.

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -39,6 +39,7 @@
 #include "scriptfile.h"
 #include "scriptfileformatwrappers.h"
 #include "scriptmodule.h"
+#include "scriptxmlfile.h"
 #include "tilecollisiondock.h"
 #include "tilelayer.h"
 #include "tilelayeredit.h"
@@ -51,6 +52,7 @@
 #include <QStandardPaths>
 #include <QTextCodec>
 #include <QtDebug>
+#include <QtXml/QDomDocument>
 
 namespace Tiled {
 
@@ -108,6 +110,11 @@ ScriptManager::ScriptManager(QObject *parent)
     qRegisterMetaType<TilesetEditor*>();
     qRegisterMetaType<ScriptMapFormatWrapper*>();
     qRegisterMetaType<ScriptTilesetFormatWrapper*>();
+    qRegisterMetaType<ScriptXMLFile*>();
+    qRegisterMetaType<ScriptXMLElement*>();
+    qRegisterMetaType<ScriptXMLList*>();
+    qRegisterMetaType<ScriptXMLAttributes*>();
+    qRegisterMetaType<ScriptXMLNode*>();
 
     connect(&mWatcher, &FileSystemWatcher::filesChanged,
             this, &ScriptManager::scriptFilesChanged);
@@ -138,6 +145,8 @@ void ScriptManager::initialize()
     globalObject.setProperty(QStringLiteral("TileLayer"), mEngine->newQMetaObject<EditableTileLayer>());
     globalObject.setProperty(QStringLiteral("TileMap"), mEngine->newQMetaObject<EditableMap>());
     globalObject.setProperty(QStringLiteral("Tileset"), mEngine->newQMetaObject<EditableTileset>());
+    globalObject.setProperty(QStringLiteral("XmlFile"), mEngine->newQMetaObject<ScriptXMLFile>());
+    globalObject.setProperty(QStringLiteral("XmlElement"), mEngine->newQMetaObject<ScriptXMLElement>());
 #endif
 
     loadExtensions();

--- a/src/tiled/scriptxmlfile.cpp
+++ b/src/tiled/scriptxmlfile.cpp
@@ -1,0 +1,323 @@
+#include "scriptxmlfile.h"
+
+#include "scriptmanager.h"
+#include "scriptfile.h"
+
+#include <QTextStream>
+#include <QtXml/QDomNode>
+
+namespace Tiled {
+
+ScriptXMLAttributes::ScriptXMLAttributes(QDomNamedNodeMap map, QDomElement parentNode, QObject *parent)
+    : QObject(parent)
+    , mMap(map)
+    , mParentNode(parentNode)
+{}
+
+QVariant ScriptXMLAttributes::get(const QString &key) const
+{
+    auto node = mMap.namedItem(key);
+    if (node.isNull())
+        return QVariant();
+    else
+        return QVariant(node.nodeValue());
+}
+
+void ScriptXMLAttributes::set(const QString &key, const QString &value)
+{
+    auto attribute = mParentNode.ownerDocument().createAttribute(key);
+    attribute.setValue(value);
+    mMap.setNamedItem(attribute);
+}
+
+void ScriptXMLAttributes::remove(const QString &key)
+{
+    mMap.removeNamedItem(key);
+}
+
+void ScriptXMLAttributes::merge(const QVariantMap &other)
+{
+    for (auto it = other.begin(); it != other.end(); ++it)
+        set(it.key(), it.value().toString());
+}
+
+QVariantMap ScriptXMLAttributes::toRaw()
+{
+    QVariantMap ret;
+    for (int i = 0; i < mMap.size(); i++) {
+        auto attribute = mMap.item(i);
+        ret.insert(attribute.nodeName(), attribute.nodeValue());
+    }
+    return ret;
+}
+
+QStringList ScriptXMLAttributes::keys()
+{
+    QStringList ret;
+    for (int i = 0; i < mMap.size(); i++) {
+        auto attribute = mMap.item(i);
+        ret.append(attribute.nodeName());
+    }
+    return ret;
+}
+
+QStringList ScriptXMLAttributes::values()
+{
+    QStringList ret;
+    for (int i = 0; i < mMap.size(); i++) {
+        auto attribute = mMap.item(i);
+        ret.append(attribute.nodeValue());
+    }
+    return ret;
+}
+
+int ScriptXMLAttributes::length()
+{
+    return mMap.length();
+}
+
+ScriptXMLList::ScriptXMLList(QDomNodeList list, QDomNode parentNode, QObject *parent)
+    : QObject(parent)
+    , mList(list)
+    , mParentNode(parentNode)
+{}
+
+ScriptXMLNode *ScriptXMLList::get(int index)
+{
+    if (index >= length())
+        return nullptr;
+    else
+        return new ScriptXMLElement(mList.at(index));
+}
+
+void ScriptXMLList::insert(int index, ScriptXMLNode *node)
+{
+    if (index >= length())
+        append(node);
+    else
+        mParentNode.insertBefore(node->node(), mList.at(index));
+}
+
+void ScriptXMLList::remove(int index)
+{
+    if (index >= length())
+        return;
+    mParentNode.removeChild(mList.at(index));
+}
+
+void ScriptXMLList::set(int index, ScriptXMLNode *node)
+{
+    if (index >= length())
+        append(node);
+    else
+        mParentNode.replaceChild(node->node(), mList.at(index));
+}
+
+void ScriptXMLList::append(ScriptXMLNode *node)
+{
+    mParentNode.appendChild(node->node());
+}
+
+void ScriptXMLList::push(ScriptXMLNode *node)
+{
+    append(node);
+}
+
+void ScriptXMLList::clear()
+{
+    while (mParentNode.hasChildNodes())
+        mParentNode.removeChild(mParentNode.lastChild());
+}
+
+QVariant ScriptXMLList::find(ScriptXMLNode *node)
+{
+    auto domNode = node->node();
+    for (int i = 0; i < mList.length(); i++) {
+        if (mList.at(i) == domNode)
+            return QVariant(i);
+    }
+    return QVariant();
+}
+
+QList<ScriptXMLElement*> ScriptXMLList::toRaw()
+{
+    QList<ScriptXMLElement*> ret;
+    ret.reserve(mList.length());
+    for (int i = 0; i < mList.length(); i++) {
+        ret.append(new ScriptXMLElement(mList.at(i)));
+    }
+    return ret;
+}
+
+int ScriptXMLList::length()
+{
+    return mList.length();
+}
+
+ScriptXMLNode::ScriptXMLNode(QDomNode *node, QObject *parent)
+    : QObject(parent)
+    , mNode(node)
+{
+    Q_ASSERT(node);
+}
+
+ScriptXMLElement *ScriptXMLNode::childByName(const QString &name)
+{
+    auto node = mNode->firstChildElement(name);
+    if (node.isNull())
+        return nullptr;
+    else
+        return new ScriptXMLElement(node);
+}
+
+QList<ScriptXMLElement*> ScriptXMLNode::childrenByName(const QString &name)
+{
+    QList<ScriptXMLElement*> ret;
+    auto children = mNode->childNodes();
+    for (int i = 0; i < children.length(); i++) {
+        auto current = children.at(i);
+        if (current.nodeName().compare(name, Qt::CaseInsensitive) == 0)
+            ret.append(new ScriptXMLElement(current));
+    }
+    return ret;
+}
+
+ScriptXMLList *ScriptXMLNode::children()
+{
+    if (mNode->hasChildNodes())
+        return new ScriptXMLList(mNode->childNodes(), *mNode);
+    else
+        return nullptr;
+}
+
+ScriptXMLFile *ScriptXMLNode::root()
+{
+    auto document = mNode->ownerDocument();
+    if (document.isNull())
+        return nullptr;
+    else
+        return new ScriptXMLFile(document);
+}
+
+QDomNode ScriptXMLNode::node()
+{
+    return *mNode;
+}
+
+ScriptXMLElement::ScriptXMLElement(QDomNode element, QObject *parent)
+    : ScriptXMLNode(&mElement, parent)
+    , mElement(element)
+{}
+
+ScriptXMLElement::ScriptXMLElement(const QString &name, QObject *parent)
+    : ScriptXMLNode(&mElement, parent)
+    , mElement(QDomElement())
+{
+    mElement.toElement().setTagName(name);
+}
+
+ScriptXMLAttributes *ScriptXMLElement::attributes()
+{
+    if (mElement.isElement())
+        return new ScriptXMLAttributes(mElement.toElement().attributes(), mElement.toElement());
+    else
+        return nullptr;
+}
+
+QString ScriptXMLElement::name()
+{
+    return mElement.nodeName();
+}
+
+ScriptXMLNode *ScriptXMLElement::parent()
+{
+    if (mElement.parentNode().isDocument())
+        return root();
+    else
+        return new ScriptXMLElement(mElement.parentNode().toElement(), root());
+}
+
+QString ScriptXMLElement::value()
+{
+    if (mElement.isText())
+        return mElement.nodeValue();
+    if (mElement.childNodes().count() == 1 && mElement.firstChild().isText())
+        return mElement.firstChild().nodeValue();
+
+    // TODO: Should we throw an error here, or log a warning?
+    return QString();
+}
+
+bool ScriptXMLElement::isTextOnly()
+{
+    return mElement.isText();
+}
+
+void ScriptXMLElement::setValue(const QString &text)
+{
+    // TODO: This breaks if mElement is neither a text node nor an element node.
+    // (e.g. a comment)
+    if (mElement.isText()) {
+        mElement.toText().setNodeValue(text);
+    } else if (mElement.childNodes().length() == 1 && mElement.firstChild().isText()) {
+        mElement.firstChild().toText().setNodeValue(text);
+    } else if (!mElement.hasChildNodes()) {
+        auto textNode = root()->document().createTextNode(text);
+        mElement.appendChild(textNode);
+    } else {
+        while (mElement.hasChildNodes())
+            mElement.removeChild(mElement.lastChild());
+        auto textNode = root()->document().createTextNode(text);
+        mElement.appendChild(textNode);
+    }
+}
+
+void ScriptXMLElement::setName(const QString &name)
+{
+    if (mElement.isElement())
+        mElement.toElement().setTagName(name);
+    else {
+        // TODO: Should we throw an error here, or log a warning?
+    }
+}
+
+ScriptXMLFile::ScriptXMLFile(const QString &source, QObject *parent)
+    : ScriptXMLNode(&mDocument, parent)
+{
+    if (source.isEmpty())
+        return;
+
+    QString errorMessage;
+    int lineNumber;
+    int columnNumber;
+    if (!mDocument.setContent(source, false, &errorMessage, &lineNumber, &columnNumber)) {
+        auto message = QStringLiteral("Error on line %1, column %2: %3")
+                .arg(lineNumber).arg(columnNumber).arg(errorMessage);
+        ScriptManager::instance().throwError(message);
+        mDocument.setContent(QString());
+        return;
+    }
+}
+
+ScriptXMLFile::ScriptXMLFile(ScriptTextFile *source, QObject *parent)
+    : ScriptXMLFile(source->readAll(), parent)
+{}
+
+ScriptXMLFile::ScriptXMLFile(QDomDocument document, QObject *parent)
+    : ScriptXMLNode(&mDocument, parent)
+    , mDocument(document)
+{}
+
+QString ScriptXMLFile::writeToString()
+{
+    QString buffer;
+    QTextStream stream(&buffer);
+    mDocument.save(stream, 0);
+    return buffer;
+}
+
+QDomDocument &ScriptXMLFile::document() {
+    return mDocument;
+}
+
+}

--- a/src/tiled/scriptxmlfile.cpp
+++ b/src/tiled/scriptxmlfile.cpp
@@ -1,3 +1,23 @@
+/*
+ * scriptxmlfile.cpp
+ * Copyright 2019, Phlosioneer <mattmdrr2@gmail.com>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "scriptxmlfile.h"
 
 #include "scriptmanager.h"

--- a/src/tiled/scriptxmlfile.h
+++ b/src/tiled/scriptxmlfile.h
@@ -1,0 +1,141 @@
+
+#pragma once
+
+#include <QObject>
+#include <QVector>
+#include <QSharedPointer>
+#include <QMap>
+#include <QtXml/QDomDocument>
+#include <QVariant>
+
+
+namespace Tiled {
+
+class ScriptXMLNode;
+class ScriptXMLFile;
+class ScriptXMLElement;
+class ScriptTextFile;
+
+class ScriptXMLAttributes : public QObject {
+    Q_OBJECT
+
+    Q_PROPERTY(QStringList keys READ keys)
+    Q_PROPERTY(QStringList values READ values)
+    Q_PROPERTY(int length READ length)
+public:
+    explicit ScriptXMLAttributes(QDomNamedNodeMap map, QDomElement parentNode, QObject *parent = nullptr);
+
+    Q_INVOKABLE QVariant get(const QString &key) const;
+    Q_INVOKABLE void set(const QString &key, const QString &value);
+    Q_INVOKABLE void remove(const QString &key);
+    Q_INVOKABLE void merge(const QVariantMap &other);
+    Q_INVOKABLE QVariantMap toRaw();
+
+    QStringList keys();
+    QStringList values();
+    int length();
+
+private:
+    QDomNamedNodeMap mMap;
+    QDomElement mParentNode;
+};
+
+class ScriptXMLList : public QObject {
+    Q_OBJECT
+
+    Q_PROPERTY(int length READ length)
+
+public:
+    explicit ScriptXMLList(QDomNodeList list, QDomNode parentNode, QObject *parent = nullptr);
+
+    Q_INVOKABLE Tiled::ScriptXMLNode *get(int index);
+    Q_INVOKABLE void insert(int index, Tiled::ScriptXMLNode *node);
+    Q_INVOKABLE void remove(int index);
+    Q_INVOKABLE void set(int index, Tiled::ScriptXMLNode *node);
+    Q_INVOKABLE void append(Tiled::ScriptXMLNode *node);
+    Q_INVOKABLE void push(Tiled::ScriptXMLNode *node);
+    Q_INVOKABLE void clear();
+
+    Q_INVOKABLE QVariant find(Tiled::ScriptXMLNode *node);
+    Q_INVOKABLE QList<ScriptXMLElement*> toRaw();
+
+    int length();
+
+private:
+    QDomNodeList mList;
+    QDomNode mParentNode;
+};
+
+class ScriptXMLNode : public QObject {
+    Q_OBJECT
+
+    Q_PROPERTY(Tiled::ScriptXMLList *children READ children)
+    Q_PROPERTY(Tiled::ScriptXMLFile *root READ root)
+
+public:
+    explicit ScriptXMLNode(QDomNode *node, QObject *parent = nullptr);
+
+    Q_INVOKABLE Tiled::ScriptXMLElement *childByName(const QString &name);
+    Q_INVOKABLE QList<Tiled::ScriptXMLElement*> childrenByName(const QString &name);
+
+    ScriptXMLList *children();
+    ScriptXMLFile *root();
+
+    QDomNode node();
+
+private:
+    QDomNode *mNode;
+};
+
+/**
+ * Represents either an element node or a text node.
+ */
+class ScriptXMLElement : public ScriptXMLNode {
+    Q_OBJECT
+
+    Q_PROPERTY(Tiled::ScriptXMLAttributes *attributes READ attributes)
+    Q_PROPERTY(QString name READ name WRITE setName)
+    Q_PROPERTY(Tiled::ScriptXMLNode *parent READ parent)
+    Q_PROPERTY(bool isTextOnly READ isTextOnly)
+    Q_PROPERTY(QString value READ value WRITE setValue)
+
+public:
+    explicit ScriptXMLElement(QDomNode element, QObject *parent = nullptr);
+    Q_INVOKABLE explicit ScriptXMLElement(const QString &name = QString(), QObject *parent = nullptr);
+
+    ScriptXMLAttributes *attributes();
+    QString name();
+    ScriptXMLNode *parent();
+    QString value();
+    bool isTextOnly();
+
+    void setValue(const QString &text);
+    void setName(const QString &name);
+private:
+    QDomNode mElement;
+};
+
+class ScriptXMLFile : public ScriptXMLNode {
+    Q_OBJECT
+
+public:
+    Q_INVOKABLE explicit ScriptXMLFile(Tiled::ScriptTextFile *source, QObject *parent = nullptr);
+    Q_INVOKABLE explicit ScriptXMLFile(const QString &source = {}, QObject *parent = nullptr);
+    explicit ScriptXMLFile(QDomDocument document, QObject *parent = nullptr);
+
+    Q_INVOKABLE QString writeToString();
+
+    QDomDocument &document();
+
+private:
+    QDomDocument mDocument;
+};
+
+} // namespace Tiled
+
+Q_DECLARE_METATYPE(Tiled::ScriptXMLElement*);
+Q_DECLARE_METATYPE(Tiled::ScriptXMLAttributes*);
+Q_DECLARE_METATYPE(Tiled::ScriptXMLList*);
+Q_DECLARE_METATYPE(Tiled::ScriptXMLNode*);
+Q_DECLARE_METATYPE(Tiled::ScriptXMLFile*);
+

--- a/src/tiled/scriptxmlfile.h
+++ b/src/tiled/scriptxmlfile.h
@@ -1,3 +1,22 @@
+/*
+ * scriptxmlfile.h
+ * Copyright 2019, Phlosioneer <mattmdrr2@gmail.com>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
 

--- a/src/tiled/tiled.pro
+++ b/src/tiled/tiled.pro
@@ -13,7 +13,7 @@ win32 {
     DESTDIR = ../../bin
 }
 
-QT += widgets qml
+QT += widgets qml xml
 
 DEFINES += TILED_VERSION=$${TILED_VERSION}
 
@@ -210,6 +210,7 @@ SOURCES += aboutdialog.cpp \
     scriptfileformatwrappers.cpp \
     scriptmanager.cpp \
     scriptmodule.cpp \
+    scriptxmlfile.cpp \
     selectionrectangle.cpp \
     selectsametiletool.cpp \
     session.cpp \
@@ -442,6 +443,7 @@ HEADERS += aboutdialog.h \
     scriptfileformatwrappers.h \
     scriptmanager.h \
     scriptmodule.h \
+    scriptxmlfile.h \
     selectionrectangle.h \
     selectsametiletool.h \
     session.h \

--- a/src/tiled/tiled.qbs
+++ b/src/tiled/tiled.qbs
@@ -13,7 +13,7 @@ QtGuiApplication {
     Depends { name: "qtpropertybrowser" }
     Depends { name: "qtsingleapplication" }
     Depends { name: "ib"; condition: qbs.targetOS.contains("macos") }
-    Depends { name: "Qt"; submodules: ["core", "widgets", "qml"]; versionAtLeast: "5.6" }
+    Depends { name: "Qt"; submodules: ["core", "widgets", "qml", "xml"]; versionAtLeast: "5.6" }
 
     property bool qtcRunnable: true
 
@@ -420,6 +420,8 @@ QtGuiApplication {
         "scriptmanager.h",
         "scriptmodule.cpp",
         "scriptmodule.h",
+        "scriptxmlfile.cpp",
+        "scriptxmlfile.h",
         "selectionrectangle.cpp",
         "selectionrectangle.h",
         "selectsametiletool.cpp",


### PR DESCRIPTION
The API is a thin wrapper around Qt's QDomDocument class, with some
ergonomic improvements (lists are mutable, attributes aren't nodes,
single-child text nodes are transparent).

Closes #2665