### PR TITLE
Allow scripting API to access properties inherited from templates

### DIFF
--- a/docs/reference/scripting.rst
+++ b/docs/reference/scripting.rst
@@ -881,14 +881,14 @@ Object.setProperties(properties : object) : void
 Object.removeProperty(name : string) : void
     Removes the custom property with the given name.
 
-Object.propertyIncludingInherited(name : string) : variant
+Object.resolvedProperty(name : string) : variant
     Returns the value of the custom property with the given name, or
     ``undefined`` if no such property is set. Includes templates and
     type defaults.
 
 .. _script-object-properties:
 
-Object.propertiesIncludingInherited() : object
+Object.resolvedProperties() : object
     Returns all custom properties set on this object. Modifications to the
     properties will not affect the original object. Includes templates and
     type defaults.

--- a/docs/reference/scripting.rst
+++ b/docs/reference/scripting.rst
@@ -850,7 +850,7 @@ Functions
 Object.property(name : string) : variant
     Returns the value of the custom property with the given name, or
     ``undefined`` if no such property is set on the object. Does not include
-    templates or type defaults.
+    inherited values (see ``resolvedProperty``).
 
     *Note:* Currently it is not possible to inspect the value of ``file`` properties.
 
@@ -868,8 +868,8 @@ Object.setProperty(name : string, value : variant) : void
 
 Object.properties() : object
     Returns all custom properties set on this object. Modifications to the
-    properties will not affect the original object. Does not include templates
-    or type defaults.
+    properties will not affect the original object. Does not include inherited
+    values (see ``resolvedProperties``).
 
 .. _script-object-setProperties:
 
@@ -883,15 +883,15 @@ Object.removeProperty(name : string) : void
 
 Object.resolvedProperty(name : string) : variant
     Returns the value of the custom property with the given name, or
-    ``undefined`` if no such property is set. Includes templates and
-    type defaults.
+    ``undefined`` if no such property is set. Includes values inherited from
+    object types, templates and tiles where applicable.
 
 .. _script-object-properties:
 
 Object.resolvedProperties() : object
     Returns all custom properties set on this object. Modifications to the
-    properties will not affect the original object. Includes templates and
-    type defaults.
+    properties will not affect the original object. Includes values inherited from
+    object types, templates and tiles where applicable.
 
 .. _script-objectgroup:
 

--- a/docs/reference/scripting.rst
+++ b/docs/reference/scripting.rst
@@ -850,7 +850,7 @@ Functions
 Object.property(name : string) : variant
     Returns the value of the custom property with the given name, or
     ``undefined`` if no such property is set on the object. Does not include
-    inherited values (see ``resolvedProperty``).
+    inherited values (see :ref:`resolvedProperty <script-object-resolvedProperty>`).
 
     *Note:* Currently it is not possible to inspect the value of ``file`` properties.
 
@@ -869,7 +869,7 @@ Object.setProperty(name : string, value : variant) : void
 Object.properties() : object
     Returns all custom properties set on this object. Modifications to the
     properties will not affect the original object. Does not include inherited
-    values (see ``resolvedProperties``).
+    values (see :ref:`resolvedProperties <script-object-resolvedProperties>`).
 
 .. _script-object-setProperties:
 
@@ -881,12 +881,14 @@ Object.setProperties(properties : object) : void
 Object.removeProperty(name : string) : void
     Removes the custom property with the given name.
 
+.. _script-object-resolvedProperty:
+
 Object.resolvedProperty(name : string) : variant
     Returns the value of the custom property with the given name, or
     ``undefined`` if no such property is set. Includes values inherited from
     object types, templates and tiles where applicable.
 
-.. _script-object-properties:
+.. _script-object-resolvedProperties:
 
 Object.resolvedProperties() : object
     Returns all custom properties set on this object. Modifications to the

--- a/docs/reference/scripting.rst
+++ b/docs/reference/scripting.rst
@@ -849,7 +849,8 @@ Functions
 
 Object.property(name : string) : variant
     Returns the value of the custom property with the given name, or
