### PR TITLE
Added checks for nullptr in script arguments

### DIFF
--- a/src/tiled/editablemap.cpp
+++ b/src/tiled/editablemap.cpp
@@ -497,10 +497,6 @@ void EditableMap::setLayerDataFormat(LayerDataFormat value)
 
 void EditableMap::setCurrentLayer(EditableLayer *layer)
 {
-    if (!layer) {
-        ScriptManager::instance().throwNullArgError(0);
-        return;
-    }
     QList<QObject*> layers;
     if (layer)
         layers.append(layer);

--- a/src/tiled/editablemap.cpp
+++ b/src/tiled/editablemap.cpp
@@ -183,7 +183,7 @@ void EditableMap::removeLayerAt(int index)
 void EditableMap::removeLayer(EditableLayer *editableLayer)
 {
     if (!editableLayer) {
-        ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Invalid argument"));
+        ScriptManager::instance().throwNullArgError(0);
         return;
     }
 
@@ -204,7 +204,7 @@ void EditableMap::insertLayerAt(int index, EditableLayer *editableLayer)
     }
 
     if (!editableLayer) {
-        ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Invalid argument"));
+        ScriptManager::instance().throwNullArgError(0);
         return;
     }
 
@@ -228,6 +228,10 @@ void EditableMap::addLayer(EditableLayer *editableLayer)
 
 bool EditableMap::addTileset(EditableTileset *editableTileset)
 {
+    if (!editableTileset) {
+        ScriptManager::instance().throwNullArgError(0);
+        return false;
+    }
     const auto &tileset = editableTileset->tileset()->sharedPointer();
     if (map()->indexOfTileset(tileset) != -1)
         return false;   // can't add existing tileset
@@ -243,6 +247,14 @@ bool EditableMap::addTileset(EditableTileset *editableTileset)
 bool EditableMap::replaceTileset(EditableTileset *oldEditableTileset,
                                  EditableTileset *newEditableTileset)
 {
+    if (!oldEditableTileset) {
+        ScriptManager::instance().throwNullArgError(0);
+        return false;
+    }
+    if (!newEditableTileset) {
+        ScriptManager::instance().throwNullArgError(1);
+        return false;
+    }
     if (oldEditableTileset == newEditableTileset) {
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Invalid argument"));
         return false;
@@ -268,6 +280,10 @@ bool EditableMap::replaceTileset(EditableTileset *oldEditableTileset,
 
 bool EditableMap::removeTileset(EditableTileset *editableTileset)
 {
+    if (!editableTileset) {
+        ScriptManager::instance().throwNullArgError(0);
+        return false;
+    }
     Tileset *tileset = editableTileset->tileset();
     int index = map()->indexOfTileset(tileset->sharedPointer());
     if (index == -1)
@@ -308,6 +324,10 @@ QList<QObject *> EditableMap::usedTilesets() const
  */
 void EditableMap::merge(EditableMap *editableMap, bool canJoin)
 {
+    if (!editableMap) {
+        ScriptManager::instance().throwNullArgError(0);
+        return;
+    }
     if (!mapDocument()) {   // todo: support this outside of the undo stack
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Merge is currently not supported for detached maps"));
         return;
@@ -477,6 +497,10 @@ void EditableMap::setLayerDataFormat(LayerDataFormat value)
 
 void EditableMap::setCurrentLayer(EditableLayer *layer)
 {
+    if (!layer) {
+        ScriptManager::instance().throwNullArgError(0);
+        return;
+    }
     QList<QObject*> layers;
     if (layer)
         layers.append(layer);

--- a/src/tiled/editableobjectgroup.cpp
+++ b/src/tiled/editableobjectgroup.cpp
@@ -81,6 +81,10 @@ void EditableObjectGroup::removeObjectAt(int index)
 
 void EditableObjectGroup::removeObject(EditableMapObject *editableMapObject)
 {
+    if (!editableMapObject) {
+        ScriptManager::instance().throwNullArgError(0);
+        return;
+    }
     int index = objectGroup()->objects().indexOf(editableMapObject->mapObject());
     if (index == -1) {
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Object not found"));
@@ -92,6 +96,10 @@ void EditableObjectGroup::removeObject(EditableMapObject *editableMapObject)
 
 void EditableObjectGroup::insertObjectAt(int index, EditableMapObject *editableMapObject)
 {
+    if (!editableMapObject) {
+        ScriptManager::instance().throwNullArgError(1);
+        return;
+    }
     if (index < 0 || index > objectCount()) {
         ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Index out of range"));
         return;

--- a/src/tiled/editabletile.cpp
+++ b/src/tiled/editabletile.cpp
@@ -216,7 +216,7 @@ void EditableTile::setProbability(qreal probability)
 void EditableTile::setObjectGroup(EditableObjectGroup *editableObjectGroup)
 {
     if (!editableObjectGroup) {
-        ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors", "Invalid argument"));
+        ScriptManager::instance().throwNullArgError(0);
         return;
     }
 

--- a/src/tiled/mapeditor.cpp
+++ b/src/tiled/mapeditor.cpp
@@ -56,6 +56,7 @@
 #include "preferences.h"
 #include "propertiesdock.h"
 #include "reversingproxymodel.h"
+#include "scriptmanager.h"
 #include "selectsametiletool.h"
 #include "shapefilltool.h"
 #include "stampbrush.h"
@@ -1013,6 +1014,10 @@ EditableMap *MapEditor::currentBrush() const
 
 void MapEditor::setCurrentBrush(EditableMap *editableMap)
 {
+    if (!editableMap) {
+        ScriptManager::instance().throwNullArgError(0);
+        return;
+    }
     // todo: filter any non-tilelayers out of the map?
     setStamp(TileStamp(editableMap->map()->clone()));
 }

--- a/src/tiled/scriptedtool.cpp
+++ b/src/tiled/scriptedtool.cpp
@@ -89,6 +89,10 @@ EditableMap *ScriptedTool::preview() const
 
 void ScriptedTool::setPreview(EditableMap *editableMap)
 {
+    if (!editableMap) {
+        ScriptManager::instance().throwNullArgError(0);
+        return;
+    }
     // todo: filter any non-tilelayers out of the map?
     auto map = editableMap->map()->clone();
     brushItem()->setMap(SharedMap { map.release() });

--- a/src/tiled/scriptfileformatwrappers.cpp
+++ b/src/tiled/scriptfileformatwrappers.cpp
@@ -92,6 +92,10 @@ EditableTileset *ScriptTilesetFormatWrapper::read(const QString &filename)
 
 void ScriptTilesetFormatWrapper::write(EditableTileset *editable, const QString &filename)
 {
+    if (!editable) {
+        ScriptManager::instance().throwNullArgError(0);
+        return;
+    }
     if (!assertCanWrite())
         return;
 
@@ -123,6 +127,10 @@ EditableMap *ScriptMapFormatWrapper::read(const QString &filename)
 
 void ScriptMapFormatWrapper::write(EditableMap *editable, const QString &filename)
 {
+    if (!editable) {
+        ScriptManager::instance().throwNullArgError(0);
+        return;
+    }
     if (!assertCanWrite())
         return;
 

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -51,6 +51,7 @@
 #include <QStandardPaths>
 #include <QTextCodec>
 #include <QtDebug>
+#include <QCoreApplication>
 
 namespace Tiled {
 
@@ -258,6 +259,13 @@ void ScriptManager::throwError(const QString &message)
 #else
     engine()->throwError(message);
 #endif
+}
+
+void ScriptManager::throwNullArgError(int argNumber)
+{
+    auto message = QCoreApplication::translate("Script Errors",
+                                               "Argument %1 is undefined or the wrong type").arg(argNumber);
+    throwError(message);
 }
 
 void ScriptManager::reset()

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -263,9 +263,8 @@ void ScriptManager::throwError(const QString &message)
 
 void ScriptManager::throwNullArgError(int argNumber)
 {
-    auto message = QCoreApplication::translate("Script Errors",
-                                               "Argument %1 is undefined or the wrong type").arg(argNumber);
-    throwError(message);
+    throwError(QCoreApplication::translate("Script Errors",
+                                           "Argument %1 is undefined or the wrong type").arg(argNumber));
 }
 
 void ScriptManager::reset()

--- a/src/tiled/scriptmanager.h
+++ b/src/tiled/scriptmanager.h
@@ -62,6 +62,7 @@ public:
 
     bool checkError(QJSValue value, const QString &program = QString());
     void throwError(const QString &message);
+    void throwNullArgError(int argNumber);
 
     void reset();
 

--- a/src/tiled/scriptmodule.cpp
+++ b/src/tiled/scriptmodule.cpp
@@ -148,6 +148,10 @@ EditableAsset *ScriptModule::activeAsset() const
 
 bool ScriptModule::setActiveAsset(EditableAsset *asset) const
 {
+    if (!asset) {
+        ScriptManager::instance().throwNullArgError(0);
+        return false;
+    }
     auto documentManager = DocumentManager::instance();
     for (const DocumentPtr &document : documentManager->documents())
         if (document->editable() == asset)
@@ -201,6 +205,10 @@ EditableAsset *ScriptModule::open(const QString &fileName) const
 
 bool ScriptModule::close(EditableAsset *asset) const
 {
+    if (!asset) {
+        ScriptManager::instance().throwNullArgError(0);
+        return false;
+    }
     auto documentManager = DocumentManager::instance();
 
     int index = documentManager->findDocument(asset->document());
@@ -215,6 +223,10 @@ bool ScriptModule::close(EditableAsset *asset) const
 
 EditableAsset *ScriptModule::reload(EditableAsset *asset) const
 {
+    if (!asset) {
+        ScriptManager::instance().throwNullArgError(0);
+        return nullptr;
+    }
     auto documentManager = DocumentManager::instance();
 
     int index = documentManager->findDocument(asset->document());

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -34,6 +34,7 @@
 #include "objectgroup.h"
 #include "preferences.h"
 #include "replacetileset.h"
+#include "scriptmanager.h"
 #include "swaptiles.h"
 #include "terrain.h"
 #include "tile.h"
@@ -880,6 +881,10 @@ SharedTileset TilesetDock::currentTileset() const
 
 void TilesetDock::setCurrentEditableTileset(EditableTileset *tileset)
 {
+    if (!tileset) {
+        ScriptManager::instance().throwNullArgError(0);
+        return;
+    }
     setCurrentTileset(tileset->tileset()->sharedPointer());
 }
 


### PR DESCRIPTION
QJSEngine can pass a nullptr to a `Q_INVOKABLE` or `Q_PROPERTY` function if the argument is either `undefined` or the wrong type.