### PR TITLE
Prevent segfault in MapView::fitMapInView() if no scene is assigned

### DIFF
--- a/src/tiled/mapview.cpp
+++ b/src/tiled/mapview.cpp
@@ -122,7 +122,11 @@ void MapView::setScale(qreal scale)
 
 void MapView::fitMapInView()
 {
-    const QRectF rect = mapScene()->mapBoundingRect();
+    MapScene* scene = mapScene();
+    if (!scene)
+        return;
+
+    const QRectF rect = scene->mapBoundingRect();
     if (rect.isEmpty())
         return;
 


### PR DESCRIPTION
This is a small fix that prevents a segmentation fault in MapView::fitMapInView() if no scene is assigned to the view.