-    ``undefined`` if no such property is set on the object.
+    ``undefined`` if no such property is set on the object. Does not include
+    templates or type defaults.
 
     *Note:* Currently it is not possible to inspect the value of ``file`` properties.
 
@@ -867,7 +868,8 @@ Object.setProperty(name : string, value : variant) : void
 
 Object.properties() : object
     Returns all custom properties set on this object. Modifications to the
-    properties will not affect the original object.
+    properties will not affect the original object. Does not include templates
+    or type defaults.
 
 .. _script-object-setProperties:
 
@@ -878,6 +880,18 @@ Object.setProperties(properties : object) : void
 
 Object.removeProperty(name : string) : void
     Removes the custom property with the given name.
+
+Object.propertyIncludingInherited(name : string) : variant
+    Returns the value of the custom property with the given name, or
+    ``undefined`` if no such property is set. Includes templates and
+    type defaults.
+
+.. _script-object-properties:
+
+Object.propertiesIncludingInherited() : object
+    Returns all custom properties set on this object. Modifications to the
+    properties will not affect the original object. Includes templates and
+    type defaults.
 
 .. _script-objectgroup:
 

--- a/src/libtiled/object.cpp
+++ b/src/libtiled/object.cpp
@@ -50,7 +50,7 @@ Object::~Object()
  *      - Its tile
  *      - Its type (or the type of its tile)
  */
-QVariant Object::inheritedProperty(const QString &name) const
+QVariant Object::resolvedProperty(const QString &name) const
 {
     if (hasProperty(name))
         return property(name);
@@ -94,11 +94,11 @@ QVariant Object::inheritedProperty(const QString &name) const
     return QVariant();
 }
 
-QVariantMap Object::inheritedProperties() const
+QVariantMap Object::resolvedProperties() const
 {
     QVariantMap allProperties;
     // Insert properties into allProperties in the reverse order that
-    // Object::inheritedProperty searches them, to make sure that the
+    // Object::resolvedProperty searches them, to make sure that the
     // same precedence is maintained.
 
     QString objectType;

--- a/src/libtiled/object.cpp
+++ b/src/libtiled/object.cpp
@@ -102,9 +102,9 @@ QVariantMap Object::inheritedProperties() const
     // same precedence is maintained.
 
     QString objectType;
-    switch (mObject->typeId()) {
+    switch (typeId()) {
     case Object::MapObjectType: {
-        auto mapObject = static_cast<const MapObject*>(mObject);
+        auto mapObject = static_cast<const MapObject*>(this);
         objectType = mapObject->type();
         if (objectType.isEmpty())
             if (const Tile *tile = mapObject->cell().tile())
@@ -112,7 +112,7 @@ QVariantMap Object::inheritedProperties() const
         break;
     }
     case Object::TileType:
-        objectType = static_cast<const Tile*>(mObject)->type();
+        objectType = static_cast<const Tile*>(this)->type();
         break;
     default:
         break;
@@ -125,9 +125,9 @@ QVariantMap Object::inheritedProperties() const
         }
     }
     
-    if (mObject->typeId() == Object::MapObjectType)
+    if (typeId() == Object::MapObjectType)
     {
-        auto mapObject = static_cast<const MapObject*>(mObject);
+        auto mapObject = static_cast<const MapObject*>(this);
 
         if (const Tile *tile = mapObject->cell().tile())
             Tiled::mergeProperties(allProperties, tile->properties());
@@ -136,7 +136,7 @@ QVariantMap Object::inheritedProperties() const
             Tiled::mergeProperties(allProperties, templateObject->properties());
     }
 
-    Tiled::mergeProperties(newProperties, properties());
+    Tiled::mergeProperties(allProperties, properties());
     
     return allProperties;
 }

--- a/src/libtiled/object.cpp
+++ b/src/libtiled/object.cpp
@@ -102,8 +102,7 @@ QVariantMap Object::inheritedProperties() const
     // same precedence is maintained.
 
     QString objectType;
