### PR TITLE
Feature 2780 script file info

### DIFF
--- a/src/tiled/scriptfileinfo.cpp
+++ b/src/tiled/scriptfileinfo.cpp
@@ -117,11 +117,12 @@ QString ScriptFileInfo::filePath(QString file)
 	return fp.filePath();
 }
 
-// QDateTime ScriptFileInfo::fileTime(QString file, QFile::FileTime time)
-// {
-// 	QFileInfo fp = QFileInfo(file);
-// 	return fp.fileTime(time);
-// }
+// https://doc.qt.io/qt-5/qfiledevice.html#FileTime-enum
+QDateTime ScriptFileInfo::fileTime(QString file, uint time)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.fileTime((QFile::FileTime)time);
+}
 
 QString ScriptFileInfo::group(QString file)
 {
@@ -261,11 +262,11 @@ QString ScriptFileInfo::path(QString file)
 	return fp.path();
 }
 
-// bool  ScriptFileInfo::permission(QString file, QFile::Permissions permissions)
-// {
-// 	QFileInfo fp = QFileInfo(file);
-// 	return fp.permission(permissions);
-// }
+bool  ScriptFileInfo::permission(QString file, uint permissions)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.permission((QFile::Permissions)permissions);
+}
 
 uint ScriptFileInfo::permissions(QString file)
 {

--- a/src/tiled/scriptfileinfo.cpp
+++ b/src/tiled/scriptfileinfo.cpp
@@ -279,12 +279,6 @@ void  ScriptFileInfo::refresh(QString file)
 	return fp.refresh();
 }
 
