### PR TITLE
support converting object reference property to and from int

### DIFF
--- a/src/libtiled/properties.h
+++ b/src/libtiled/properties.h
@@ -55,6 +55,9 @@ struct TILEDSHARED_EXPORT ObjectRef
 
 public:
     int id;
+
+    static int toInt(const ObjectRef &ref) { return ref.id; }
+    static ObjectRef fromInt(int id) { return ObjectRef { id }; }
 };
 
 class TILEDSHARED_EXPORT AggregatedPropertyData

--- a/src/libtiled/properties.h
+++ b/src/libtiled/properties.h
@@ -46,6 +46,9 @@ class TILEDSHARED_EXPORT FilePath
 
 public:
     QUrl url;
+
+    static QString toString(const FilePath &path);
+    static FilePath fromString(const QString &string);
 };
 
 struct TILEDSHARED_EXPORT ObjectRef
@@ -125,6 +128,8 @@ TILEDSHARED_EXPORT QVariant fromExportValue(const QVariant &value, int type);
 
 TILEDSHARED_EXPORT QVariant toExportValue(const QVariant &value, const QDir &dir);
 TILEDSHARED_EXPORT QVariant fromExportValue(const QVariant &value, int type, const QDir &dir);
+
+TILEDSHARED_EXPORT void initializeMetatypes();
 
 } // namespace Tiled
 

--- a/src/tiled/main.cpp
+++ b/src/tiled/main.cpp
@@ -355,6 +355,9 @@ int main(int argc, char *argv[])
 
     TiledApplication a(argc, argv);
 
+    QMetaType::registerConverter<ObjectRef, int>(&ObjectRef::toInt);
+    QMetaType::registerConverter<int, ObjectRef>(&ObjectRef::fromInt);
+
     a.setOrganizationDomain(QLatin1String("mapeditor.org"));
 #if defined(Q_OS_MAC) || defined(Q_OS_WIN)
     a.setApplicationName(QLatin1String("Tiled"));

--- a/src/tiled/main.cpp
+++ b/src/tiled/main.cpp
@@ -355,8 +355,7 @@ int main(int argc, char *argv[])
 
     TiledApplication a(argc, argv);
 
-    QMetaType::registerConverter<ObjectRef, int>(&ObjectRef::toInt);
-    QMetaType::registerConverter<int, ObjectRef>(&ObjectRef::fromInt);
+    initializeMetatypes();
 
     a.setOrganizationDomain(QLatin1String("mapeditor.org"));
 #if defined(Q_OS_MAC) || defined(Q_OS_WIN)

--- a/src/tiled/propertiesdock.cpp
+++ b/src/tiled/propertiesdock.cpp
@@ -395,6 +395,7 @@ void PropertiesDock::showContextMenu(const QPoint& pos)
             QVariant::Color,
             QVariant::Double,
             filePathTypeId(),
+            objectRefTypeId(),
             QVariant::Int,
             QVariant::String
         };

--- a/src/tiled/propertybrowser.cpp
+++ b/src/tiled/propertybrowser.cpp
@@ -443,9 +443,9 @@ void PropertyBrowser::propertyAdded(Object *object, const QString &name)
 {
     if (!objectPropertiesRelevant(mDocument, object))
         return;
-    if (mNameToProperty.contains(name)) {
+    if (QtVariantProperty *property = mNameToProperty.value(name)) {
         if (propertyValueAffected(mObject, object, name))
-            setCustomPropertyValue(mNameToProperty[name], object->property(name));
+            setCustomPropertyValue(property, object->property(name));
     } else {
         QVariant value;
         if (mObject->hasProperty(name))
@@ -453,7 +453,7 @@ void PropertyBrowser::propertyAdded(Object *object, const QString &name)
         else
             value = predefinedPropertyValue(mObject, name);
 
-        createCustomProperty(name, value);
+        createCustomProperty(name, toDisplayValue(value));
     }
     updateCustomPropertyColor(name);
 }
@@ -1512,9 +1512,8 @@ QtVariantProperty *PropertyBrowser::createCustomProperty(const QString &name, co
     }
 
     mUpdating = true;
-    const QVariant displayValue = toDisplayValue(value);
-    QtVariantProperty *property = createProperty(CustomProperty, displayValue.userType(), name);
-    property->setValue(displayValue);
+    QtVariantProperty *property = createProperty(CustomProperty, value.userType(), name);
+    property->setValue(value);
     mCustomPropertiesGroup->insertSubProperty(property, precedingProperty);
 
     // Collapse custom color properties, to save space
@@ -1535,20 +1534,22 @@ void PropertyBrowser::deleteCustomProperty(QtVariantProperty *property)
 void PropertyBrowser::setCustomPropertyValue(QtVariantProperty *property,
                                              const QVariant &value)
 {
-    if (value.userType() != property->valueType()) {
+    const QVariant displayValue = toDisplayValue(value);
+
+    if (displayValue.userType() != property->valueType()) {
         // Re-creating the property is necessary to change its type
         const QString name = property->propertyName();
         const bool wasCurrent = currentItem() && currentItem()->property() == property;
 
         deleteCustomProperty(property);
-        property = createCustomProperty(name, value);
+        property = createCustomProperty(name, displayValue);
         updateCustomPropertyColor(name);
 
         if (wasCurrent)
             setCurrentItem(items(property).constFirst());
     } else {
         mUpdating = true;
-        property->setValue(toDisplayValue(value));
+        property->setValue(displayValue);
         mUpdating = false;
     }
 }

--- a/src/tiled/variantpropertymanager.cpp
+++ b/src/tiled/variantpropertymanager.cpp
@@ -89,9 +89,9 @@ bool VariantPropertyManager::isPropertyTypeSupported(int propertyType) const
 int VariantPropertyManager::valueType(int propertyType) const
 {
     if (propertyType == filePathTypeId())
-        return QVariant::String;
+        return propertyType;
     if (propertyType == displayObjectRefTypeId())
-        return QVariant::String;
+        return propertyType;
     if (propertyType == tilesetParametersTypeId())
         return qMetaTypeId<TilesetDocument*>();
     if (propertyType == alignmentTypeId())


### PR DESCRIPTION
Users could have previously had custom properties of type int that
referenced objects by ID. Registering a converter for ObjectRef to
and from int should help migration to the new object reference type.

Updates #707