-    switch (mObject->typeId())
-    {
+    switch (mObject->typeId()) {
     case Object::MapObjectType: {
         auto mapObject = static_cast<const MapObject*>(mObject);
         objectType = mapObject->type();

--- a/src/libtiled/object.cpp
+++ b/src/libtiled/object.cpp
@@ -125,8 +125,7 @@ QVariantMap Object::inheritedProperties() const
         }
     }
     
-    if (typeId() == Object::MapObjectType)
-    {
+    if (typeId() == Object::MapObjectType) {
         auto mapObject = static_cast<const MapObject*>(this);
 
         if (const Tile *tile = mapObject->cell().tile())

--- a/src/libtiled/object.h
+++ b/src/libtiled/object.h
@@ -96,7 +96,6 @@ public:
     { return mProperties.value(name); }
 
     QVariant resolvedProperty(const QString &name) const;
-
     QVariantMap resolvedProperties() const;
 
     /**

--- a/src/libtiled/object.h
+++ b/src/libtiled/object.h
@@ -95,9 +95,9 @@ public:
     QVariant property(const QString &name) const
     { return mProperties.value(name); }
 
-    QVariant inheritedProperty(const QString &name) const;
+    QVariant resolvedProperty(const QString &name) const;
 
-    QVariantMap inheritedProperties() const;
+    QVariantMap resolvedProperties() const;
 
     /**
      * Returns the value of the object's \a name property, as a string.

--- a/src/libtiled/object.h
+++ b/src/libtiled/object.h
@@ -97,6 +97,8 @@ public:
 
     QVariant inheritedProperty(const QString &name) const;
 
+    QVariantMap inheritedProperties() const;
+
     /**
      * Returns the value of the object's \a name property, as a string.
      *

--- a/src/plugins/gmx/gmxplugin.cpp
+++ b/src/plugins/gmx/gmxplugin.cpp
@@ -42,7 +42,7 @@ using namespace Gmx;
 template <typename T>
 static T optionalProperty(const Object *object, const QString &name, const T &def)
 {
-    const QVariant var = object->inheritedProperty(name);
+    const QVariant var = object->resolvedProperty(name);
     return var.isValid() ? var.value<T>() : def;
 }
 

--- a/src/tiled/editableobject.cpp
+++ b/src/tiled/editableobject.cpp
@@ -31,6 +31,8 @@
 
 #include <QCoreApplication>
 
+#include "qtcompat_p.h"
+
 namespace Tiled {
 
 EditableObject::EditableObject(EditableAsset *asset,

--- a/src/tiled/editableobject.cpp
+++ b/src/tiled/editableobject.cpp
@@ -73,63 +73,6 @@ void EditableObject::removeProperty(const QString &name)
         mObject->removeProperty(name);
 }
 
-QVariantMap EditableObject::propertiesIncludingInherited() const
-{
-    auto mergeVariantMaps = [](QVariantMap& dstMap, const QVariantMap& srcMap) {
-        for (auto iter = srcMap.constBegin(); iter != srcMap.constEnd(); ++iter)
-        {
-            dstMap.insert(iter.key(), iter.value());
-        }
-    };
-
-    QVariantMap allProperties;
-    // Insert properties into allProperties in the reverse order that
-    // Object::inheritedProperty searches them, to make sure that the
-    // same precedence is maintained.
-
-    QString objectType;
-    switch (mObject->typeId()) {
-    case Object::MapObjectType:
-    {
-        auto mapObject = static_cast<const MapObject*>(mObject);
-        objectType = mapObject->type();
-        if (objectType.isEmpty())
-            if (const Tile *tile = mapObject->cell().tile())
-                objectType = tile->type();
-        break;
-    }
-    case Object::TileType:
-        objectType = static_cast<const Tile*>(mObject)->type();
-        break;
-    default:
-        break;
-    }
-
-    if (!objectType.isEmpty()) {
-        for (const ObjectType &type : qAsConst(Object::objectTypes())) {
-            if (type.name == objectType)
-                mergeVariantMaps(allProperties, type.defaultProperties);
-        }
-    }
-    
-    if (mObject->typeId() == Object::MapObjectType) {
-        auto mapObject = static_cast<const MapObject*>(mObject);
-
-        if (const Tile *tile = mapObject->cell().tile())
-            mergeVariantMaps(allProperties, tile->properties());
-        
-        if (const MapObject *templateObject = mapObject->templateObject())
-            mergeVariantMaps(allProperties, templateObject->properties());
-    }
-    
-    return allProperties;
-}
-
-QVariant EditableObject::propertyIncludingInherited(const QString &name) const
-{
-    return mObject->inheritedProperty(name);
-}
-
 Document *EditableObject::document() const
 {
     return asset() ? asset()->document() : nullptr;

--- a/src/tiled/editableobject.cpp
+++ b/src/tiled/editableobject.cpp
@@ -31,8 +31,6 @@
 
 #include <QCoreApplication>
 
-#include "qtcompat_p.h"
-
 namespace Tiled {
 
 EditableObject::EditableObject(EditableAsset *asset,

--- a/src/tiled/editableobject.h
+++ b/src/tiled/editableobject.h
@@ -60,6 +60,9 @@ public:
 
     Q_INVOKABLE void removeProperty(const QString &name);
 
+    Q_INVOKABLE QVariantMap propertiesIncludingInherited() const;
+    Q_INVOKABLE QVariant propertyIncludingInherited(const QString &name) const;
+
     Object *object() const;
     Document *document() const;
 

--- a/src/tiled/editableobject.h
+++ b/src/tiled/editableobject.h
@@ -100,12 +100,12 @@ inline QVariantMap EditableObject::properties() const
 
 inline QVariant EditableObject::resolvedProperty(const QString &name) const
 {
-    return toScript(mObject->inheritedProperty(name));
+    return toScript(mObject->resolvedProperty(name));
 }
 
 inline QVariantMap EditableObject::resolvedProperties() const
 {
-    return toScript(mObject->inheritedProperties());
+    return toScript(mObject->resolvedProperties());
 }
 
 inline Object *EditableObject::object() const

--- a/src/tiled/editableobject.h
+++ b/src/tiled/editableobject.h
@@ -60,8 +60,8 @@ public:
 
     Q_INVOKABLE void removeProperty(const QString &name);
 
-    Q_INVOKABLE QVariantMap propertiesIncludingInherited() const;
-    Q_INVOKABLE QVariant propertyIncludingInherited(const QString &name) const;
+    Q_INVOKABLE QVariant resolvedProperty(const QString &name) const;
+    Q_INVOKABLE QVariantMap resolvedProperties() const;
 
     Object *object() const;
     Document *document() const;
@@ -96,6 +96,16 @@ inline QVariant EditableObject::property(const QString &name) const
 inline QVariantMap EditableObject::properties() const
 {
     return toScript(mObject->properties());
+}
+
+inline QVariant EditableObject::resolvedProperty(const QString &name) const
+{
+    return toScript(mObject->inheritedProperty(name));
+}
+
+inline QVariantMap EditableObject::resolvedProperties() const
+{
+    return toScript(mObject->inheritedProperties());
 }
 
 inline Object *EditableObject::object() const

--- a/src/tiled/propertiesdock.cpp
+++ b/src/tiled/propertiesdock.cpp
@@ -363,7 +363,7 @@ void PropertiesDock::showContextMenu(const QPoint &pos)
     QMenu contextMenu(mPropertyBrowser);
 
     if (customPropertiesSelected && propertyNames.size() == 1) {
-        const auto value = object->inheritedProperty(propertyNames.first());
+        const auto value = object->resolvedProperty(propertyNames.first());
         if (value.userType() == filePathTypeId()) {
             const FilePath filePath = value.value<FilePath>();
             const QString localFile = filePath.url.toLocalFile();


### PR DESCRIPTION
Per discussion on https://github.com/bjorn/tiled/issues/2664 , this adds new callbacks to access properties that allow inheritance, rather than shoving inheritance into the existing callbacks. The existing function name Object::inheritedProperty is ambiguous/misleading, so I went with propertyIncludingInherited.