### PR TITLE
Include QPainterPath where necessary

### DIFF
--- a/src/libtiled/hexagonalrenderer.cpp
+++ b/src/libtiled/hexagonalrenderer.cpp
@@ -36,6 +36,7 @@
 
 #include <QVector2D>
 #include <QtCore/qmath.h>
+#include <QPainterPath>
 
 #include <limits>
 

--- a/src/libtiled/isometricrenderer.h
+++ b/src/libtiled/isometricrenderer.h
@@ -30,6 +30,8 @@
 
 #include "maprenderer.h"
 
+#include <QPainterPath>
+
 namespace Tiled {
 
 /**

--- a/src/libtiled/mapobject.cpp
+++ b/src/libtiled/mapobject.cpp
@@ -37,6 +37,7 @@
 #include "tile.h"
 
 #include <QFontMetricsF>
+#include <QPainterPath>
 #include <qmath.h>
 
 namespace Tiled {

--- a/src/libtiled/orthogonalrenderer.h
+++ b/src/libtiled/orthogonalrenderer.h
@@ -30,6 +30,8 @@
 
 #include "maprenderer.h"
 
+#include <QPainterPath>
+
 namespace Tiled {
 
 /**


### PR DESCRIPTION
Apparently an include was removed in a header somewhere in newer
versions of Qt.