### PR TITLE
Switch current tileset tab if all selected tiles are from the same tileset

### DIFF
--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -401,8 +401,8 @@ void TilesetDock::selectTiles(const QList<Tile *> &tiles)
         else
             currentChanged(currentIndex);
 
-        // If all of the selected tiles are in the same tileset,
-        // switch the current tab to that tileset so the user doesn't need to.
+        // If all of the selected tiles are in the same tileset, switch the
+        // current tab to that tileset.
         if (selections.size() == 1) {
             auto tileset = tiles.first()->tileset()->sharedPointer();
             const int tilesetTabIndex = mTilesets.indexOf(tileset);

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -403,13 +403,7 @@ void TilesetDock::selectTiles(const QList<Tile *> &tiles)
 
         // If all of the selected tiles are in the same tileset,
         // switch the current tab to that tileset so the user doesn't need to.
-        bool allTilesInSameTileset = true;
-        Tileset *firstTileset = tiles.first()->tileset();
-        for (int i = 1; i < tiles.size() && allTilesInSameTileset; ++i) {
-            if (tiles.at(i)->tileset() != firstTileset)
-                allTilesInSameTileset = false;
-        }
-        if (allTilesInSameTileset) {
+        if (selections.size() == 1) {
             auto tileset = tiles.first()->tileset()->sharedPointer();
             const int tilesetTabIndex = mTilesets.indexOf(tileset);
             mTabBar->setCurrentIndex(tilesetTabIndex);

--- a/src/tiled/tilesetdock.cpp
+++ b/src/tiled/tilesetdock.cpp
@@ -401,6 +401,20 @@ void TilesetDock::selectTiles(const QList<Tile *> &tiles)
         else
             currentChanged(currentIndex);
 
+        // If all of the selected tiles are in the same tileset,
+        // switch the current tab to that tileset so the user doesn't need to.
+        bool allTilesInSameTileset = true;
+        Tileset *firstTileset = tiles.first()->tileset();
+        for (int i = 1; i < tiles.size() && allTilesInSameTileset; ++i) {
+            if (tiles.at(i)->tileset() != firstTileset)
+                allTilesInSameTileset = false;
+        }
+        if (allTilesInSameTileset) {
+            auto tileset = tiles.first()->tileset()->sharedPointer();
+            const int tilesetTabIndex = mTilesets.indexOf(tileset);
+            mTabBar->setCurrentIndex(tilesetTabIndex);
+        }
+
         mSynchronizingSelection = false;
     }
 }


### PR DESCRIPTION
This makes any workflow involving "picking" tiles from the map much easier.