### PR TITLE
Pass tilePos to RenderTileCallback

### DIFF
--- a/src/libtiled/hexagonalrenderer.cpp
+++ b/src/libtiled/hexagonalrenderer.cpp
@@ -271,8 +271,8 @@ void HexagonalRenderer::drawTileLayer(QPainter *painter,
                                       const QRectF &exposed) const
 {
     CellRenderer renderer(painter, this, layer->effectiveTintColor(), CellRenderer::HexagonalCells);
-    auto tileRenderFunction = [&renderer](const Cell &cell, const QPointF &pos, const QSizeF &size) {
-        renderer.render(cell, pos, size, CellRenderer::BottomLeft);
+    auto tileRenderFunction = [&renderer](const Cell &cell, const QPoint &/*tilePos*/, const QPointF &screenPos, const QSizeF &size) {
+        renderer.render(cell, screenPos, size, CellRenderer::BottomLeft);
     };
     drawTileLayer(layer, tileRenderFunction, exposed);
 }
@@ -342,7 +342,7 @@ void HexagonalRenderer::drawTileLayer(const TileLayer *layer,
                 if (!cell.isEmpty()) {
                     const Tile *tile = cell.tile();
                     const QSize size = tile ? tile->size() : map()->tileSize();
-                    renderTile(cell, rowPos, size);
+                    renderTile(cell, rowTile, rowPos, size);
                 }
 
                 rowPos.rx() += p.tileWidth + p.sideLengthX;
@@ -387,7 +387,7 @@ void HexagonalRenderer::drawTileLayer(const TileLayer *layer,
                 if (!cell.isEmpty()) {
                     const Tile *tile = cell.tile();
                     const QSize size = tile ? tile->size() : map()->tileSize();
-                    renderTile(cell, rowPos, size);
+                    renderTile(cell, rowTile, rowPos, size);
                 }
 
                 rowPos.rx() += p.tileWidth + p.sideLengthX;

--- a/src/libtiled/hexagonalrenderer.h
+++ b/src/libtiled/hexagonalrenderer.h
@@ -79,9 +79,8 @@ public:
     void drawTileLayer(QPainter *painter, const TileLayer *layer,
                        const QRectF &exposed = QRectF()) const override;
 
-    void drawTileLayer(const TileLayer *layer,
-                       const RenderTileCallback &renderTile,
-                       const QRectF &exposed = QRectF()) const override;
+    void drawTileLayer(const RenderTileCallback &renderTile,
+                       const QRectF &exposed) const override;
 
     void drawTileSelection(QPainter *painter,
                            const QRegion &region,

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -267,8 +267,8 @@ void IsometricRenderer::drawTileLayer(QPainter *painter,
                                       const QRectF &exposed) const
 {
     CellRenderer renderer(painter, this, layer->effectiveTintColor());
-    auto tileRenderFunction = [&renderer](const Cell &cell, const QPointF &pos, const QSizeF &size) {
-        renderer.render(cell, pos, size, CellRenderer::BottomLeft);
+    auto tileRenderFunction = [&renderer](const Cell &cell, const QPoint &/*tilePos*/, const QPointF &screenPos, const QSizeF &size) {
+        renderer.render(cell, screenPos, size, CellRenderer::BottomLeft);
     };
     drawTileLayer(layer, tileRenderFunction, exposed);
 }
@@ -339,7 +339,7 @@ void IsometricRenderer::drawTileLayer(const TileLayer *layer,
             if (!cell.isEmpty()) {
                 const Tile *tile = cell.tile();
                 const QSize size = (tile && !tile->image().isNull()) ? tile->size() : map()->tileSize();
-                renderTile(cell, QPointF(x, (qreal)y / 2), size);
+                renderTile(cell, columnItr, QPointF(x, (qreal)y / 2), size);
             }
 
             // Advance to the next column

--- a/src/libtiled/isometricrenderer.h
+++ b/src/libtiled/isometricrenderer.h
@@ -57,9 +57,8 @@ public:
     void drawTileLayer(QPainter *painter, const TileLayer *layer,
                        const QRectF &exposed = QRectF()) const override;
 
-    void drawTileLayer(const TileLayer *layer,
-                       const RenderTileCallback &renderTile,
-                       const QRectF &exposed = QRectF()) const override;
+    void drawTileLayer(const RenderTileCallback &renderTile,
+                       const QRectF &exposed) const override;
 
     void drawTileSelection(QPainter *painter,
                            const QRegion &region,

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -273,7 +273,7 @@ CellRenderer::CellRenderer(QPainter *painter, const MapRenderer *renderer, const
  *
  * This call expects `painter.translate(pos)` to correspond to the Origin point.
  */
-void CellRenderer::render(const Cell &cell, const QPointF &pos, const QSizeF &size, Origin origin)
+void CellRenderer::render(const Cell &cell, const QPointF &screenPos, const QSizeF &size, Origin origin)
 {
     const Tile *tile = cell.tile();
 
@@ -281,7 +281,7 @@ void CellRenderer::render(const Cell &cell, const QPointF &pos, const QSizeF &si
         tile = tile->currentFrameTile();
 
     if (!tile || tile->image().isNull()) {
-        QRectF target { pos, size };
+        QRectF target { screenPos, size };
 
         if (origin == BottomLeft)
             target.translate(0.0, -size.height());
@@ -309,8 +309,8 @@ void CellRenderer::render(const Cell &cell, const QPointF &pos, const QSizeF &si
 
     QPainter::PixmapFragment fragment;
     // Calculate the position as if the origin is TopLeft, and correct it later.
-    fragment.x = pos.x() + (offset.x() * scale.width()) + sizeHalf.x();
-    fragment.y = pos.y() + (offset.y() * scale.height()) + sizeHalf.y();
+    fragment.x = screenPos.x() + (offset.x() * scale.width()) + sizeHalf.x();
+    fragment.y = screenPos.y() + (offset.y() * scale.height()) + sizeHalf.y();
     fragment.sourceLeft = 0;
     fragment.sourceTop = 0;
     fragment.width = imageSize.width();

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -132,7 +132,7 @@ public:
     virtual void drawGrid(QPainter *painter, const QRectF &rect,
                           QColor gridColor = Qt::black) const = 0;
 
-    typedef std::function<void(const Cell &, const QPoint &, const QPointF &, const QSizeF &)> RenderTileCallback;
+    typedef std::function<void(QPoint, const QPointF &)> RenderTileCallback;
 
     /**
      * Draws the given \a layer using the given \a painter.
@@ -158,9 +158,8 @@ public:
      * Optionally, you can pass in the \a exposed rect (of pixels), so that
      * only tiles that can be visible in this area will be drawn.
      */
-    virtual void drawTileLayer(const TileLayer *layer,
-                               const RenderTileCallback &renderTile,
-                               const QRectF &exposed = QRectF()) const = 0;
+    virtual void drawTileLayer(const RenderTileCallback &renderTile,
+                               const QRectF &exposed) const = 0;
 
     /**
      * Draws the tile selection given by \a region in the specified \a color.

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -132,7 +132,7 @@ public:
     virtual void drawGrid(QPainter *painter, const QRectF &rect,
                           QColor gridColor = Qt::black) const = 0;
 
-    typedef std::function<void(const Cell &, const QPointF &, const QSizeF &)> RenderTileCallback;
+    typedef std::function<void(const Cell &, const QPoint &, const QPointF &, const QSizeF &)> RenderTileCallback;
 
     /**
      * Draws the given \a layer using the given \a painter.
@@ -145,6 +145,15 @@ public:
 
     /**
      * Draws the given \a layer using the given \a renderTile callback.
+     *
+     * The callback takes four arguments:
+     *
+     * \list
+     * \li \c cell - The Cell that is being rendered.
+     * \li \c tilePos - The tile position of the cell being rendered.
+     * \li \c screenPos - The screen position of the cell being rendered.
+     * \li \c size - The size of the cell being rendered.
+     * \endlist
      *
      * Optionally, you can pass in the \a exposed rect (of pixels), so that
      * only tiles that can be visible in this area will be drawn.

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -266,8 +266,8 @@ void OrthogonalRenderer::drawTileLayer(QPainter *painter,
                                        const QRectF &exposed) const
 {
     CellRenderer renderer(painter, this, layer->effectiveTintColor());
-    auto tileRenderFunction = [&renderer](const Cell &cell, const QPointF &pos, const QSizeF &size) {
-        renderer.render(cell, pos, size, CellRenderer::BottomLeft);
+    auto tileRenderFunction = [&renderer](const Cell &cell, const QPoint &/*tilePos*/, const QPointF &screenPos, const QSizeF &size) {
+        renderer.render(cell, screenPos, size, CellRenderer::BottomLeft);
     };
     drawTileLayer(layer, tileRenderFunction, exposed);
 }
@@ -346,7 +346,7 @@ void OrthogonalRenderer::drawTileLayer(const TileLayer *layer,
 
             const Tile *tile = cell.tile();
             const QSize size = (tile && !tile->image().isNull()) ? tile->size() : map()->tileSize();
-            renderTile(cell, layerPos + QPointF(x * tileWidth, (y + 1) * tileHeight), size);
+            renderTile(cell, QPoint(x, y), layerPos + QPointF(x * tileWidth, (y + 1) * tileHeight), size);
         }
     }
 }

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -265,20 +265,9 @@ void OrthogonalRenderer::drawTileLayer(QPainter *painter,
                                        const TileLayer *layer,
                                        const QRectF &exposed) const
 {
-    CellRenderer renderer(painter, this, layer->effectiveTintColor());
-    auto tileRenderFunction = [&renderer](const Cell &cell, const QPoint &/*tilePos*/, const QPointF &screenPos, const QSizeF &size) {
-        renderer.render(cell, screenPos, size, CellRenderer::BottomLeft);
-    };
-    drawTileLayer(layer, tileRenderFunction, exposed);
-}
-
-void OrthogonalRenderer::drawTileLayer(const TileLayer *layer,
-                                       const RenderTileCallback &renderTile,
-                                       const QRectF &exposed) const
-{
-
     const int tileWidth = map()->tileWidth();
     const int tileHeight = map()->tileHeight();
+
     if (tileWidth <= 0 || tileHeight <= 0)
         return;
 
@@ -286,10 +275,6 @@ void OrthogonalRenderer::drawTileLayer(const TileLayer *layer,
                            layer->y() * tileHeight);
 
     QRect bounds = layer->localBounds();
-    int startX = bounds.left();
-    int startY = bounds.top();
-    int endX = bounds.right();
-    int endY = bounds.bottom();
 
     if (!exposed.isNull()) {
         QMargins drawMargins = layer->drawMargins();
@@ -303,11 +288,39 @@ void OrthogonalRenderer::drawTileLayer(const TileLayer *layer,
 
         rect.translate(-layerPos);
 
-        startX = qMax(qFloor(rect.x() / tileWidth), startX);
-        startY = qMax(qFloor(rect.y() / tileHeight), startY);
-        endX = qMin(qCeil(rect.right()) / tileWidth, endX);
-        endY = qMin(qCeil(rect.bottom()) / tileHeight, endY);
+        bounds.setLeft(qMax(qFloor(rect.x() / tileWidth), bounds.left()));
+        bounds.setTop(qMax(qFloor(rect.y() / tileHeight), bounds.top()));
+        bounds.setRight(qMin(qCeil(rect.right()) / tileWidth, bounds.right()));
+        bounds.setBottom(qMin(qCeil(rect.bottom()) / tileHeight, bounds.bottom()));
     }
+
+    CellRenderer renderer(painter, this, layer->effectiveTintColor());
+
+    auto tileRenderFunction = [layer, &renderer, this, layerPos](QPoint tilePos, const QPointF &screenPos) {
+        const Cell &cell = layer->cellAt(tilePos);
+        if (!cell.isEmpty()) {
+            const Tile *tile = cell.tile();
+            const QSize size = (tile && !tile->image().isNull()) ? tile->size() : map()->tileSize();
+            renderer.render(cell, screenPos + layerPos, size, CellRenderer::BottomLeft);
+        }
+    };
+
+    drawTileLayer(tileRenderFunction, boundingRect(bounds));
+}
+
+void OrthogonalRenderer::drawTileLayer(const RenderTileCallback &renderTile,
+                                       const QRectF &exposed) const
+{
+    const int tileWidth = map()->tileWidth();
+    const int tileHeight = map()->tileHeight();
+
+    if (tileWidth <= 0 || tileHeight <= 0)
+        return;
+
+    int startX = qFloor(exposed.x() / tileWidth);
+    int startY = qFloor(exposed.y() / tileHeight);
+    int endX = qCeil(exposed.right()) / tileWidth;
+    int endY = qCeil(exposed.bottom()) / tileHeight;
 
     // Return immediately when there is nothing to draw
     if (startX > endX || startY > endY)
@@ -338,17 +351,9 @@ void OrthogonalRenderer::drawTileLayer(const TileLayer *layer,
     endX += incX;
     endY += incY;
 
-    for (int y = startY; y != endY; y += incY) {
-        for (int x = startX; x != endX; x += incX) {
-            const Cell &cell = layer->cellAt(x, y);
-            if (cell.isEmpty())
-                continue;
-
-            const Tile *tile = cell.tile();
-            const QSize size = (tile && !tile->image().isNull()) ? tile->size() : map()->tileSize();
-            renderTile(cell, QPoint(x, y), layerPos + QPointF(x * tileWidth, (y + 1) * tileHeight), size);
-        }
-    }
+    for (int y = startY; y != endY; y += incY)
+        for (int x = startX; x != endX; x += incX)
+            renderTile(QPoint(x, y), QPointF(x * tileWidth, (y + 1) * tileHeight));
 }
 
 void OrthogonalRenderer::drawTileSelection(QPainter *painter,

--- a/src/libtiled/orthogonalrenderer.h
+++ b/src/libtiled/orthogonalrenderer.h
@@ -55,9 +55,8 @@ public:
     void drawTileLayer(QPainter *painter, const TileLayer *layer,
                        const QRectF &exposed = QRectF()) const override;
 
-    void drawTileLayer(const TileLayer *layer,
-                       const RenderTileCallback &renderTile,
-                       const QRectF &exposed = QRectF()) const override;
+    void drawTileLayer(const RenderTileCallback &renderTile,
+                       const QRectF &exposed) const override;
 
     void drawTileSelection(QPainter *painter,
                            const QRegion &region,

--- a/src/tiledquickplugin/tilelayeritem.cpp
+++ b/src/tiledquickplugin/tilelayeritem.cpp
@@ -155,7 +155,7 @@ QSGNode *TileLayerItem::updatePaintNode(QSGNode *node,
      * drawn tiles are using the same tileset, they will share a single
      * geometry node.
      */
-    auto tileRenderFunction = [&](const Cell &cell, const QPointF &pos, const QSizeF &size) {
+    auto tileRenderFunction = [&](const Cell &cell, const QPoint &/*tilePos*/, const QPointF &screenPos, const QSizeF &size) {
         Tileset *tileset = cell.tileset();
         if (!tileset)
             return;
@@ -180,8 +180,8 @@ QSGNode *TileLayerItem::updatePaintNode(QSGNode *node,
         const auto offset = tileset->tileOffset();
 
         TileData data;
-        data.x = static_cast<float>(pos.x()) + offset.x();
-        data.y = static_cast<float>(pos.y() - size.height()) + offset.y();
+        data.x = static_cast<float>(screenPos.x()) + offset.x();
+        data.y = static_cast<float>(screenPos.y() - size.height()) + offset.y();
         data.width = static_cast<float>(size.width());
         data.height = static_cast<float>(size.height());
         data.flippedHorizontally = cell.flippedHorizontally();

--- a/src/tiledquickplugin/tilelayeritem.cpp
+++ b/src/tiledquickplugin/tilelayeritem.cpp
@@ -155,7 +155,8 @@ QSGNode *TileLayerItem::updatePaintNode(QSGNode *node,
      * drawn tiles are using the same tileset, they will share a single
      * geometry node.
      */
-    auto tileRenderFunction = [&](const Cell &cell, const QPoint &/*tilePos*/, const QPointF &screenPos, const QSizeF &size) {
+    auto tileRenderFunction = [&](QPoint tilePos, const QPointF &screenPos) {
+        const Cell &cell = mLayer->cellAt(tilePos);
         Tileset *tileset = cell.tileset();
         if (!tileset)
             return;
@@ -178,6 +179,8 @@ QSGNode *TileLayerItem::updatePaintNode(QSGNode *node,
 //        }
 
         const auto offset = tileset->tileOffset();
+        const auto tile = tileset->findTile(cell.tileId());
+        const QSize size = (tile && !tile->image().isNull()) ? tile->size() : mRenderer->map()->tileSize();
 
         TileData data;
         data.x = static_cast<float>(screenPos.x()) + offset.x();
@@ -190,7 +193,7 @@ QSGNode *TileLayerItem::updatePaintNode(QSGNode *node,
         tileData.append(data);
     };
 
-    mRenderer->drawTileLayer(mLayer, tileRenderFunction, mVisibleArea);
+    mRenderer->drawTileLayer(tileRenderFunction, mVisibleArea);
 
     if (!tileData.isEmpty())
         node->appendChildNode(new TilesNode(helper.texture(), tileData));
@@ -201,7 +204,19 @@ QSGNode *TileLayerItem::updatePaintNode(QSGNode *node,
 void TileLayerItem::updateVisibleTiles()
 {
     const MapItem *mapItem = static_cast<MapItem*>(parentItem());
-    const QRectF &rect = mapItem->visibleArea();
+
+    QRectF rect = mapItem->visibleArea();
+
+    QMargins drawMargins = mLayer->drawMargins();
+    drawMargins.setTop(drawMargins.top() - mRenderer->map()->tileHeight());
+    drawMargins.setRight(drawMargins.right() - mRenderer->map()->tileWidth());
+
+    rect.adjust(-drawMargins.right(),
+                -drawMargins.bottom(),
+                drawMargins.left(),
+                drawMargins.top());
+
+    rect &= mRenderer->boundingRect(mLayer->localBounds());
 
     if (mVisibleArea != rect) {
         mVisibleArea = rect;


### PR DESCRIPTION
This allows custom tile-rendering code to benefit from the tile position
calculations that the renderers do. It is necessary in order to allow
each tile to be its own QQuickItem.