### PR TITLE
Add animation advancing to tmxrasterizer

### DIFF
--- a/src/libtiled/tilesetmanager.h
+++ b/src/libtiled/tilesetmanager.h
@@ -71,6 +71,8 @@ public:
 
     void setAnimateTiles(bool enabled);
     bool animateTiles() const;
+
+    void advanceTileAnimations(int ms);
     void resetTileAnimations();
 
     void tilesetImageSourceChanged(const Tileset &tileset,
@@ -90,8 +92,6 @@ signals:
 
 private:
     void filesChanged(const QStringList &fileNames);
-
-    void advanceTileAnimations(int ms);
 
     /**
      * The list of loaded tilesets (weak references).

--- a/src/tmxrasterizer/main.cpp
+++ b/src/tmxrasterizer/main.cpp
@@ -130,12 +130,12 @@ int main(int argc, char *argv[])
     }
 
     if (parser.isSet(QLatin1String("advance-animations"))) {
-      bool ok;
-      w.setAdvanceAnimations(parser.value(QLatin1String("advance-animations")).toDouble(&ok));
-      if (!ok || w.advanceAnimations() <= 0.0) {
-        qWarning().noquote() << QCoreApplication::translate("main", "Invalid advance-animations specified: \"%1\"").arg(parser.value(QLatin1String("advance-animations")));
+        bool ok;
+        w.setAdvanceAnimations(parser.value(QLatin1String("advance-animations")).toInt(&ok));
+        if (!ok || w.advanceAnimations() < 0) {
+            qWarning().noquote() << QCoreApplication::translate("main", "Invalid advance-animations specified: \"%1\"").arg(parser.value(QLatin1String("advance-animations")));
             exit(1);
-      }
+        }
     }
 
     return w.render(fileToOpen, fileToSave);

--- a/src/tmxrasterizer/main.cpp
+++ b/src/tmxrasterizer/main.cpp
@@ -77,6 +77,9 @@ int main(int argc, char *argv[])
                           { "show-layer",
                             QCoreApplication::translate("main", "If used only specified layers are shown. Can be repeated to show multiple specified layers only."),
                             QCoreApplication::translate("main", "name") },
+                          { "advance-animations",
+                            QCoreApplication::translate("main", "If used tile animations are advanced by the specified duration."),
+                            QCoreApplication::translate("main", "duration") }
                       });
     parser.addPositionalArgument("map|world", QCoreApplication::translate("main", "Map or world file to render."));
     parser.addPositionalArgument("image", QCoreApplication::translate("main", "Image file to output."));
@@ -124,6 +127,15 @@ int main(int argc, char *argv[])
             qWarning().noquote() << QCoreApplication::translate("main", "Invalid scale specified: \"%1\"").arg(parser.value(QLatin1String("scale")));
             exit(1);
         }
+    }
+
+    if (parser.isSet(QLatin1String("advance-animations"))) {
+      bool ok;
+      w.setAdvanceAnimations(parser.value(QLatin1String("advance-animations")).toDouble(&ok));
+      if (!ok || w.advanceAnimations() <= 0.0) {
+        qWarning().noquote() << QCoreApplication::translate("main", "Invalid advance-animations specified: \"%1\"").arg(parser.value(QLatin1String("advance-animations")));
+            exit(1);
+      }
     }
 
     return w.render(fileToOpen, fileToSave);

--- a/src/tmxrasterizer/tmxrasterizer.cpp
+++ b/src/tmxrasterizer/tmxrasterizer.cpp
@@ -183,9 +183,8 @@ int TmxRasterizer::renderMap(const QString &mapFileName,
         xScale = yScale = mScale;
     }
 
-    if (mAdvanceAnimations > 0) {
+    if (mAdvanceAnimations > 0) 
         TilesetManager::instance()->advanceTileAnimations(mAdvanceAnimations);
-    }
 
     QMargins margins = map->computeLayerOffsetMargins();
     mapSize.setWidth(mapSize.width() + margins.left() + margins.right());
@@ -294,9 +293,9 @@ int TmxRasterizer::renderWorld(const QString &worldFileName,
                     qUtf8Printable(errorString));
             continue;
         }
-        if (mAdvanceAnimations > 0) {
+        if (mAdvanceAnimations > 0) 
             TilesetManager::instance()->advanceTileAnimations(mAdvanceAnimations);
-        }
+        
         std::unique_ptr<MapRenderer> renderer = createRenderer(*map);
         drawMapLayers(*renderer, painter, *map, mapEntry.rect.topLeft());
         TilesetManager::instance()->resetTileAnimations();

--- a/src/tmxrasterizer/tmxrasterizer.cpp
+++ b/src/tmxrasterizer/tmxrasterizer.cpp
@@ -31,6 +31,7 @@
 #include "hexagonalrenderer.h"
 #include "imagelayer.h"
 #include "isometricrenderer.h"
+#include "tilesetmanager.h"
 #include "map.h"
 #include "mapformat.h"
 #include "mapreader.h"
@@ -66,6 +67,7 @@ TmxRasterizer::TmxRasterizer():
     mScale(1.0),
     mTileSize(0),
     mSize(0),
+    mAdvanceAnimations(0),
     mUseAntiAliasing(false),
     mSmoothImages(true),
     mIgnoreVisibility(false)
@@ -181,6 +183,10 @@ int TmxRasterizer::renderMap(const QString &mapFileName,
         xScale = yScale = mScale;
     }
 
+    if (mAdvanceAnimations > 0) {
+        TilesetManager::instance()->advanceTileAnimations(mAdvanceAnimations);
+    }
+
     QMargins margins = map->computeLayerOffsetMargins();
     mapSize.setWidth(mapSize.width() + margins.left() + margins.right());
     mapSize.setHeight(mapSize.height() + margins.top() + margins.bottom());
@@ -288,8 +294,12 @@ int TmxRasterizer::renderWorld(const QString &worldFileName,
                     qUtf8Printable(errorString));
             continue;
         }
+        if (mAdvanceAnimations > 0) {
+            TilesetManager::instance()->advanceTileAnimations(mAdvanceAnimations);
+        }
         std::unique_ptr<MapRenderer> renderer = createRenderer(*map);
         drawMapLayers(*renderer, painter, *map, mapEntry.rect.topLeft());
+        TilesetManager::instance()->resetTileAnimations();
     }
 
     return saveImage(imageFileName, image);

--- a/src/tmxrasterizer/tmxrasterizer.h
+++ b/src/tmxrasterizer/tmxrasterizer.h
@@ -49,7 +49,7 @@ public:
     qreal scale() const { return mScale; }
     int tileSize() const { return mTileSize; }
     int size() const { return mSize; }
-    int advanceAnimations() const {return mAdvanceAnimations; }
+    int advanceAnimations() const { return mAdvanceAnimations; }
     bool useAntiAliasing() const { return mUseAntiAliasing; }
     bool smoothImages() const { return mSmoothImages; }
     bool ignoreVisibility() const { return mIgnoreVisibility; }
@@ -58,14 +58,12 @@ public:
     void setTileSize(int tileSize) { mTileSize = tileSize; }
     void setSize(int size) { mSize = size; }
     void setAdvanceAnimations(int duration) { mAdvanceAnimations = duration; }
-
     void setAntiAliasing(bool useAntiAliasing) { mUseAntiAliasing = useAntiAliasing; }
     void setSmoothImages(bool smoothImages) { mSmoothImages = smoothImages; }
     void setIgnoreVisibility(bool IgnoreVisibility) { mIgnoreVisibility = IgnoreVisibility; }
 
     void setLayersToHide(QStringList layersToHide) { mLayersToHide = layersToHide; }
     void setLayersToShow(QStringList layersToShow) { mLayersToShow = layersToShow; }
-    
 
     int render(const QString &fileName, const QString &imageFileName);
 

--- a/src/tmxrasterizer/tmxrasterizer.h
+++ b/src/tmxrasterizer/tmxrasterizer.h
@@ -49,6 +49,7 @@ public:
     qreal scale() const { return mScale; }
     int tileSize() const { return mTileSize; }
     int size() const { return mSize; }
+    int advanceAnimations() const {return mAdvanceAnimations; }
     bool useAntiAliasing() const { return mUseAntiAliasing; }
     bool smoothImages() const { return mSmoothImages; }
     bool ignoreVisibility() const { return mIgnoreVisibility; }
@@ -56,12 +57,15 @@ public:
     void setScale(qreal scale) { mScale = scale; }
     void setTileSize(int tileSize) { mTileSize = tileSize; }
     void setSize(int size) { mSize = size; }
+    void setAdvanceAnimations(int duration) { mAdvanceAnimations = duration; }
+
     void setAntiAliasing(bool useAntiAliasing) { mUseAntiAliasing = useAntiAliasing; }
     void setSmoothImages(bool smoothImages) { mSmoothImages = smoothImages; }
     void setIgnoreVisibility(bool IgnoreVisibility) { mIgnoreVisibility = IgnoreVisibility; }
 
     void setLayersToHide(QStringList layersToHide) { mLayersToHide = layersToHide; }
     void setLayersToShow(QStringList layersToShow) { mLayersToShow = layersToShow; }
+    
 
     int render(const QString &fileName, const QString &imageFileName);
 
@@ -69,6 +73,7 @@ private:
     qreal mScale;
     int mTileSize;
     int mSize;
+    int mAdvanceAnimations;
     bool mUseAntiAliasing;
     bool mSmoothImages;
     bool mIgnoreVisibility;


### PR DESCRIPTION
Relates to #1433 .

**Objective**
Allow a user to advance animations by a duration prior to rasterizing an image via tmxrasterizer.

**Reasoning**
This is an alternative to GIF support. A user can script multiple tmxrasterizer commands, each advancing the animation. This results in multiple PNG files, which the user can stitch together with any GIF creation tool such as `imagemagick`.

**Notes**
This should work with worlds, as it includes the tile animation reset. However I have not yet tested it on an animated world.