### PR TITLE
Scripting: Enabled creating images and using them

### DIFF
--- a/docs/reference/scripting.rst
+++ b/docs/reference/scripting.rst
@@ -728,6 +728,152 @@ GroupLayer.addLayer(layer : :ref:`script-layer`) : void
     When adding a :ref:`script-tilelayer` to a map, the layer's width and
     height are automatically initialized to the size of the map (since Tiled 1.4.2).
 
+.. raw:: html
+
+   <div class="new">New in Tiled 1.5</div>
+
+.. _script-image:
+
+Image
+^^^^^
+
+Can be used to create, load, save and modify images. Also useful when writing
+an importer, where the image can be set on a tileset or its tiles (see :ref:`Tileset.loadFromImage <script-tileset-loadFromImage>` and :ref:`Tile.setImage <script-tile-setImage>`).
+
+Properties
+~~~~~~~~~~
+
+.. csv-table::
+    :widths: 1, 2
+
+    **width** : int, Width of the image in pixels.
+    **height** : int, Height of the image in pixels.
+    **depth** : int, Number of bits used to store a single pixel.
+    **size** : :ref:`script-size`, Size of the image in pixels.
+    **format** : :ref:`Format <script-image-format>`, Format of the image.
+
+Functions
+~~~~~~~~~
+
+new Image()
+    Constructs an empty image.
+
+new Image(width : int, height : int, format : :ref:`Format <script-image-format>`)
+    Constructs an image of the given size using the given format.
+
+new Image(data : ArrayBuffer, width : int, height : int, format : :ref:`Format <script-image-format>`)
+    Constructs an image from the given data, interpreting it in the specified format and size.
+
+new Image(data : ArrayBuffer, width : int, height : int, bytesPerLine : int, format : :ref:`Format <script-image-format>`)
+    Constructs an image from the given data, interpreting it in the specified format and size.
+    The `bytesPerLine` argument specifies the stride and can be useful for referencing a sub-image.
+
+new Image(fileName : string [, format : string])
+    Construct an image by loading it from the given file name.
+    When no format is given it will be auto-detected (can be "bmp", "png", etc.).
+
+Image.pixel(x : int, y : int) : uint
+    Returns the 32-bit color value.
+
+Image.pixelColor(x : int, y : int) : color
+    Returns the color at the given position as string like "#rrggbb".
+
+Image.setPixel(x : int, y : int, index_or_rgb : uint) : void
+    Sets the color at the specified location to the given 32-bit color value or color table index.
+
+Image.setPixelColor(x : int, y : int, color : color) : void
+    Sets the color at the specified location to the given color by string (supports values like "#rrggbb").
+
+Image.fill(index_or_rgb : uint) : void
+    Fills the image with the given 32-bit color value or color table index.
+
+Image.fill(color : color) : void
+    Fills the image with the given color by string (supports values like "#rrggbb").
+
+Image.load(fileName : string [, format : string]) : void
+    Loads the image from the given file name.
+    When no format is given it will be auto-detected (can be "bmp", "png", etc.).
+
+Image.loadFromData(data : ArrayBuffer, format: string)
+    Loads the image from the given data interpreted with the given format (can be "bmp", png", etc.).
+
+Image.color(index : int) : uint
+    Returns the 32-bit color value at the given index in the color table.
+
+Image.colorTable() : array
+    Returns the color table as an array of 32-bit color values.
+
+Image.setColor(index : int, rgb : uint) : void
+    Sets the color at the given index in the color table to a given 32-bit color value.
+
+Image.setColor(index : int, color : color) : void
+    Sets the color at the given index in the color table to a color by string (supports values like "#rrggbb").
+
+Image.setColorTable(colors : array) : void
+    Sets the color table given by an array of either 32-bit color values or strings (supports values like "#rrggbb").
+
+Image.copy(x : int, y : int, width : int, height : int) : Image
+    Copies the given rectangle to a new image object.
+
+Image.scaled(width : int, height : int [, aspectRatioMode : :ref:`AspectRatioMode <script-image-aspectRatioMode>` [, transformationMode : :ref:`TransformationMode <script-image-transformationMode>`]]) : Image
+    Returns a scaled copy of this image. Default ``aspectRatioMode`` behavior is to ignore the aspect ratio. Default ``mode`` is a fast transformation.
+
+Image.mirrored(horizontal : bool, vertical : bool) : Image
+    Returns a mirrored copy of this image.
+
+.. _script-image-format:
+
+.. csv-table::
+    :header: "Image.Format"
+
+    Image.Format_Invalid
+    Image.Format_Mono
+    Image.Format_MonoLSB
+    Image.Format_Indexed8
+    Image.Format_RGB32
+    Image.Format_ARGB32
+    Image.Format_ARGB32_Premultiplied
+    Image.Format_RGB16
+    Image.Format_ARGB8565_Premultiplied
+    Image.Format_RGB666
+    Image.Format_ARGB6666_Premultiplied
+    Image.Format_RGB555
+    Image.Format_ARGB8555_Premultiplied
+    Image.Format_RGB888
+    Image.Format_RGB444
+    Image.Format_ARGB4444_Premultiplied
+    Image.Format_RGBX8888
+    Image.Format_RGBA8888
+    Image.Format_RGBA8888_Premultiplied
+    Image.Format_BGR30
+    Image.Format_A2BGR30_Premultiplied
+    Image.Format_RGB30
+    Image.Format_A2RGB30_Premultiplied
+    Image.Format_Alpha8
+    Image.Format_Grayscale8
+    Image.Format_RGBX64
+    Image.Format_RGBA64
+    Image.Format_RGBA64_Premultiplied
+    Image.Format_Grayscale16
+    Image.Format_BGR888
+
+.. _script-image-aspectRatioMode:
+
+.. csv-table::
+    :header: "Image.AspectRatioMode"
+
+    Image.IgnoreAspectRatio
+    Image.KeepAspectRatio
+    Image.KeepAspectRatioByExpanding
+
+.. _script-image-transformationMode:
+
+.. csv-table::
+    :header: "Image.TransformationMode"
+
+    Image.FastTransformation
+    Image.SmoothTransformation
+
 .. _script-imagelayer:
 
 ImageLayer
@@ -743,6 +889,17 @@ Properties
 
     **transparentColor** : color, Color used as transparent color when rendering the image.
     **imageSource** : url, Reference to the image rendered by this layer.
+
+Functions
+~~~~~~~~~
+
+.. _script-imagelayer-loadFromImage:
+
+ImageLayer.loadFromImage(image : :ref:`script-image` [, source: url]) : void
+    Sets the image for this layer to the given image, optionally also setting
+    the source of the image.
+
+    *Warning: This function has no undo!*
 
 .. _script-layer:
 
@@ -1079,6 +1236,16 @@ Properties
     Tile.FlippedVertically
     Tile.FlippedAntiDiagonally
     Tile.RotatedHexagonal120
+
+Functions
+~~~~~~~~~
+
+.. _script-tile-setImage:
+
+Tile.setImage(image : :ref:`script-image`) : void
+    Sets the image of this tile.
+
+    *Warning: This function has no undo and does not affect the saved tileset!*
 
 .. _script-tilecollisioneditor:
 
@@ -1521,6 +1688,19 @@ Tileset.setTileSize(width : int, height : int) : void
     Sets the tile size for this tileset. If an image has been specified as well,
     the tileset will be (re)loaded. Can't be used on image collection tilesets.
 
+.. _script-tileset-loadFromImage:
+
+Tileset.loadFromImage(image : :ref:`script-image` [, source: string]) : void
+    Creates the tiles in this tileset by cutting them out of the given image,
+    using the current tile size, tile spacing and margin parameters. These
+    values should be set before calling this function.
+
+    Optionally sets the source file of the image. This may be useful, but be
+    careful since Tiled will try to reload the tileset from that source when
+    the tileset parameters are changed.
+
+    *Warning: This function has no undo!*
+
 Tileset.addTile() : :ref:`script-tile`
     Adds a new tile to this tileset and returns it. Only works for image collection tilesets.
 
@@ -1580,6 +1760,10 @@ Properties
 
     **currentTileset** : :ref:`script-tileset`, "Access or change the currently displayed tileset."
     **selectedTiles** : [:ref:`script-tile`], "A list of the tiles that are selected in the current tileset."
+
+.. raw:: html
+
+   <div class="new">New in Tiled 1.5</div>
 
 .. _script-wangset:
 

--- a/src/tiled/editableimagelayer.cpp
+++ b/src/tiled/editableimagelayer.cpp
@@ -22,6 +22,7 @@
 
 #include "changeimagelayerproperties.h"
 #include "editablemap.h"
+#include "scriptimage.h"
 
 namespace Tiled {
 
@@ -62,6 +63,12 @@ void EditableImageLayer::setImageSource(const QUrl &imageSource)
         else
             imageLayer()->loadFromImage(imageSource);
     }
+}
+
+void EditableImageLayer::setImage(ScriptImage *image, const QUrl &source)
+{
+    // WARNING: This function has no undo!
+    imageLayer()->loadFromImage(QPixmap::fromImage(image->image()), source);
 }
 
 } // namespace Tiled

