### PR TITLE
Scripting: Added FileInfo API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@
 * Scripting: Added support for custom "file" properties
 * Scripting: Added checks for nullptr arguments (by Phlosioneer, #2736)
 * Scripting: Added some missing tileset related properties
+* Scripting: Added FileInfo API with various file path operations
 * Scripting: Provide access to registered file formats (by Phlosioneer, #2716)
 * Scripting: Enabled scripted formats to be used on the command-line
 * Scripting: Introduced \__filename global value (with konsumer)

--- a/docs/reference/scripting.rst
+++ b/docs/reference/scripting.rst
@@ -661,7 +661,7 @@ FileInfo.fileName(filePath : string) : string
     Returns the last component of ``filePath``, that is, everything after the last '/' character.
 
 FileInfo.fromNativeSeparators(filePath : string) : string
-    On Windows, returns ``filePath`` with all '\' characters replaced by '/'. On other operating systems, it returns the input unmodified.
+    On Windows, returns ``filePath`` with all '\\\\' characters replaced by '/'. On other operating systems, it returns the input unmodified.
 
 FileInfo.isAbsolutePath(filePath : string) : boolean
     Returns true if `filePath` is an absolute path and false if it is a relative one.
@@ -679,7 +679,7 @@ FileInfo.suffix(filePath : string) : string
     Returns the file suffix of ``filePath`` from (but not including) the first '.' character.
 
 FileInfo.toNativeSeparators(filePath : string) : string
-    On Windows, returns ``filePath`` with all '/' characters replaced by '\'. On other operating systems, it returns the input unmodified.
+    On Windows, returns ``filePath`` with all '/' characters replaced by '\\\\'. On other operating systems, it returns the input unmodified.
 
 .. _script-grouplayer:
 

--- a/docs/reference/scripting.rst
+++ b/docs/reference/scripting.rst
@@ -630,6 +630,57 @@ Functions
 FileFormat.supportsFile(fileName : string) : bool
     Returns whether the file is readable by this format.
 
+.. _script-fileinfo:
+
+FileInfo
+^^^^^^^^
+
+Offers various operations on file paths, such as turning absolute paths into relative ones, splitting a path into its components, and so on.
+
+Functions
+~~~~~~~~~
+
+FileInfo.baseName(filePath : string) : string
+    Returns the file name of ``filePath`` up to (but not including) the first '.' character.
+
+FileInfo.canonicalPath(filePath : string) : string
+    Returns a canonicalized ``filePath``, i.e. an absolute path without symbolic links or redundant "." or ".." elements. On Windows, drive substitutions are also resolved.
+
+    It is recommended to use ``canonicalPath`` in only those cases where canonical paths are really necessary. In most cases, ``cleanPath`` should be enough.
+
+FileInfo.cleanPath(filePath : string) : string
+    Returns ``filePath`` without redundant separators and with resolved occurrences of `.` and `..` components. For instance, ``/usr/local//../bin/`` becomes ``/usr/bin``.
+
+FileInfo.completeBaseName(filePath: string) : string
+    Returns the file name of ``filePath`` up to (but not including) the last '.' character.
+
+FileInfo.completeSuffix(filePath : string) : string
+    Returns the file suffix of ``filePath`` from (but not including) the last '.' character.
+
+FileInfo.fileName(filePath : string) : string
+    Returns the last component of ``filePath``, that is, everything after the last '/' character.
+
+FileInfo.fromNativeSeparators(filePath : string) : string
+    On Windows, returns ``filePath`` with all '\' characters replaced by '/'. On other operating systems, it returns the input unmodified.
+
+FileInfo.isAbsolutePath(filePath : string) : boolean
+    Returns true if `filePath` is an absolute path and false if it is a relative one.
+
+FileInfo.joinPaths(...paths) : string
+    Concatenates the given paths using the '/' character.
+
+FileInfo.path(filePath : string) : string
+    Returns the part of ``filePath`` that is not the file name, that is, everything up to (but not including) the last '/' character. If ``filePath`` is just a file name, then '.' is returned. If ``filePath`` ends with a '/' character, then the file name is assumed to be empty for the purpose of the above definition.
+
+FileInfo.relativePath(dirPath : string, filePath : string) : string
+    Returns the path to ``filePath`` relative to the directory ``dirPath``. If necessary, '..' components are inserted.
+
+FileInfo.suffix(filePath : string) : string
+    Returns the file suffix of ``filePath`` from (but not including) the first '.' character.
+
+FileInfo.toNativeSeparators(filePath : string) : string
+    On Windows, returns ``filePath`` with all '/' characters replaced by '\'. On other operating systems, it returns the input unmodified.
+
 .. _script-grouplayer:
 
 GroupLayer

--- a/src/tiled/scriptfileinfo.cpp
+++ b/src/tiled/scriptfileinfo.cpp
@@ -1,0 +1,134 @@
+/*
+ * scriptfileinfo.cpp
+ * Copyright 2020, David Konsumer <konsumer@jetboystudio.com>
+ * Copyright 2020, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "scriptfileinfo.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QJSEngine>
+
+namespace Tiled {
+
+class ScriptFileInfo : public QObject
+{
+    Q_OBJECT
+
+public:
+    ScriptFileInfo(QObject *parent = nullptr);
+
+    Q_INVOKABLE QString baseName(const QString &filePath) const;
+    Q_INVOKABLE QString canonicalPath(const QString &filePath) const;
+    Q_INVOKABLE QString cleanPath(const QString &filePath) const;
+    Q_INVOKABLE QString completeBaseName(const QString &filePath) const;
+    Q_INVOKABLE QString completeSuffix(const QString &filePath) const;
+    Q_INVOKABLE QString fileName(const QString &filePath) const;
+    Q_INVOKABLE QString fromNativeSeparators(const QString &filePath) const;
+    Q_INVOKABLE bool isAbsolutePath(const QString &filePath) const;
+    Q_INVOKABLE QString _joinPaths(const QStringList &paths) const;
+    Q_INVOKABLE QString path(const QString &filePath) const;
+    Q_INVOKABLE QString relativePath(const QString &dirPath, const QString &filePath) const;
+    Q_INVOKABLE QString suffix(const QString &filePath) const;
+    Q_INVOKABLE QString toNativeSeparators(const QString &filePath) const;
+};
+
+ScriptFileInfo::ScriptFileInfo(QObject *parent)
+    : QObject(parent)
+{}
+
+QString ScriptFileInfo::baseName(const QString &filePath) const
+{
+    return QFileInfo(filePath).baseName();
+}
+
+QString ScriptFileInfo::canonicalPath(const QString &filePath) const
+{
+    return QFileInfo(filePath).canonicalFilePath();
+}
+
+QString ScriptFileInfo::cleanPath(const QString &filePath) const
+{
+    return QDir::cleanPath(filePath);
+}
+
+QString ScriptFileInfo::completeBaseName(const QString &filePath) const
+{
+    return QFileInfo(filePath).completeBaseName();
+}
+
+QString ScriptFileInfo::completeSuffix(const QString &filePath) const
+{
+    return QFileInfo(filePath).completeSuffix();
+}
+
+QString ScriptFileInfo::fileName(const QString &filePath) const
+{
+    return QFileInfo(filePath).fileName();
+}
+
+QString ScriptFileInfo::fromNativeSeparators(const QString &filePath) const
+{
+    return QDir::fromNativeSeparators(filePath);
+}
+
+bool ScriptFileInfo::isAbsolutePath(const QString &filePath) const
+{
+    return QFileInfo(filePath).isAbsolute();
+}
+
+QString ScriptFileInfo::_joinPaths(const QStringList &paths) const
+{
+    return QDir::cleanPath(paths.join(QLatin1Char('/')));
+}
+
+QString ScriptFileInfo::path(const QString &filePath) const
+{
+    return QFileInfo(filePath).path();
+}
+
+QString ScriptFileInfo::relativePath(const QString &dirPath, const QString &filePath) const
+{
+    return QDir(dirPath).relativeFilePath(filePath);
+}
+
+QString ScriptFileInfo::suffix(const QString &filePath) const
+{
+    return QFileInfo(filePath).suffix();
+}
+
+QString ScriptFileInfo::toNativeSeparators(const QString &filePath) const
+{
+    return QDir::toNativeSeparators(filePath);
+}
+
+
+void registerFileInfo(QJSEngine *jsEngine)
+{
+    jsEngine->globalObject().setProperty(QStringLiteral("FileInfo"),
+                                         jsEngine->newQObject(new ScriptFileInfo));
+    // allow dynamic arg-length
+    jsEngine->evaluate(QLatin1String("FileInfo.joinPaths = function (...args) { "
+                                     "    return this._joinPaths(args)"
+                                     "}"));
+}
+
+} // namespace Tiled
+
+#include "scriptfileinfo.moc"

--- a/src/tiled/scriptfileinfo.h
+++ b/src/tiled/scriptfileinfo.h
@@ -1,0 +1,29 @@
+/*
+ * scriptfileinfo.h
+ * Copyright 2020, Thorbjørn Lindeijer <bjorn@lindeijer.nl>
+ *
+ * This file is part of Tiled.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+class QJSEngine;
+
+namespace Tiled {
+
+void registerFileInfo(QJSEngine *jsEngine);
+
+} // namespace Tiled

--- a/src/tiled/scriptmanager.cpp
+++ b/src/tiled/scriptmanager.cpp
@@ -41,6 +41,7 @@
 #include "scriptedtool.h"
 #include "scriptfile.h"
 #include "scriptfileformatwrappers.h"
+#include "scriptfileinfo.h"
 #include "scriptmodule.h"
 #include "tilecollisiondock.h"
 #include "tilelayer.h"
@@ -302,6 +303,8 @@ void ScriptManager::initialize()
     globalObject.setProperty(QStringLiteral("TileMap"), mEngine->newQMetaObject<EditableMap>());
     globalObject.setProperty(QStringLiteral("Tileset"), mEngine->newQMetaObject<EditableTileset>());
 #endif
+
+    registerFileInfo(mEngine);
 
     loadExtensions();
 }

--- a/src/tiled/tiled.pro
+++ b/src/tiled/tiled.pro
@@ -214,6 +214,7 @@ SOURCES += aboutdialog.cpp \
     scriptedtool.cpp \
     scriptfile.cpp \
     scriptfileformatwrappers.cpp \
+    scriptfileinfo.cpp \
     scriptmanager.cpp \
     scriptmodule.cpp \
     selectionrectangle.cpp \
@@ -456,6 +457,7 @@ HEADERS += aboutdialog.h \
     scriptedtool.h \
     scriptfile.h \
     scriptfileformatwrappers.h \
+    scriptfileinfo.h \
     scriptmanager.h \
     scriptmodule.h \
     selectionrectangle.h \

--- a/src/tiled/tiled.qbs
+++ b/src/tiled/tiled.qbs
@@ -432,6 +432,8 @@ QtGuiApplication {
         "scriptfile.h",
         "scriptfileformatwrappers.cpp",
         "scriptfileformatwrappers.h",
+        "scriptfileinfo.cpp",
+        "scriptfileinfo.h",
         "scriptmanager.cpp",
         "scriptmanager.h",
         "scriptmodule.cpp",


### PR DESCRIPTION
Based on the Qbs FileInfo service.

I've taken the code from https://github.com/4QJS/Qbs4QJS/blob/master/fileinfo.h and adjusted it a little:

* Removed `fromWindowsSeparators` and `toWindowsSeparators` (which were just calling the same function as the "Native" versions of these).

* Returned `absoluteFilePath` for the `absolutePath` function, to make sure the file name is still included.

* Dropped intention to support "hostOS" parameter, which only really makes sense in Qbs as build system.

* Code style changes.

* Documentation reformatted and adjusted.

Co-authored-by: @konsumer