### PR TITLE
Don't derive base libtiled classes from QObject

### DIFF
--- a/src/libtiled/grouplayer.h
+++ b/src/libtiled/grouplayer.h
@@ -30,8 +30,6 @@ namespace Tiled {
 
 class TILEDSHARED_EXPORT GroupLayer : public Layer
 {
-    Q_OBJECT
-
 public:
     GroupLayer(const QString &name, int x, int y);
     ~GroupLayer() override;

--- a/src/libtiled/imagelayer.h
+++ b/src/libtiled/imagelayer.h
@@ -45,8 +45,6 @@ namespace Tiled {
  */
 class TILEDSHARED_EXPORT ImageLayer : public Layer
 {
-    Q_OBJECT
-
 public:
     ImageLayer(const QString &name, int x, int y);
     ~ImageLayer() override;

--- a/src/libtiled/layer.h
+++ b/src/libtiled/layer.h
@@ -51,15 +51,6 @@ class TileLayer;
  */
 class TILEDSHARED_EXPORT Layer : public Object
 {
-    Q_OBJECT
-
-    Q_PROPERTY(QString name READ name)
-    Q_PROPERTY(qreal opacity READ opacity)
-    Q_PROPERTY(QColor tintColor READ tintColor WRITE setTintColor)
-    Q_PROPERTY(bool visible READ isVisible)
-    Q_PROPERTY(bool locked READ isLocked)
-    Q_PROPERTY(QPointF offset READ offset)
-
 public:
     enum TypeFlag {
         TileLayerType   = 0x01,
@@ -419,3 +410,5 @@ TILEDSHARED_EXPORT int globalIndex(Layer *layer);
 TILEDSHARED_EXPORT Layer *layerAtGlobalIndex(const Map *map, int index);
 
 } // namespace Tiled
+
+Q_DECLARE_METATYPE(Tiled::Layer*)

--- a/src/libtiled/map.cpp
+++ b/src/libtiled/map.cpp
@@ -82,44 +82,6 @@ Map::~Map()
     qDeleteAll(mLayers);
 }
 
-void Map::setWidth(int width)
-{
-    if (width == mWidth)
-        return;
-
-    mWidth = width;
-    emit widthChanged();
-    emit sizeChanged();
-}
-
-void Map::setHeight(int height)
-{
-    if (height == mHeight)
-        return;
-
-    mHeight = height;
-    emit heightChanged();
-    emit sizeChanged();
-}
-
-void Map::setTileWidth(int width)
-{
-    if (width == mTileWidth)
-        return;
-
-    mTileWidth = width;
-    emit tileWidthChanged();
-}
-
-void Map::setTileHeight(int height)
-{
-    if (height == mTileHeight)
-        return;
-
-    mTileHeight = height;
-    emit tileHeightChanged();
-}
-
 QMargins Map::drawMargins() const
 {
     if (mDrawMarginsDirty)

--- a/src/libtiled/map.h
+++ b/src/libtiled/map.h
@@ -57,14 +57,6 @@ class Tile;
  */
 class TILEDSHARED_EXPORT Map : public Object
 {
-    Q_OBJECT
-
-    Q_PROPERTY(int width READ width NOTIFY widthChanged)
-    Q_PROPERTY(int height READ height NOTIFY heightChanged)
-    Q_PROPERTY(int tileWidth READ tileWidth NOTIFY tileWidthChanged)
-    Q_PROPERTY(int tileHeight READ tileHeight NOTIFY tileHeightChanged)
-    Q_PROPERTY(QSize size READ size NOTIFY sizeChanged)
-
     class LayerIteratorHelper
     {
     public:
@@ -98,7 +90,6 @@ public:
         Staggered,
         Hexagonal
     };
-    Q_ENUM(Orientation)
 
     /**
      * The different formats in which the tile layer data can be stored.
@@ -111,7 +102,6 @@ public:
         Base64Zstandard = 4,
         CSV             = 5
     };
-    Q_ENUM(LayerDataFormat)
 
     /**
      * The order in which tiles are rendered on screen.
@@ -122,7 +112,6 @@ public:
         LeftDown   = 2,
         LeftUp     = 3
     };
-    Q_ENUM(RenderOrder)
 
     /**
      * Which axis is staggered. Only used by the isometric staggered and
@@ -132,7 +121,6 @@ public:
         StaggerX,
         StaggerY
     };
-    Q_ENUM(StaggerAxis)
 
     /**
      * When staggering, specifies whether the odd or the even rows/columns are
@@ -143,7 +131,6 @@ public:
         StaggerOdd  = 0,
         StaggerEven = 1
     };
-    Q_ENUM(StaggerIndex)
 
     Map();
 
@@ -470,13 +457,6 @@ public:
 
     QRegion tileRegion() const;
 
-signals:
-    void widthChanged();
-    void heightChanged();
-    void tileWidthChanged();
-    void tileHeightChanged();
-    void sizeChanged();
-
 private:
     friend class GroupLayer;    // so it can call adoptLayer
 
@@ -506,6 +486,26 @@ private:
     int mNextObjectId;
 };
 
+
+inline void Map::setWidth(int width)
+{
+    mWidth = width;
+}
+
+inline void Map::setHeight(int height)
+{
+    mHeight = height;
+}
+
+inline void Map::setTileWidth(int width)
+{
+    mTileWidth = width;
+}
+
+inline void Map::setTileHeight(int height)
+{
+    mTileHeight = height;
+}
 
 inline int Map::hexSideLength() const
 {
@@ -691,6 +691,7 @@ typedef QSharedPointer<Map> SharedMap;
 
 } // namespace Tiled
 
+Q_DECLARE_METATYPE(Tiled::Map*)
 Q_DECLARE_METATYPE(Tiled::Map::Orientation)
 Q_DECLARE_METATYPE(Tiled::Map::LayerDataFormat)
 Q_DECLARE_METATYPE(Tiled::Map::RenderOrder)

--- a/src/libtiled/mapobject.h
+++ b/src/libtiled/mapobject.h
@@ -74,8 +74,6 @@ struct TILEDSHARED_EXPORT TextData
  */
 class TILEDSHARED_EXPORT MapObject : public Object
 {
-    Q_OBJECT
-
 public:
     /**
      * Enumerates the different object shapes. Rectangle is the default shape.

--- a/src/libtiled/object.h
+++ b/src/libtiled/object.h
@@ -28,8 +28,6 @@
 
 #pragma once
 
-#include <QObject>
-
 #include "properties.h"
 #include "objecttypes.h"
 
@@ -38,10 +36,8 @@ namespace Tiled {
 /**
  * The base class for anything that can hold properties.
  */
-class TILEDSHARED_EXPORT Object : public QObject
+class TILEDSHARED_EXPORT Object
 {
-    Q_OBJECT
-
 public:
     enum TypeId {
         LayerType,

--- a/src/libtiled/objectgroup.h
+++ b/src/libtiled/objectgroup.h
@@ -47,8 +47,6 @@ class MapObject;
  */
 class TILEDSHARED_EXPORT ObjectGroup : public Layer
 {
-    Q_OBJECT
-
 public:
     /**
      * Objects within an object group can either be drawn top down (sorted

--- a/src/libtiled/objecttemplate.h
+++ b/src/libtiled/objecttemplate.h
@@ -42,8 +42,6 @@ class ObjectTemplateFormat;
 
 class TILEDSHARED_EXPORT ObjectTemplate : public Object
 {
-    Q_OBJECT
-
 public:
     ObjectTemplate();
     ObjectTemplate(const QString &fileName);

--- a/src/libtiled/terrain.h
+++ b/src/libtiled/terrain.h
@@ -42,18 +42,16 @@ namespace Tiled {
  */
 class TILEDSHARED_EXPORT Terrain : public Object
 {
-    Q_OBJECT
-
 public:
     Terrain(int id,
             Tileset *tileset,
             QString name,
-            int imageTileId):
-        Object(TerrainType),
-        mId(id),
-        mTileset(tileset),
-        mName(std::move(name)),
-        mImageTileId(imageTileId)
+            int imageTileId)
+        : Object(TerrainType)
+        , mId(id)
+        , mImageTileId(imageTileId)
+        , mTileset(tileset)
+        , mName(std::move(name))
     {
     }
 
@@ -78,9 +76,9 @@ public:
 
 private:
     int mId;
+    int mImageTileId;
     Tileset *mTileset;
     QString mName;
-    int mImageTileId;
     QVector<int> mTransitionDistance;
 
     friend class Tileset; // To allow changing the terrain id

--- a/src/libtiled/tile.h
+++ b/src/libtiled/tile.h
@@ -94,8 +94,6 @@ struct Frame
 
 class TILEDSHARED_EXPORT Tile : public Object
 {
-    Q_OBJECT
-
 public:
     Tile(int id, Tileset *tileset);
     Tile(const QPixmap &image, int id, Tileset *tileset);
@@ -265,7 +263,8 @@ inline void Tile::setType(const QString &type)
  */
 inline int Tile::cornerTerrainId(int corner) const
 {
-    unsigned t = (terrain() >> (3 - corner)*8) & 0xFF; return t == 0xFF ? -1 : (int)t;
+    unsigned t = (terrain() >> (3 - corner)*8) & 0xFF;
+    return t == 0xFF ? -1 : int(t);
 }
 
 /**
@@ -338,3 +337,5 @@ inline void Tile::setImageStatus(LoadingStatus status)
 }
 
 } // namespace Tiled
+
+Q_DECLARE_METATYPE(Tiled::Tile*)

--- a/src/libtiled/tilelayer.h
+++ b/src/libtiled/tilelayer.h
@@ -219,8 +219,6 @@ inline const Cell &Chunk::cellAt(QPoint point) const
  */
 class TILEDSHARED_EXPORT TileLayer : public Layer
 {
-    Q_OBJECT
-
 public:
     class iterator
     {

--- a/src/libtiled/tileset.h
+++ b/src/libtiled/tileset.h
@@ -65,8 +65,6 @@ typedef QSharedPointer<Tileset> SharedTileset;
  */
 class TILEDSHARED_EXPORT Tileset : public Object
 {
-    Q_OBJECT
-
 public:
     /**
      * The orientation of the tileset determines the projection used in the
@@ -689,4 +687,5 @@ inline LoadingStatus Tileset::imageStatus() const
 
 } // namespace Tiled
 
+Q_DECLARE_METATYPE(Tiled::Tileset*)
 Q_DECLARE_METATYPE(Tiled::SharedTileset)

--- a/src/libtiled/wangset.h
+++ b/src/libtiled/wangset.h
@@ -229,8 +229,6 @@ private:
 
 class TILEDSHARED_EXPORT WangColor : public Object
 {
-    Q_OBJECT
-
 public:
     WangColor();
     WangColor(int colorIndex,
@@ -274,8 +272,6 @@ private:
  */
 class TILEDSHARED_EXPORT WangSet : public Object
 {
-    Q_OBJECT
-
 public:
     WangSet(Tileset *tileset,
             const QString &name,

--- a/src/tiled/editablemap.cpp
+++ b/src/tiled/editablemap.cpp
@@ -59,10 +59,6 @@ EditableMap::EditableMap(QObject *parent)
     , mSelectedArea(nullptr)
 {
     mDetachedMap.reset(map());
-
-    connect(map(), &Map::sizeChanged, this, &EditableMap::sizeChanged);
-    connect(map(), &Map::tileWidthChanged, this, &EditableMap::tileWidthChanged);
-    connect(map(), &Map::tileHeightChanged, this, &EditableMap::tileHeightChanged);
 }
 
 EditableMap::EditableMap(MapDocument *mapDocument, QObject *parent)
@@ -70,10 +66,6 @@ EditableMap::EditableMap(MapDocument *mapDocument, QObject *parent)
     , mReadOnly(false)
     , mSelectedArea(new EditableSelectedArea(mapDocument, this))
 {
-    connect(map(), &Map::sizeChanged, this, &EditableMap::sizeChanged);
-    connect(map(), &Map::tileWidthChanged, this, &EditableMap::tileWidthChanged);
-    connect(map(), &Map::tileHeightChanged, this, &EditableMap::tileHeightChanged);
-
     connect(mapDocument, &Document::fileNameChanged, this, &EditableAsset::fileNameChanged);
     connect(mapDocument, &Document::changed, this, &EditableMap::documentChanged);
     connect(mapDocument, &MapDocument::layerAdded, this, &EditableMap::attachLayer);

--- a/src/tiled/editablemap.h
+++ b/src/tiled/editablemap.h
@@ -38,11 +38,11 @@ class EditableMap : public EditableAsset
 {
     Q_OBJECT
 
-    Q_PROPERTY(int width READ width WRITE setWidth NOTIFY sizeChanged)
-    Q_PROPERTY(int height READ height WRITE setHeight NOTIFY sizeChanged)
-    Q_PROPERTY(QSize size READ size NOTIFY sizeChanged)
-    Q_PROPERTY(int tileWidth READ tileWidth WRITE setTileWidth NOTIFY tileWidthChanged)
-    Q_PROPERTY(int tileHeight READ tileHeight WRITE setTileHeight NOTIFY tileHeightChanged)
+    Q_PROPERTY(int width READ width WRITE setWidth)
+    Q_PROPERTY(int height READ height WRITE setHeight)
+    Q_PROPERTY(QSize size READ size)
+    Q_PROPERTY(int tileWidth READ tileWidth WRITE setTileWidth)
+    Q_PROPERTY(int tileHeight READ tileHeight WRITE setTileHeight)
     Q_PROPERTY(bool infinite READ infinite WRITE setInfinite)
     Q_PROPERTY(int hexSideLength READ hexSideLength WRITE setHexSideLength)
     Q_PROPERTY(StaggerAxis staggerAxis READ staggerAxis WRITE setStaggerAxis)
@@ -189,10 +189,6 @@ public:
     MapDocument *mapDocument() const;
 
 signals:
-    void sizeChanged();
-    void tileWidthChanged();
-    void tileHeightChanged();
-
     void currentLayerChanged();
     void selectedLayersChanged();
     void selectedObjectsChanged();

--- a/src/tiledquickplugin/mapitem.cpp
+++ b/src/tiledquickplugin/mapitem.cpp
@@ -41,12 +41,12 @@ MapItem::MapItem(QQuickItem *parent)
 
 MapItem::~MapItem() = default;
 
-void MapItem::setMap(Tiled::Map *map)
+void MapItem::setMap(MapRef map)
 {
-    if (mMap == map)
+    if (mMap == map.mMap)
         return;
 
-    mMap = map;
+    mMap = map.mMap;
     refresh();
     emit mapChanged();
 }

--- a/src/tiledquickplugin/mapitem.h
+++ b/src/tiledquickplugin/mapitem.h
@@ -20,12 +20,13 @@
 
 #pragma once
 
+#include "mapref.h"
+
 #include <QQuickItem>
 
 #include <memory>
 
 namespace Tiled {
-class Map;
 class MapRenderer;
 } // namespace Tiled
 
@@ -41,15 +42,15 @@ class MapItem : public QQuickItem
 {
     Q_OBJECT
 
-    Q_PROPERTY(Tiled::Map *map READ map WRITE setMap NOTIFY mapChanged)
+    Q_PROPERTY(TiledQuick::MapRef map READ map WRITE setMap NOTIFY mapChanged)
     Q_PROPERTY(QRectF visibleArea READ visibleArea WRITE setVisibleArea NOTIFY visibleAreaChanged)
 
 public:
     explicit MapItem(QQuickItem *parent = nullptr);
     ~MapItem();
 
-    Tiled::Map *map() const;
-    void setMap(Tiled::Map *map);
+    MapRef map() const;
+    void setMap(MapRef map);
 
     const QRectF &visibleArea() const;
     void setVisibleArea(const QRectF &visibleArea);
@@ -86,7 +87,7 @@ private:
 inline const QRectF &MapItem::visibleArea() const
 { return mVisibleArea; }
 
-inline Tiled::Map *MapItem::map() const
-{ return mMap; }
+inline MapRef MapItem::map() const
+{ return { mMap }; }
 
 } // namespace TiledQuick

--- a/src/tiledquickplugin/maploader.h
+++ b/src/tiledquickplugin/maploader.h
@@ -20,14 +20,12 @@
 
 #pragma once
 
+#include "mapref.h"
+
 #include <QObject>
 #include <QUrl>
 
 #include <memory>
-
-namespace Tiled {
-class Map;
-}
 
 namespace TiledQuick {
 
@@ -36,7 +34,7 @@ class MapLoader : public QObject
     Q_OBJECT
 
     Q_PROPERTY(QUrl source READ source WRITE setSource NOTIFY sourceChanged)
-    Q_PROPERTY(Tiled::Map *map READ map NOTIFY sourceChanged)
+    Q_PROPERTY(TiledQuick::MapRef map READ map NOTIFY sourceChanged)
     Q_PROPERTY(Status status READ status NOTIFY statusChanged)
     Q_PROPERTY(QString error READ error NOTIFY errorChanged)
 
@@ -52,7 +50,7 @@ public:
     ~MapLoader();
 
     QUrl source() const;
-    Tiled::Map *map() const;
+    MapRef map() const;
     Status status() const;
     QString error() const;
 
@@ -73,9 +71,9 @@ private:
 };
 
 
-inline Tiled::Map *MapLoader::map() const
+inline MapRef MapLoader::map() const
 {
-    return m_map.get();
+    return { m_map.get() };
 }
 
 inline MapLoader::Status MapLoader::status() const

--- a/src/tiledquickplugin/mapref.h
+++ b/src/tiledquickplugin/mapref.h
@@ -1,6 +1,6 @@
 /*
- * tiledquickplugin.cpp
- * Copyright 2014, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ * mapref.h
+ * Copyright 2020, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
  *
  * This file is part of Tiled Quick.
  *
@@ -18,29 +18,30 @@
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "tiledquickplugin.h"
+#pragma once
 
-#include "map.h"
-#include "mapobject.h"
-#include "objectgroup.h"
+#include <QObject>
 
-#include "mapitem.h"
-#include "maploader.h"
-
-#include <qqml.h>
-
-using namespace TiledQuick;
-
-void TiledQuickPlugin::registerTypes(const char *uri)
-{
-    // @uri org.mapeditor.Tiled
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    qmlRegisterType<MapRef>();
-#else
-    qmlRegisterAnonymousType<MapRef>(uri, 1);
-#endif
-
-    qmlRegisterType<MapLoader>(uri, 1, 0, "MapLoader");
-    qmlRegisterType<MapItem>(uri, 1, 0, "MapItem");
+namespace Tiled {
+class Map;
 }
+
+namespace TiledQuick {
+
+class MapRef
+{
+    Q_GADGET
+
+public:
+    MapRef(Tiled::Map *map = nullptr)
+        : mMap(map)
+    {}
+
+    Tiled::Map *mMap;
+
+    operator Tiled::Map *() const { return mMap; }
+};
+
+} // namespace TiledQuick
+
+Q_DECLARE_METATYPE(TiledQuick::MapRef)

--- a/src/tiledquickplugin/tiledquickplugin.pro
+++ b/src/tiledquickplugin/tiledquickplugin.pro
@@ -44,6 +44,7 @@ HEADERS += \
     tiledquickplugin.h \
     mapitem.h \
     maploader.h \
+    mapref.h \
     tilelayeritem.h \
     tilesnode.h
 

--- a/src/tiledquickplugin/tiledquickplugin.qbs
+++ b/src/tiledquickplugin/tiledquickplugin.qbs
@@ -30,6 +30,7 @@ DynamicLibrary {
         "mapitem.h",
         "maploader.cpp",
         "maploader.h",
+        "mapref.h",
         "tiledquickplugin.cpp",
         "tiledquickplugin.h",
         "tilelayeritem.cpp",

--- a/src/tiledquickplugin/tilelayeritem.cpp
+++ b/src/tiledquickplugin/tilelayeritem.cpp
@@ -233,7 +233,7 @@ TileItem::TileItem(const Cell &cell, QPoint position, MapItem *parent)
     , mPosition(position)
 {
     setFlag(ItemHasContents);
-    setZ(position.y() * parent->map()->tileHeight());
+    setZ(position.y() * parent->map().mMap->tileHeight());
 }
 
 QSGNode *TileItem::updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNodeData *)


### PR DESCRIPTION
Deriving from QObject makes them rather more heavy-weight than necessary. The only reason they were derived from QObject was to expose them to QML, but so far this functionality is not actually used. Only Tiled::Map was passed on in QML and this use-case was replaced by a small wrapper.

In general we now have "Editable" wrappers around these base objects, which I'd aim to expose in the TiledQuickPlugin somehow, for use by Tiled Quick.

@mitchcurtis Since you may be relying on these classes, please let me know if this would cause you any headaches.