--- a/src/tiled/editableimagelayer.h
+++ b/src/tiled/editableimagelayer.h
@@ -25,6 +25,8 @@
 
 namespace Tiled {
 
+class ScriptImage;
+
 class EditableImageLayer : public EditableLayer
 {
     Q_OBJECT
@@ -45,6 +47,8 @@ public:
 
     void setTransparentColor(const QColor &transparentColor);
     void setImageSource(const QUrl &imageSource);
+
+    Q_INVOKABLE void setImage(Tiled::ScriptImage *image, const QUrl &source = QUrl());
 
 private:
     ImageLayer *imageLayer() const;

--- a/src/tiled/editabletile.cpp
+++ b/src/tiled/editabletile.cpp
@@ -30,6 +30,7 @@
 #include "editabletileset.h"
 #include "imagecache.h"
 #include "objectgroup.h"
+#include "scriptimage.h"
 #include "scriptmanager.h"
 
 #include <QCoreApplication>
@@ -78,6 +79,12 @@ QJSValue EditableTile::frames() const
 EditableTileset *EditableTile::tileset() const
 {
     return static_cast<EditableTileset*>(asset());
+}
+
+void EditableTile::setImage(ScriptImage *image)
+{
+    // WARNING: This function has no undo!
+    tile()->setImage(QPixmap::fromImage(image->image()));
 }
 
 void EditableTile::detach()

--- a/src/tiled/editabletile.h
+++ b/src/tiled/editabletile.h
@@ -29,6 +29,7 @@ namespace Tiled {
 
 class EditableObjectGroup;
 class EditableTileset;
+class ScriptImage;
 class TilesetDocument;
 
 class EditableTile : public EditableObject
@@ -80,6 +81,8 @@ public:
     QJSValue frames() const;
     bool isAnimated() const;
     EditableTileset *tileset() const;
+
+    Q_INVOKABLE void setImage(Tiled::ScriptImage *image);
 
     Tile *tile() const;
 

--- a/src/tiled/editabletileset.cpp
+++ b/src/tiled/editabletileset.cpp
@@ -25,6 +25,7 @@
 #include "editablemanager.h"
 #include "editabletile.h"
 #include "editablewangset.h"
+#include "scriptimage.h"
 #include "scriptmanager.h"
 #include "tilesetchanges.h"
 #include "tilesetdocument.h"
@@ -67,6 +68,12 @@ EditableTileset::~EditableTileset()
     detachWangSets(tileset()->wangSets());
 
     EditableManager::instance().mEditableTilesets.remove(tileset());
+}
+
+void EditableTileset::loadFromImage(ScriptImage *image, const QString &source)
+{
+    // WARNING: This function has no undo!
+    tileset()->loadFromImage(image->image(), source);
 }
 
 EditableTile *EditableTileset::tile(int id)

--- a/src/tiled/editabletileset.h
+++ b/src/tiled/editabletileset.h
@@ -27,6 +27,7 @@ namespace Tiled {
 
 class EditableTile;
 class EditableWangSet;
+class ScriptImage;
 class TilesetDocument;
 
 class EditableTileset : public EditableAsset
@@ -103,6 +104,9 @@ public:
     Orientation orientation() const;
     QColor backgroundColor() const;
     bool isCollection() const;
+
+    Q_INVOKABLE void loadFromImage(Tiled::ScriptImage *image,
+                                   const QString &source = QString());
 
     Q_INVOKABLE Tiled::EditableTile *tile(int id);
     QList<QObject*> tiles();

--- a/src/tiled/scriptimage.cpp
+++ b/src/tiled/scriptimage.cpp
@@ -100,10 +100,12 @@ ScriptImage *ScriptImage::copy(int x, int y, int w, int h) const
 }
 
 ScriptImage *ScriptImage::scaled(int w, int h,
-                                 Qt::AspectRatioMode aspectMode,
-                                 Qt::TransformationMode mode) const
+                                 AspectRatioMode aspectMode,
+                                 TransformationMode mode) const
 {
-    return new ScriptImage(mImage.scaled(w, h, aspectMode, mode));
+    return new ScriptImage(mImage.scaled(w, h,
+                                         static_cast<Qt::AspectRatioMode>(aspectMode),
+                                         static_cast<Qt::TransformationMode>(mode)));
 }
 
 ScriptImage *ScriptImage::mirrored(bool horiz, bool vert) const

--- a/src/tiled/scriptimage.cpp
+++ b/src/tiled/scriptimage.cpp
@@ -79,7 +79,7 @@ void ScriptImage::setColorTable(QJSValue colors)
         } else if (color.isString()) {
             const QString colorName = color.toString();
             if (QColor::isValidColor(colorName)) {
-                colorTable[i] = QColor(colorName).rgb();
+                colorTable[i] = QColor(colorName).rgba();
             } else {
                 ScriptManager::instance().throwError(QCoreApplication::translate("Script Errors",
                                                                                  "Invalid color name: '%2'").arg(colorName));

--- a/src/tiled/scriptimage.cpp
+++ b/src/tiled/scriptimage.cpp
@@ -1,0 +1,97 @@
+/*
+ * scriptimage.cpp
+ * Copyright 2020, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "scriptimage.h"
+
+#include "scriptmanager.h"
+
+#include <QJSEngine>
+
+namespace Tiled {
+
+ScriptImage::ScriptImage(QObject *parent)
+    : QObject(parent)
+{}
+
+ScriptImage::ScriptImage(int width, int height, Format format, QObject *parent)
+    : QObject(parent)
+    , mImage(width, height, static_cast<QImage::Format>(format))
+{}
+
+ScriptImage::ScriptImage(const QByteArray &data, int width, int height, Format format, QObject *parent)
+    : QObject(parent)
+    , mImageData(data)
+    , mImage(reinterpret_cast<const uchar*>(mImageData.constData()), width, height, static_cast<QImage::Format>(format))
+{}
+
+ScriptImage::ScriptImage(const QByteArray &data, int width, int height, int bytesPerLine, Format format, QObject *parent)
+    : QObject(parent)
+    , mImageData(data)
+    , mImage(reinterpret_cast<const uchar*>(mImageData.constData()), width, height, bytesPerLine, static_cast<QImage::Format>(format))
+{}
+
+ScriptImage::ScriptImage(const QString &fileName, const QByteArray &format, QObject *parent)
+    : QObject(parent)
+    , mImage(fileName, format.isEmpty() ? nullptr : format.data())
+{}
+
+QJSValue ScriptImage::colorTable() const
+{
+    QJSEngine *engine = ScriptManager::instance().engine();
+    const auto colors = mImage.colorTable();
+
+    QJSValue array = engine->newArray(colors.size());
+    for (int i = 0; i < colors.size(); ++i)
+        array.setProperty(i, colors.at(i));
+
+    return array;
+}
+
+void ScriptImage::setColorTable(QJSValue colors)
+{
+    QVector<QRgb> colorTable;
+
+    const int length = colors.property(QStringLiteral("length")).toInt();
+    colorTable.resize(length);
+
+    for (int i = 0; i < length; ++i)
+        colorTable[i] = colors.property(i).toUInt();
+
+    mImage.setColorTable(std::move(colorTable));
+}
+
+ScriptImage *ScriptImage::copy(int x, int y, int w, int h) const
+{
+    return new ScriptImage(mImage.copy(x, y, w, h));
+}
+
+ScriptImage *ScriptImage::scaled(int w, int h,
+                                 Qt::AspectRatioMode aspectMode,
+                                 Qt::TransformationMode mode) const
+{
+    return new ScriptImage(mImage.scaled(w, h, aspectMode, mode));
+}
+
+ScriptImage *ScriptImage::mirrored(bool horiz, bool vert) const
+{
+    return new ScriptImage(mImage.mirrored(horiz, vert));
+}
+
+} // namespace Tiled

--- a/src/tiled/scriptimage.h
+++ b/src/tiled/scriptimage.h
@@ -94,11 +94,20 @@ public:
     Q_INVOKABLE uint pixel(int x, int y) const
     { return mImage.pixel(x, y); }
 
+    Q_INVOKABLE QColor pixelColor(int x, int y) const
+    { return mImage.pixelColor(x, y); }
+
     Q_INVOKABLE void setPixel(int x, int y, uint index_or_rgb)
     { mImage.setPixel(x, y, index_or_rgb); }
 
+    Q_INVOKABLE void setPixelColor(int x, int y, const QColor &color)
+    { mImage.setPixelColor(x, y, color); }
+
     Q_INVOKABLE void fill(uint index_or_rgb)
     { mImage.fill(index_or_rgb); }
+
+    Q_INVOKABLE void fill(const QColor &color)
+    { mImage.fill(color); }
 
     Q_INVOKABLE bool load(const QString &fileName, const QByteArray &format = QByteArray())
     { return mImage.load(fileName, format); }
@@ -113,6 +122,9 @@ public:
 
     Q_INVOKABLE void setColor(int i, uint rgb)
     { mImage.setColor(i, rgb); }
+
+    Q_INVOKABLE void setColor(int i, const QColor &color)
+    { mImage.setColor(i, color.rgba()); }
 
     Q_INVOKABLE void setColorTable(QJSValue colors);
 

--- a/src/tiled/scriptimage.h
+++ b/src/tiled/scriptimage.h
@@ -1,0 +1,132 @@
+/*
+ * scriptimage.h
+ * Copyright 2020, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QImage>
+#include <QJSValue>
+#include <QObject>
+
+namespace Tiled {
+
+class ScriptImage : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(int width READ width)
+    Q_PROPERTY(int height READ height)
+    Q_PROPERTY(QSize size READ size)
+    Q_PROPERTY(Format format READ format)
+
+public:
+    // Copied from QImage
+    enum Format {
+        Format_Invalid,
+        Format_Mono,
+        Format_MonoLSB,
+        Format_Indexed8,
+        Format_RGB32,
+        Format_ARGB32,
+        Format_ARGB32_Premultiplied,
+        Format_RGB16,
+        Format_ARGB8565_Premultiplied,
+        Format_RGB666,
+        Format_ARGB6666_Premultiplied,
+        Format_RGB555,
+        Format_ARGB8555_Premultiplied,
+        Format_RGB888,
+        Format_RGB444,
+        Format_ARGB4444_Premultiplied,
+        Format_RGBX8888,
+        Format_RGBA8888,
+        Format_RGBA8888_Premultiplied,
+        Format_BGR30,
+        Format_A2BGR30_Premultiplied,
+        Format_RGB30,
+        Format_A2RGB30_Premultiplied,
+        Format_Alpha8,
+        Format_Grayscale8,
+        Format_RGBX64,
+        Format_RGBA64,
+        Format_RGBA64_Premultiplied,
+        Format_Grayscale16,
+        Format_BGR888,
+#ifndef Q_QDOC
+        NImageFormats
+#endif
+    };
+    Q_ENUM(Format)
+
+    Q_INVOKABLE explicit ScriptImage(QObject *parent = nullptr);
+    Q_INVOKABLE ScriptImage(int width, int height, Format format = Format_ARGB32_Premultiplied, QObject *parent = nullptr);
+    Q_INVOKABLE ScriptImage(const QByteArray &data, int width, int height, Format format, QObject *parent = nullptr);
+    Q_INVOKABLE ScriptImage(const QByteArray &data, int width, int height, int bytesPerLine, Format format, QObject *parent = nullptr);
+    Q_INVOKABLE ScriptImage(const QString &fileName, const QByteArray &format = QByteArray(), QObject *parent = nullptr);
+
+    ScriptImage(QImage image)
+        : mImage(std::move(image))
+    {}
+
+    Format format() const { return static_cast<Format>(mImage.format()); }
+    int width() const { return mImage.width(); }
+    int height() const { return mImage.height(); }
+    QSize size() const { return mImage.size(); }
+
+    Q_INVOKABLE uint pixel(int x, int y) const
+    { return mImage.pixel(x, y); }
+
+    Q_INVOKABLE void setPixel(int x, int y, uint index_or_rgb)
+    { mImage.setPixel(x, y, index_or_rgb); }
+
+    Q_INVOKABLE void fill(uint index_or_rgb)
+    { mImage.fill(index_or_rgb); }
+
+    Q_INVOKABLE bool load(const QString &fileName, const QByteArray &format = QByteArray())
+    { return mImage.load(fileName, format); }
+
+    Q_INVOKABLE bool loadFromData(const QByteArray &data, const QByteArray &format = QByteArray())
+    { return mImage.loadFromData(data, format); }
+
+    Q_INVOKABLE uint color(int i) const
+    { return mImage.color(i); }
+
+    Q_INVOKABLE QJSValue colorTable() const;
+
+    Q_INVOKABLE void setColor(int i, uint rgb)
+    { mImage.setColor(i, rgb); }
+
+    Q_INVOKABLE void setColorTable(QJSValue colors);
+
+    Q_INVOKABLE ScriptImage *copy(int x, int y, int w, int h) const;
+    Q_INVOKABLE ScriptImage *scaled(int w, int h,
+                                    Qt::AspectRatioMode aspectMode = Qt::IgnoreAspectRatio,
+                                    Qt::TransformationMode mode = Qt::FastTransformation) const;
+    Q_INVOKABLE ScriptImage *mirrored(bool horiz, bool vert) const;
+
+    const QImage &image() const { return mImage; }
+
+private:
+    QByteArray mImageData;
+    QImage mImage;
+};
+
+} // namespace Tiled
+
+Q_DECLARE_METATYPE(Tiled::ScriptImage*)

--- a/src/tiled/scriptimage.h
+++ b/src/tiled/scriptimage.h
@@ -32,6 +32,7 @@ class ScriptImage : public QObject
 
     Q_PROPERTY(int width READ width)
     Q_PROPERTY(int height READ height)
+    Q_PROPERTY(int depth READ depth)
     Q_PROPERTY(QSize size READ size)
     Q_PROPERTY(Format format READ format)
 
@@ -87,6 +88,7 @@ public:
     Format format() const { return static_cast<Format>(mImage.format()); }
     int width() const { return mImage.width(); }
     int height() const { return mImage.height(); }
+    int depth() const { return mImage.depth(); }
     QSize size() const { return mImage.size(); }
 
     Q_INVOKABLE uint pixel(int x, int y) const

--- a/src/tiled/scriptimage.h
+++ b/src/tiled/scriptimage.h
@@ -75,6 +75,19 @@ public:
     };
     Q_ENUM(Format)
 
+    enum AspectRatioMode {
+        IgnoreAspectRatio           = Qt::IgnoreAspectRatio,
+        KeepAspectRatio             = Qt::KeepAspectRatio,
+        KeepAspectRatioByExpanding  = Qt::KeepAspectRatioByExpanding
+    };
+    Q_ENUM(AspectRatioMode)
+
+    enum TransformationMode {
+        FastTransformation          = Qt::FastTransformation,
+        SmoothTransformation        = Qt::SmoothTransformation
+    };
+    Q_ENUM(TransformationMode)
+
     Q_INVOKABLE explicit ScriptImage(QObject *parent = nullptr);
     Q_INVOKABLE ScriptImage(int width, int height, Format format = Format_ARGB32_Premultiplied, QObject *parent = nullptr);
     Q_INVOKABLE ScriptImage(const QByteArray &data, int width, int height, Format format, QObject *parent = nullptr);
@@ -130,8 +143,8 @@ public:
 
     Q_INVOKABLE ScriptImage *copy(int x, int y, int w, int h) const;
     Q_INVOKABLE ScriptImage *scaled(int w, int h,
-                                    Qt::AspectRatioMode aspectMode = Qt::IgnoreAspectRatio,
-                                    Qt::TransformationMode mode = Qt::FastTransformation) const;
+                                    AspectRatioMode aspectMode = IgnoreAspectRatio,
+                                    TransformationMode mode = FastTransformation) const;
     Q_INVOKABLE ScriptImage *mirrored(bool horiz, bool vert) const;
 
     const QImage &image() const { return mImage; }

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -42,6 +42,7 @@
 #include "scriptfile.h"
 #include "scriptfileformatwrappers.h"
 #include "scriptfileinfo.h"
+#include "scriptimage.h"
 #include "scriptmodule.h"
 #include "tilecollisiondock.h"
 #include "tilelayer.h"
@@ -113,6 +114,7 @@ ScriptManager::ScriptManager(QObject *parent)
     qRegisterMetaType<TilesetEditor*>();
     qRegisterMetaType<ScriptMapFormatWrapper*>();
     qRegisterMetaType<ScriptTilesetFormatWrapper*>();
+    qRegisterMetaType<ScriptImage*>();
 
     connect(&mWatcher, &FileSystemWatcher::pathsChanged,
             this, &ScriptManager::scriptFilesChanged);
@@ -322,6 +324,7 @@ void ScriptManager::initialize()
     globalObject.setProperty(QStringLiteral("TileMap"), mEngine->newQMetaObject<EditableMap>());
     globalObject.setProperty(QStringLiteral("Tileset"), mEngine->newQMetaObject<EditableTileset>());
     globalObject.setProperty(QStringLiteral("WangSet"), mEngine->newQMetaObject<EditableWangSet>());
+    globalObject.setProperty(QStringLiteral("Image"), mEngine->newQMetaObject<ScriptImage>());
 #endif
 
     registerFileInfo(mEngine);

--- a/src/tiled/scriptmodule.h
+++ b/src/tiled/scriptmodule.h
@@ -37,11 +37,12 @@ namespace Tiled {
 
 class EditableAsset;
 class MapEditor;
+class ScriptImage;
+class ScriptMapFormatWrapper;
+class ScriptTilesetFormatWrapper;
 class ScriptedAction;
 class ScriptedMapFormat;
 class ScriptedTilesetFormat;
-class ScriptMapFormatWrapper;
-class ScriptTilesetFormatWrapper;
 class ScriptedTool;
 class TilesetEditor;
 

--- a/src/tiled/tiled.pro
+++ b/src/tiled/tiled.pro
@@ -221,6 +221,7 @@ SOURCES += aboutdialog.cpp \
     scriptfile.cpp \
     scriptfileformatwrappers.cpp \
     scriptfileinfo.cpp \
+    scriptimage.cpp \
     scriptmanager.cpp \
     scriptmodule.cpp \
     selectionrectangle.cpp \
@@ -457,6 +458,7 @@ HEADERS += aboutdialog.h \
     scriptfile.h \
     scriptfileformatwrappers.h \
     scriptfileinfo.h \
+    scriptimage.h \
     scriptmanager.h \
     scriptmodule.h \
     selectionrectangle.h \

--- a/src/tiled/tiled.qbs
+++ b/src/tiled/tiled.qbs
@@ -429,6 +429,8 @@ QtGuiApplication {
         "scriptfileformatwrappers.h",
         "scriptfileinfo.cpp",
         "scriptfileinfo.h",
+        "scriptimage.cpp",
+        "scriptimage.h",
         "scriptmanager.cpp",
         "scriptmanager.h",
         "scriptmodule.cpp",


### PR DESCRIPTION
Now a script can create an image, either directly or by loading from a file or data or based on raw data. Then, the image can be passed to Tileset.loadFromImage or Tile.setImage.

Related to issue #2695