-void  ScriptFileInfo::setCaching(QString file, bool enable)
-{
-	QFileInfo fp = QFileInfo(file);
-	return fp.setCaching(enable);
-}
-
 qint64  ScriptFileInfo::size(QString file)
 {
 	QFileInfo fp = QFileInfo(file);

--- a/src/tiled/scriptfileinfo.cpp
+++ b/src/tiled/scriptfileinfo.cpp
@@ -1,0 +1,57 @@
+/*
+ * scriptfileinfo.cpp
+ * Copyright 2019, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "scriptfileinfo.h"
+#include <QtCore/qcoreapplication.h>
+#include <QtCore/qdatetime.h>
+#include <QtCore/qdir.h>
+#include <QtCore/qfileinfo.h>
+#include <QtCore/qregexp.h>
+
+#if defined(Q_OS_UNIX)
+#include <cerrno>
+#include <sys/stat.h>
+#include <unistd.h>
+#elif defined(Q_OS_WIN)
+#include <QtCore/qt_windows.h>
+#endif
+
+ScriptFileInfo::ScriptFileInfo(QObject *parent)
+		: QObject(parent)
+{
+
+}
+
+QString ScriptFileInfo::fileName(const QString &fp)
+{
+	int last = fp.lastIndexOf(QLatin1Char('/'));
+	if (last < 0)
+		return fp;
+	return fp.mid(last + 1);
+}
+
+QString ScriptFileInfo::baseName(const QString &fp)
+{
+	QString fn = fileName(fp);
+	int dot = fn.indexOf(QLatin1Char('.'));
+	if (dot < 0)
+		return fn;
+	return fn.mid(0, dot);
+}

--- a/src/tiled/scriptfileinfo.cpp
+++ b/src/tiled/scriptfileinfo.cpp
@@ -264,14 +264,14 @@ QString ScriptFileInfo::path(QString file)
 // bool  ScriptFileInfo::permission(QString file, QFile::Permissions permissions)
 // {
 // 	QFileInfo fp = QFileInfo(file);
-// 	return fp.permission();
+// 	return fp.permission(permissions);
 // }
 
-// QFile::Permissions  ScriptFileInfo::permissions(QString file)
-// {
-// 	QFileInfo fp = QFileInfo(file);
-// 	return fp.permissions();
-// }
+uint ScriptFileInfo::permissions(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.permissions();
+}
 
 void  ScriptFileInfo::refresh(QString file)
 {

--- a/src/tiled/scriptfileinfo.cpp
+++ b/src/tiled/scriptfileinfo.cpp
@@ -19,39 +19,286 @@
  */
 
 #include "scriptfileinfo.h"
-#include <QtCore/qcoreapplication.h>
-#include <QtCore/qdatetime.h>
-#include <QtCore/qdir.h>
-#include <QtCore/qfileinfo.h>
-#include <QtCore/qregexp.h>
 
-#if defined(Q_OS_UNIX)
-#include <cerrno>
-#include <sys/stat.h>
-#include <unistd.h>
-#elif defined(Q_OS_WIN)
-#include <QtCore/qt_windows.h>
-#endif
 
 ScriptFileInfo::ScriptFileInfo(QObject *parent)
 		: QObject(parent)
-{
+{}
 
+QString ScriptFileInfo::absoluteDir(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	QDir dir = fp.dir();
+	return dir.absolutePath();
 }
 
-QString ScriptFileInfo::fileName(const QString &fp)
+QString ScriptFileInfo::absoluteFilePath(QString file)
 {
-	int last = fp.lastIndexOf(QLatin1Char('/'));
-	if (last < 0)
-		return fp;
-	return fp.mid(last + 1);
+	QFileInfo fp = QFileInfo(file);
+	return fp.absoluteFilePath();
 }
 
-QString ScriptFileInfo::baseName(const QString &fp)
+QString ScriptFileInfo::absolutePath(QString file)
 {
-	QString fn = fileName(fp);
-	int dot = fn.indexOf(QLatin1Char('.'));
-	if (dot < 0)
-		return fn;
-	return fn.mid(0, dot);
+	QFileInfo fp = QFileInfo(file);
+	return fp.absolutePath();
+}
+
+QString ScriptFileInfo::baseName(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.baseName();
+}
+
+QDateTime ScriptFileInfo::birthTime(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.birthTime();
+}
+
+QString ScriptFileInfo::bundleName(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.bundleName();
+}
+
+bool ScriptFileInfo::caching(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.caching();
+}
+
+QString ScriptFileInfo::canonicalFilePath(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.canonicalFilePath();
+}
+
+QString ScriptFileInfo::canonicalPath(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.canonicalPath();
+}
+
+QString ScriptFileInfo::completeBaseName(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.completeBaseName();
+}
+
+QString ScriptFileInfo::completeSuffix(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.completeSuffix();
+}
+
+QString ScriptFileInfo::dir(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	QDir dir = fp.dir();
+	return dir.path();
+}
+
+bool  ScriptFileInfo::exists(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.exists();
+}
+
+QString ScriptFileInfo::fileName(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.fileName();
+}
+
+QString ScriptFileInfo::filePath(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.filePath();
+}
+
+// QDateTime ScriptFileInfo::fileTime(QString file, QFile::FileTime time)
+// {
+// 	QFileInfo fp = QFileInfo(file);
+// 	return fp.fileTime(time);
+// }
+
+QString ScriptFileInfo::group(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.group();
+}
+
+uint  ScriptFileInfo::groupId(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.groupId();
+}
+
+bool  ScriptFileInfo::isAbsolute(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.isAbsolute();
+}
+
+bool  ScriptFileInfo::isBundle(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.isBundle();
+}
+
+bool  ScriptFileInfo::isDir(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.isDir();
+}
+
+bool  ScriptFileInfo::isExecutable(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.isExecutable();
+}
+
+bool  ScriptFileInfo::isFile(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.isFile();
+}
+
+bool  ScriptFileInfo::isHidden(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.isHidden();
+}
+
+bool  ScriptFileInfo::isNativePath(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.isNativePath();
+}
+
+bool  ScriptFileInfo::isReadable(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.isReadable();
+}
+
+bool  ScriptFileInfo::isRelative(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.isRelative();
+}
+
+bool  ScriptFileInfo::isRoot(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.isRoot();
+}
+
+bool  ScriptFileInfo::isShortcut(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.isShortcut();
+}
+
+bool  ScriptFileInfo::isSymLink(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.isSymLink();
+}
+
+bool  ScriptFileInfo::isSymbolicLink(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.isSymbolicLink();
+}
+
+bool  ScriptFileInfo::isWritable(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.isWritable();
+}
+
+QDateTime ScriptFileInfo::lastModified(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.lastModified();
+}
+
+QDateTime ScriptFileInfo::lastRead(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.lastRead();
+}
+
+bool  ScriptFileInfo::makeAbsolute(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.makeAbsolute();
+}
+
+QDateTime ScriptFileInfo::metadataChangeTime(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.metadataChangeTime();
+}
+
+QString ScriptFileInfo::owner(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.owner();
+}
+
+uint  ScriptFileInfo::ownerId(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.ownerId();
+}
+
+QString ScriptFileInfo::path(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.path();
+}
+
+// bool  ScriptFileInfo::permission(QString file, QFile::Permissions permissions)
+// {
+// 	QFileInfo fp = QFileInfo(file);
+// 	return fp.permission();
+// }
+
+// QFile::Permissions  ScriptFileInfo::permissions(QString file)
+// {
+// 	QFileInfo fp = QFileInfo(file);
+// 	return fp.permissions();
+// }
+
+void  ScriptFileInfo::refresh(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.refresh();
+}
+
+void  ScriptFileInfo::setCaching(QString file, bool enable)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.setCaching(enable);
+}
+
+qint64  ScriptFileInfo::size(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.size();
+}
+
+QString ScriptFileInfo::suffix(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.suffix();
+}
+
+QString ScriptFileInfo::symLinkTarget(QString file)
+{
+	QFileInfo fp = QFileInfo(file);
+	return fp.symLinkTarget();
 }

--- a/src/tiled/scriptfileinfo.h
+++ b/src/tiled/scriptfileinfo.h
@@ -75,7 +75,6 @@ public:
   // Q_INVOKABLE bool  permission(QString file, QFile::Permissions permissions);
   // Q_INVOKABLE QFile::Permissions  permissions(QString file);
   Q_INVOKABLE void  refresh(QString file);
-  Q_INVOKABLE void  setCaching(QString file, bool enable);
   Q_INVOKABLE qint64  size(QString file);
   Q_INVOKABLE QString suffix(QString file);
   Q_INVOKABLE QString symLinkTarget(QString file);

--- a/src/tiled/scriptfileinfo.h
+++ b/src/tiled/scriptfileinfo.h
@@ -21,6 +21,10 @@
 #pragma once
 
 #include <QObject>
+#include <QtCore/qfileinfo.h>
+#include <QtCore/qdir.h>
+#include <QtCore/qfileinfo.h>
+#include <QtCore/qdatetime.h>
 
 class ScriptFileInfo : public QObject
 {
@@ -28,7 +32,51 @@ class ScriptFileInfo : public QObject
 
 public:
 	ScriptFileInfo(QObject *parent = nullptr);
-
-	Q_INVOKABLE QString fileName(const QString &fp);
-	Q_INVOKABLE QString baseName(const QString &fp);
+  
+  Q_INVOKABLE QString absoluteDir(QString file);
+  Q_INVOKABLE QString absoluteFilePath(QString file);
+  Q_INVOKABLE QString absolutePath(QString file);
+  Q_INVOKABLE QString baseName(QString file);
+  Q_INVOKABLE QDateTime birthTime(QString file);
+  Q_INVOKABLE QString bundleName(QString file);
+  Q_INVOKABLE bool  caching(QString file);
+  Q_INVOKABLE QString canonicalFilePath(QString file);
+  Q_INVOKABLE QString canonicalPath(QString file);
+  Q_INVOKABLE QString completeBaseName(QString file);
+  Q_INVOKABLE QString completeSuffix(QString file);
+  Q_INVOKABLE QString dir(QString file);
+  Q_INVOKABLE bool  exists(QString file);
+  Q_INVOKABLE QString fileName(QString file);
+  Q_INVOKABLE QString filePath(QString file);
+  // Q_INVOKABLE QDateTime fileTime(QString file, QFile::FileTime time);
+  Q_INVOKABLE QString group(QString file);
+  Q_INVOKABLE uint  groupId(QString file);
+  Q_INVOKABLE bool  isAbsolute(QString file);
+  Q_INVOKABLE bool  isBundle(QString file);
+  Q_INVOKABLE bool  isDir(QString file);
+  Q_INVOKABLE bool  isExecutable(QString file);
+  Q_INVOKABLE bool  isFile(QString file);
+  Q_INVOKABLE bool  isHidden(QString file);
+  Q_INVOKABLE bool  isNativePath(QString file);
+  Q_INVOKABLE bool  isReadable(QString file);
+  Q_INVOKABLE bool  isRelative(QString file);
+  Q_INVOKABLE bool  isRoot(QString file);
+  Q_INVOKABLE bool  isShortcut(QString file);
+  Q_INVOKABLE bool  isSymLink(QString file);
+  Q_INVOKABLE bool  isSymbolicLink(QString file);
+  Q_INVOKABLE bool  isWritable(QString file);
+  Q_INVOKABLE QDateTime lastModified(QString file);
+  Q_INVOKABLE QDateTime lastRead(QString file);
+  Q_INVOKABLE bool  makeAbsolute(QString file);
+  Q_INVOKABLE QDateTime metadataChangeTime(QString file);
+  Q_INVOKABLE QString owner(QString file);
+  Q_INVOKABLE uint  ownerId(QString file);
+  Q_INVOKABLE QString path(QString file);
+  // Q_INVOKABLE bool  permission(QString file, QFile::Permissions permissions);
+  // Q_INVOKABLE QFile::Permissions  permissions(QString file);
+  Q_INVOKABLE void  refresh(QString file);
+  Q_INVOKABLE void  setCaching(QString file, bool enable);
+  Q_INVOKABLE qint64  size(QString file);
+  Q_INVOKABLE QString suffix(QString file);
+  Q_INVOKABLE QString symLinkTarget(QString file);
 };

--- a/src/tiled/scriptfileinfo.h
+++ b/src/tiled/scriptfileinfo.h
@@ -73,7 +73,7 @@ public:
   Q_INVOKABLE uint  ownerId(QString file);
   Q_INVOKABLE QString path(QString file);
   // Q_INVOKABLE bool  permission(QString file, QFile::Permissions permissions);
-  // Q_INVOKABLE QFile::Permissions  permissions(QString file);
+  Q_INVOKABLE uint  permissions(QString file);
   Q_INVOKABLE void  refresh(QString file);
   Q_INVOKABLE qint64  size(QString file);
   Q_INVOKABLE QString suffix(QString file);

--- a/src/tiled/scriptfileinfo.h
+++ b/src/tiled/scriptfileinfo.h
@@ -48,7 +48,7 @@ public:
   Q_INVOKABLE bool  exists(QString file);
   Q_INVOKABLE QString fileName(QString file);
   Q_INVOKABLE QString filePath(QString file);
-  // Q_INVOKABLE QDateTime fileTime(QString file, QFile::FileTime time);
+  Q_INVOKABLE QDateTime fileTime(QString file, uint time);
   Q_INVOKABLE QString group(QString file);
   Q_INVOKABLE uint  groupId(QString file);
   Q_INVOKABLE bool  isAbsolute(QString file);
@@ -72,7 +72,7 @@ public:
   Q_INVOKABLE QString owner(QString file);
   Q_INVOKABLE uint  ownerId(QString file);
   Q_INVOKABLE QString path(QString file);
-  // Q_INVOKABLE bool  permission(QString file, QFile::Permissions permissions);
+  Q_INVOKABLE bool  permission(QString file, uint permissions);
   Q_INVOKABLE uint  permissions(QString file);
   Q_INVOKABLE void  refresh(QString file);
   Q_INVOKABLE qint64  size(QString file);

--- a/src/tiled/scriptfileinfo.h
+++ b/src/tiled/scriptfileinfo.h
@@ -1,0 +1,34 @@
+/*
+ * scriptfileinfo.h
+ * Copyright 2019, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+
+class ScriptFileInfo : public QObject
+{
+	Q_OBJECT
+
+public:
+	ScriptFileInfo(QObject *parent = nullptr);
+
+	static QString fileName(const QString &fp);
+    static QString baseName(const QString &fp);
+};

--- a/src/tiled/scriptfileinfo.h
+++ b/src/tiled/scriptfileinfo.h
@@ -29,6 +29,6 @@ class ScriptFileInfo : public QObject
 public:
 	ScriptFileInfo(QObject *parent = nullptr);
 
-	static QString fileName(const QString &fp);
-    static QString baseName(const QString &fp);
+	Q_INVOKABLE QString fileName(const QString &fp);
+	Q_INVOKABLE QString baseName(const QString &fp);
 };

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -40,6 +40,7 @@
 #include "scriptedfileformat.h"
 #include "scriptedtool.h"
 #include "scriptfile.h"
+#include "scriptfileinfo.h"
 #include "scriptfileformatwrappers.h"
 #include "scriptmodule.h"
 #include "tilecollisiondock.h"
@@ -125,7 +126,7 @@ ScriptManager::ScriptManager(QObject *parent)
 
 void ScriptManager::initialize()
 {
-    Q_ASSERT(!mEngine && !mModule);
+    Q_ASSERT(!mEngine && !mModule && !mFileInfo);
 
     refreshExtensionsPaths();
     setupEngine();
@@ -265,9 +266,11 @@ void ScriptManager::reset()
 
     delete mEngine;
     delete mModule;
+    delete mFileInfo;
 
     mEngine = nullptr;
     mModule = nullptr;
+    mFileInfo = nullptr;
     mTempCount = 0;
 
     setupEngine();
@@ -278,9 +281,11 @@ void ScriptManager::setupEngine()
 {
     mEngine = new QQmlEngine(this);
     mModule = new ScriptModule(this);
+    mFileInfo = new ScriptFileInfo(this);
 
     QJSValue globalObject = mEngine->globalObject();
     globalObject.setProperty(QStringLiteral("tiled"), mEngine->newQObject(mModule));
+    globalObject.setProperty(QStringLiteral("FileInfo"), mEngine->newQObject(mFileInfo));
 #if QT_VERSION >= 0x050800
     globalObject.setProperty(QStringLiteral("TextFile"), mEngine->newQMetaObject<ScriptTextFile>());
     globalObject.setProperty(QStringLiteral("BinaryFile"), mEngine->newQMetaObject<ScriptBinaryFile>());

--- a/src/tiled/scriptmanager.h
+++ b/src/tiled/scriptmanager.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "filesystemwatcher.h"
+#include "scriptfileinfo.h"
 
 #include <QJSValue>
 #include <QObject>
@@ -77,6 +78,7 @@ private:
 
     QJSEngine *mEngine = nullptr;
     ScriptModule *mModule = nullptr;
+    ScriptFileInfo *mFileInfo = nullptr;
     FileSystemWatcher mWatcher;
     QString mExtensionsPath;
     QStringList mExtensionsPaths;

--- a/src/tiled/tiled.pro
+++ b/src/tiled/tiled.pro
@@ -212,6 +212,7 @@ SOURCES += aboutdialog.cpp \
     scriptedtool.cpp \
     scriptfile.cpp \
     scriptfileformatwrappers.cpp \
+    scriptfileinfo.cpp \
     scriptmanager.cpp \
     scriptmodule.cpp \
     selectionrectangle.cpp \
@@ -452,6 +453,7 @@ HEADERS += aboutdialog.h \
     scriptedtool.h \
     scriptfile.h \
     scriptfileformatwrappers.h \
+    scriptfileinfo.h \
     scriptmanager.h \
     scriptmodule.h \
     selectionrectangle.h \

--- a/src/tiled/tiled.qbs
+++ b/src/tiled/tiled.qbs
@@ -427,6 +427,8 @@ QtGuiApplication {
         "scriptfile.h",
         "scriptfileformatwrappers.cpp",
         "scriptfileformatwrappers.h",
+        "scriptfileinfo.cpp",
+        "scriptfileinfo.h",
         "scriptmanager.cpp",
         "scriptmanager.h",
         "scriptmodule.cpp",


### PR DESCRIPTION
This adds some file info utils to JS plugin API (#2780)

You can see example usage [here](https://github.com/konsumer/tiled-fileinfodemo/blob/master/export_fileinfo_tilemap.js).

Example output:

```json
{
  "absoluteDir": "/home/konsumer/Documents/otherdev/tiled-example",
  "absoluteFilePath": "/home/konsumer/Documents/otherdev/tiled-example/town1.json",
  "absolutePath": "/home/konsumer/Documents/otherdev/tiled-example",
  "baseName": "town1",
  "birthTime": "2020-04-20T23:20:18.807Z",
  "bundleName": "",
  "caching": true,
  "canonicalFilePath": "/home/konsumer/Documents/otherdev/tiled-example/town1.json",
  "canonicalPath": "/home/konsumer/Documents/otherdev/tiled-example",
  "completeBaseName": "town1",
  "completeSuffix": "json",
  "dir": "/home/konsumer/Documents/otherdev/tiled-example",
  "exists": true,
  "fileName": "town1.json",
  "filePath": "/home/konsumer/Documents/otherdev/tiled-example/town1.json",
  "fileTimeAccess": "2020-04-20T23:20:18.807Z",
  "fileTimeBirth": "2020-04-20T23:20:18.807Z",
  "fileTimeMetaChange": "2020-04-20T23:45:57.840Z",
  "fileTimeModification": "2020-04-20T23:45:57.840Z",
  "group": "konsumer",
  "groupId": 1000,
  "isAbsolute": true,
  "isBundle": false,
  "isDir": false,
  "isExecutable": false,
  "isFile": true,
  "isHidden": false,
  "isNativePath": true,
  "isReadable": true,
  "isRelative": false,
  "isRoot": false,
  "isShortcut": false,
  "isSymLink": false,
  "isSymbolicLink": false,
  "isWritable": true,
  "lastModified": "2020-04-20T23:45:57.840Z",
  "lastRead": "2020-04-20T23:20:18.807Z",
  "makeAbsolute": false,
  "metadataChangeTime": "2020-04-20T23:45:57.840Z",
  "owner": "konsumer",
  "ownerId": 1000,
  "path": "/home/konsumer/Documents/otherdev/tiled-example",
  "permissions": 26180,
  "size": 1424,
  "suffix": "json",
  "symLinkTarget": ""
}
```