### PR TITLE
Pass tilePos to RenderTileCallback

### DIFF
--- a/src/libtiled/hexagonalrenderer.cpp
+++ b/src/libtiled/hexagonalrenderer.cpp
@@ -266,37 +266,6 @@ void HexagonalRenderer::drawGrid(QPainter *painter, const QRectF &exposed,
     }
 }
 
-void HexagonalRenderer::drawTileLayer(QPainter *painter,
-                                      const TileLayer *layer,
-                                      const QRectF &exposed) const
-{
-    QRect rect = boundingRect(layer->bounds());
-    if (!exposed.isNull())
-        rect &= exposed.toAlignedRect();
-
-    QMargins drawMargins = layer->drawMargins();
-    drawMargins.setBottom(drawMargins.bottom() + map()->tileHeight());
-    drawMargins.setRight(drawMargins.right() - map()->tileWidth());
-
-    rect.adjust(-drawMargins.right(),
-                -drawMargins.bottom(),
-                drawMargins.left(),
-                drawMargins.top());
-
-    CellRenderer renderer(painter, this, layer->effectiveTintColor(), CellRenderer::HexagonalCells);
-
-    auto tileRenderFunction = [layer, &renderer, this](QPoint tilePos, const QPointF &screenPos) {
-        const Cell &cell = layer->cellAt(tilePos);
-        if (!cell.isEmpty()) {
-            const Tile *tile = cell.tile();
-            const QSize size = tile ? tile->size() : map()->tileSize();
-            renderer.render(cell, screenPos, size, CellRenderer::BottomLeft);
-        }
-    };
-
-    drawTileLayer(tileRenderFunction, rect);
-}
-
 void HexagonalRenderer::drawTileLayer(const RenderTileCallback &renderTile,
                                       const QRectF &exposed) const
 {
@@ -325,7 +294,7 @@ void HexagonalRenderer::drawTileLayer(const RenderTileCallback &renderTile,
 
         bool staggeredRow = p.doStaggerX(startTile.x());
 
-        while (startPos.y() < exposed.bottom()) {
+        while (startPos.y() - p.tileHeight < exposed.bottom()) {
             QPoint rowTile = startTile;
             QPoint rowPos = startPos;
 
@@ -356,7 +325,7 @@ void HexagonalRenderer::drawTileLayer(const RenderTileCallback &renderTile,
         if (p.doStaggerY(startTile.y()))
             startPos.rx() -= p.columnWidth;
 
-        for (; startPos.y() < exposed.bottom(); startTile.ry()++) {
+        for (; startPos.y() - p.tileHeight < exposed.bottom(); startTile.ry()++) {
             QPoint rowTile = startTile;
             QPoint rowPos = startPos;
 

--- a/src/libtiled/hexagonalrenderer.cpp
+++ b/src/libtiled/hexagonalrenderer.cpp
@@ -271,8 +271,8 @@ void HexagonalRenderer::drawTileLayer(QPainter *painter,
                                       const QRectF &exposed) const
 {
     CellRenderer renderer(painter, this, layer->effectiveTintColor(), CellRenderer::HexagonalCells);
-    auto tileRenderFunction = [&renderer](const Cell &cell, const QPointF &pos, const QSizeF &size) {
-        renderer.render(cell, pos, size, CellRenderer::BottomLeft);
+    auto tileRenderFunction = [&renderer](const Cell &cell, const QPoint &/*tilePos*/, const QPointF &screenPos, const QSizeF &size) {
+        renderer.render(cell, screenPos, size, CellRenderer::BottomLeft);
     };
     drawTileLayer(layer, tileRenderFunction, exposed);
 }
@@ -342,7 +342,7 @@ void HexagonalRenderer::drawTileLayer(const TileLayer *layer,
                 if (!cell.isEmpty()) {
                     const Tile *tile = cell.tile();
                     const QSize size = tile ? tile->size() : map()->tileSize();
-                    renderTile(cell, rowPos, size);
+                    renderTile(cell, rowTile, rowPos, size);
                 }
 
                 rowPos.rx() += p.tileWidth + p.sideLengthX;
@@ -387,7 +387,7 @@ void HexagonalRenderer::drawTileLayer(const TileLayer *layer,
                 if (!cell.isEmpty()) {
                     const Tile *tile = cell.tile();
                     const QSize size = tile ? tile->size() : map()->tileSize();
-                    renderTile(cell, rowPos, size);
+                    renderTile(cell, rowTile, rowPos, size);
                 }
 
                 rowPos.rx() += p.tileWidth + p.sideLengthX;

--- a/src/libtiled/hexagonalrenderer.h
+++ b/src/libtiled/hexagonalrenderer.h
@@ -76,9 +76,7 @@ public:
     void drawGrid(QPainter *painter, const QRectF &exposed,
                   QColor gridColor) const override;
 
-    void drawTileLayer(QPainter *painter, const TileLayer *layer,
-                       const QRectF &exposed = QRectF()) const override;
-
+    using MapRenderer::drawTileLayer;
     void drawTileLayer(const RenderTileCallback &renderTile,
                        const QRectF &exposed) const override;
 

--- a/src/libtiled/hexagonalrenderer.h
+++ b/src/libtiled/hexagonalrenderer.h
@@ -79,9 +79,8 @@ public:
     void drawTileLayer(QPainter *painter, const TileLayer *layer,
                        const QRectF &exposed = QRectF()) const override;
 
-    void drawTileLayer(const TileLayer *layer,
-                       const RenderTileCallback &renderTile,
-                       const QRectF &exposed = QRectF()) const override;
+    void drawTileLayer(const RenderTileCallback &renderTile,
+                       const QRectF &exposed) const override;
 
     void drawTileSelection(QPainter *painter,
                            const QRegion &region,

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -267,8 +267,8 @@ void IsometricRenderer::drawTileLayer(QPainter *painter,
                                       const QRectF &exposed) const
 {
     CellRenderer renderer(painter, this, layer->effectiveTintColor());
-    auto tileRenderFunction = [&renderer](const Cell &cell, const QPointF &pos, const QSizeF &size) {
-        renderer.render(cell, pos, size, CellRenderer::BottomLeft);
+    auto tileRenderFunction = [&renderer](const Cell &cell, const QPoint &/*tilePos*/, const QPointF &screenPos, const QSizeF &size) {
+        renderer.render(cell, screenPos, size, CellRenderer::BottomLeft);
     };
     drawTileLayer(layer, tileRenderFunction, exposed);
 }
@@ -339,7 +339,7 @@ void IsometricRenderer::drawTileLayer(const TileLayer *layer,
             if (!cell.isEmpty()) {
                 const Tile *tile = cell.tile();
                 const QSize size = (tile && !tile->image().isNull()) ? tile->size() : map()->tileSize();
-                renderTile(cell, QPointF(x, (qreal)y / 2), size);
+                renderTile(cell, columnItr, QPointF(x, (qreal)y / 2), size);
             }
 
             // Advance to the next column

--- a/src/libtiled/isometricrenderer.cpp
+++ b/src/libtiled/isometricrenderer.cpp
@@ -262,43 +262,6 @@ void IsometricRenderer::drawGrid(QPainter *painter, const QRectF &rect,
     }
 }
 
-void IsometricRenderer::drawTileLayer(QPainter *painter,
-                                      const TileLayer *layer,
-                                      const QRectF &exposed) const
-{
-    const int tileWidth = map()->tileWidth();
-    const int tileHeight = map()->tileHeight();
-
-    if (tileWidth <= 0 || tileHeight <= 1)
-        return;
-
-    QRect rect = boundingRect(layer->bounds());
-    if (!exposed.isNull())
-        rect &= exposed.toAlignedRect();
-
-    QMargins drawMargins = layer->drawMargins();
-    drawMargins.setTop(drawMargins.top() - tileHeight);
-    drawMargins.setRight(drawMargins.right() - tileWidth);
-
-    rect.adjust(-drawMargins.right(),
-                -drawMargins.bottom(),
-                drawMargins.left(),
-                drawMargins.top());
-
-    CellRenderer renderer(painter, this, layer->effectiveTintColor());
-
-    auto tileRenderFunction = [layer, &renderer, this](QPoint tilePos, const QPointF &screenPos) {
-        const Cell &cell = layer->cellAt(tilePos - layer->position());
-        if (!cell.isEmpty()) {
-            const Tile *tile = cell.tile();
-            const QSize size = (tile && !tile->image().isNull()) ? tile->size() : map()->tileSize();
-            renderer.render(cell, screenPos, size, CellRenderer::BottomLeft);
-        }
-    };
-
-    drawTileLayer(tileRenderFunction, rect);
-}
-
 void IsometricRenderer::drawTileLayer(const RenderTileCallback &renderTile,
                                       const QRectF &exposed) const
 {

--- a/src/libtiled/isometricrenderer.h
+++ b/src/libtiled/isometricrenderer.h
@@ -54,9 +54,7 @@ public:
 
     void drawGrid(QPainter *painter, const QRectF &rect, QColor grid) const override;
 
-    void drawTileLayer(QPainter *painter, const TileLayer *layer,
-                       const QRectF &exposed = QRectF()) const override;
-
+    using MapRenderer::drawTileLayer;
     void drawTileLayer(const RenderTileCallback &renderTile,
                        const QRectF &exposed) const override;
 

--- a/src/libtiled/isometricrenderer.h
+++ b/src/libtiled/isometricrenderer.h
@@ -57,9 +57,8 @@ public:
     void drawTileLayer(QPainter *painter, const TileLayer *layer,
                        const QRectF &exposed = QRectF()) const override;
 
-    void drawTileLayer(const TileLayer *layer,
-                       const RenderTileCallback &renderTile,
-                       const QRectF &exposed = QRectF()) const override;
+    void drawTileLayer(const RenderTileCallback &renderTile,
+                       const QRectF &exposed) const override;
 
     void drawTileSelection(QPainter *painter,
                            const QRegion &region,

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -273,7 +273,7 @@ CellRenderer::CellRenderer(QPainter *painter, const MapRenderer *renderer, const
  *
  * This call expects `painter.translate(pos)` to correspond to the Origin point.
  */
-void CellRenderer::render(const Cell &cell, const QPointF &pos, const QSizeF &size, Origin origin)
+void CellRenderer::render(const Cell &cell, const QPointF &screenPos, const QSizeF &size, Origin origin)
 {
     const Tile *tile = cell.tile();
 
@@ -281,7 +281,7 @@ void CellRenderer::render(const Cell &cell, const QPointF &pos, const QSizeF &si
         tile = tile->currentFrameTile();
 
     if (!tile || tile->image().isNull()) {
-        QRectF target { pos, size };
+        QRectF target { screenPos, size };
 
         if (origin == BottomLeft)
             target.translate(0.0, -size.height());
@@ -309,8 +309,8 @@ void CellRenderer::render(const Cell &cell, const QPointF &pos, const QSizeF &si
 
     QPainter::PixmapFragment fragment;
     // Calculate the position as if the origin is TopLeft, and correct it later.
-    fragment.x = pos.x() + (offset.x() * scale.width()) + sizeHalf.x();
-    fragment.y = pos.y() + (offset.y() * scale.height()) + sizeHalf.y();
+    fragment.x = screenPos.x() + (offset.x() * scale.width()) + sizeHalf.x();
+    fragment.y = screenPos.y() + (offset.y() * scale.height()) + sizeHalf.y();
     fragment.sourceLeft = 0;
     fragment.sourceTop = 0;
     fragment.width = imageSize.width();

--- a/src/libtiled/maprenderer.cpp
+++ b/src/libtiled/maprenderer.cpp
@@ -174,6 +174,41 @@ QPainterPath MapRenderer::pointInteractionShape(const MapObject *object) const
     return path;
 }
 
+void MapRenderer::drawTileLayer(QPainter *painter, const TileLayer *layer, const QRectF &exposed) const
+{
+    const QSize tileSize = map()->tileSize();
+
+    // Don't draw more than the bounding rectangle of the given layer,
+    // intersected with the exposed rectangle.
+    QRect rect = boundingRect(layer->bounds());
+    if (!exposed.isNull())
+        rect &= exposed.toAlignedRect();
+
+    // Draw margins extend the rendered area on the opposite side. We subtract
+    // the grid size because this has already been taken into account by
+    // boundingRect.
+    QMargins drawMargins = layer->drawMargins();
+    drawMargins.setTop(drawMargins.top() - tileSize.height());
+    drawMargins.setRight(drawMargins.right() - tileSize.width());
+    rect.adjust(-drawMargins.right(),
+                -drawMargins.bottom(),
+                drawMargins.left(),
+                drawMargins.top());
+
+    CellRenderer renderer(painter, this, layer->effectiveTintColor());
+
+    auto tileRenderFunction = [layer, &renderer, tileSize](QPoint tilePos, const QPointF &screenPos) {
+        const Cell &cell = layer->cellAt(tilePos - layer->position());
+        if (!cell.isEmpty()) {
+            const Tile *tile = cell.tile();
+            const QSize size = (tile && !tile->image().isNull()) ? tile->size() : tileSize;
+            renderer.render(cell, screenPos, size, CellRenderer::BottomLeft);
+        }
+    };
+
+    drawTileLayer(tileRenderFunction, rect);
+}
+
 void MapRenderer::setFlag(RenderFlag flag, bool enabled)
 {
 #if QT_VERSION >= 0x050700
@@ -207,7 +242,7 @@ QPolygonF MapRenderer::lineToPolygon(const QPointF &start, const QPointF &end)
     return polygon;
 }
 
-QPen MapRenderer::makeGridPen(const QPaintDevice *device, QColor color) const
+QPen MapRenderer::makeGridPen(const QPaintDevice *device, QColor color)
 {
     const qreal devicePixelRatio = device->devicePixelRatioF();
 
@@ -252,12 +287,11 @@ static bool hasOpenGLEngine(const QPainter *painter)
             type == QPaintEngine::OpenGL2);
 }
 
-CellRenderer::CellRenderer(QPainter *painter, const MapRenderer *renderer, const QColor &tintColor, CellType cellType)
+CellRenderer::CellRenderer(QPainter *painter, const MapRenderer *renderer, const QColor &tintColor)
     : mPainter(painter)
     , mRenderer(renderer)
     , mTile(nullptr)
     , mIsOpenGL(hasOpenGLEngine(painter))
-    , mCellType(cellType)
     , mTintColor(tintColor)
 {
 }
@@ -324,7 +358,7 @@ void CellRenderer::render(const Cell &cell, const QPointF &screenPos, const QSiz
     if (origin == BottomLeft)
         fragment.y -= size.height();
 
-    if (mCellType == HexagonalCells) {
+    if (mRenderer->cellType() == MapRenderer::HexagonalCells) {
 
         if (cell.flippedAntiDiagonally())
             fragment.rotation += 60;
@@ -333,7 +367,6 @@ void CellRenderer::render(const Cell &cell, const QPointF &screenPos, const QSiz
             fragment.rotation += 120;
 
     } else if (cell.flippedAntiDiagonally()) {
-        Q_ASSERT(mCellType == OrthogonalCells);
         fragment.rotation = 90;
 
         flippedHorizontally = cell.flippedVertically();

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -132,7 +132,7 @@ public:
     virtual void drawGrid(QPainter *painter, const QRectF &rect,
                           QColor gridColor = Qt::black) const = 0;
 
-    typedef std::function<void(const Cell &, const QPoint &, const QPointF &, const QSizeF &)> RenderTileCallback;
+    typedef std::function<void(QPoint, const QPointF &)> RenderTileCallback;
 
     /**
      * Draws the given \a layer using the given \a painter.
@@ -158,9 +158,8 @@ public:
      * Optionally, you can pass in the \a exposed rect (of pixels), so that
      * only tiles that can be visible in this area will be drawn.
      */
-    virtual void drawTileLayer(const TileLayer *layer,
-                               const RenderTileCallback &renderTile,
-                               const QRectF &exposed = QRectF()) const = 0;
+    virtual void drawTileLayer(const RenderTileCallback &renderTile,
+                               const QRectF &exposed) const = 0;
 
     /**
      * Draws the tile selection given by \a region in the specified \a color.

--- a/src/libtiled/maprenderer.h
+++ b/src/libtiled/maprenderer.h
@@ -132,7 +132,7 @@ public:
     virtual void drawGrid(QPainter *painter, const QRectF &rect,
                           QColor gridColor = Qt::black) const = 0;
 
-    typedef std::function<void(const Cell &, const QPointF &, const QSizeF &)> RenderTileCallback;
+    typedef std::function<void(const Cell &, const QPoint &, const QPointF &, const QSizeF &)> RenderTileCallback;
 
     /**
      * Draws the given \a layer using the given \a painter.
@@ -145,6 +145,15 @@ public:
 
     /**
      * Draws the given \a layer using the given \a renderTile callback.
+     *
+     * The callback takes four arguments:
+     *
+     * \list
+     * \li \c cell - The Cell that is being rendered.
+     * \li \c tilePos - The tile position of the cell being rendered.
+     * \li \c screenPos - The screen position of the cell being rendered.
+     * \li \c size - The size of the cell being rendered.
+     * \endlist
      *
      * Optionally, you can pass in the \a exposed rect (of pixels), so that
      * only tiles that can be visible in this area will be drawn.

--- a/src/libtiled/orthogonalrenderer.cpp
+++ b/src/libtiled/orthogonalrenderer.cpp
@@ -268,8 +268,8 @@ void OrthogonalRenderer::drawTileLayer(QPainter *painter,
                                        const QRectF &exposed) const
 {
     CellRenderer renderer(painter, this, layer->effectiveTintColor());
-    auto tileRenderFunction = [&renderer](const Cell &cell, const QPointF &pos, const QSizeF &size) {
-        renderer.render(cell, pos, size, CellRenderer::BottomLeft);
+    auto tileRenderFunction = [&renderer](const Cell &cell, const QPoint &/*tilePos*/, const QPointF &screenPos, const QSizeF &size) {
+        renderer.render(cell, screenPos, size, CellRenderer::BottomLeft);
     };
     drawTileLayer(layer, tileRenderFunction, exposed);
 }
@@ -348,7 +348,7 @@ void OrthogonalRenderer::drawTileLayer(const TileLayer *layer,
 
             const Tile *tile = cell.tile();
             const QSize size = (tile && !tile->image().isNull()) ? tile->size() : map()->tileSize();
-            renderTile(cell, layerPos + QPointF(x * tileWidth, (y + 1) * tileHeight), size);
+            renderTile(cell, QPoint(x, y), layerPos + QPointF(x * tileWidth, (y + 1) * tileHeight), size);
         }
     }
 }

--- a/src/libtiled/orthogonalrenderer.h
+++ b/src/libtiled/orthogonalrenderer.h
@@ -55,9 +55,8 @@ public:
     void drawTileLayer(QPainter *painter, const TileLayer *layer,
                        const QRectF &exposed = QRectF()) const override;
 
-    void drawTileLayer(const TileLayer *layer,
-                       const RenderTileCallback &renderTile,
-                       const QRectF &exposed = QRectF()) const override;
+    void drawTileLayer(const RenderTileCallback &renderTile,
+                       const QRectF &exposed) const override;
 
     void drawTileSelection(QPainter *painter,
                            const QRegion &region,

--- a/src/libtiled/orthogonalrenderer.h
+++ b/src/libtiled/orthogonalrenderer.h
@@ -52,9 +52,7 @@ public:
     void drawGrid(QPainter *painter, const QRectF &rect,
                   QColor gridColor) const override;
 
-    void drawTileLayer(QPainter *painter, const TileLayer *layer,
-                       const QRectF &exposed = QRectF()) const override;
-
+    using MapRenderer::drawTileLayer;
     void drawTileLayer(const RenderTileCallback &renderTile,
                        const QRectF &exposed) const override;
 

--- a/src/libtiled/tilelayer.cpp
+++ b/src/libtiled/tilelayer.cpp
@@ -122,6 +122,7 @@ TileLayer::TileLayer(const QString &name, QPoint position, QSize size)
 
 static QMargins computeDrawMargins(const QSet<SharedTileset> &tilesets)
 {
+    // Not differentiating between width and height, because tiles could be rotated
     int maxTileSize = 0;
     QMargins offsetMargins;
 
@@ -139,6 +140,8 @@ static QMargins computeDrawMargins(const QSet<SharedTileset> &tilesets)
                                    offsetMargins);
     }
 
+    // Adding maxTileSize to top-right of the margins assumes a bottom-left tile
+    // alignment within the grid cell.
     return QMargins(offsetMargins.left(),
                     offsetMargins.top() + maxTileSize,
                     offsetMargins.right() + maxTileSize,

--- a/src/libtiledquick/tilelayeritem.cpp
+++ b/src/libtiledquick/tilelayeritem.cpp
@@ -155,7 +155,7 @@ QSGNode *TileLayerItem::updatePaintNode(QSGNode *node,
      * drawn tiles are using the same tileset, they will share a single
      * geometry node.
      */
-    auto tileRenderFunction = [&](const Cell &cell, const QPointF &pos, const QSizeF &size) {
+    auto tileRenderFunction = [&](const Cell &cell, const QPoint &/*tilePos*/, const QPointF &screenPos, const QSizeF &size) {
         Tileset *tileset = cell.tileset();
         if (!tileset)
             return;
@@ -180,8 +180,8 @@ QSGNode *TileLayerItem::updatePaintNode(QSGNode *node,
         const auto offset = tileset->tileOffset();
 
         TileData data;
-        data.x = static_cast<float>(pos.x()) + offset.x();
-        data.y = static_cast<float>(pos.y() - size.height()) + offset.y();
+        data.x = static_cast<float>(screenPos.x()) + offset.x();
+        data.y = static_cast<float>(screenPos.y() - size.height()) + offset.y();
         data.width = static_cast<float>(size.width());
         data.height = static_cast<float>(size.height());
         data.flippedHorizontally = cell.flippedHorizontally();

--- a/src/libtiledquick/tilelayeritem.cpp
+++ b/src/libtiledquick/tilelayeritem.cpp
@@ -155,7 +155,8 @@ QSGNode *TileLayerItem::updatePaintNode(QSGNode *node,
      * drawn tiles are using the same tileset, they will share a single
      * geometry node.
      */
-    auto tileRenderFunction = [&](const Cell &cell, const QPoint &/*tilePos*/, const QPointF &screenPos, const QSizeF &size) {
+    auto tileRenderFunction = [&](QPoint tilePos, const QPointF &screenPos) {
+        const Cell &cell = mLayer->cellAt(tilePos);
         Tileset *tileset = cell.tileset();
         if (!tileset)
             return;
@@ -178,6 +179,8 @@ QSGNode *TileLayerItem::updatePaintNode(QSGNode *node,
 //        }
 
         const auto offset = tileset->tileOffset();
+        const auto tile = tileset->findTile(cell.tileId());
+        const QSize size = (tile && !tile->image().isNull()) ? tile->size() : mRenderer->map()->tileSize();
 
         TileData data;
         data.x = static_cast<float>(screenPos.x()) + offset.x();
@@ -190,7 +193,7 @@ QSGNode *TileLayerItem::updatePaintNode(QSGNode *node,
         tileData.append(data);
     };
 
-    mRenderer->drawTileLayer(mLayer, tileRenderFunction, mVisibleArea);
+    mRenderer->drawTileLayer(tileRenderFunction, mVisibleArea);
 
     if (!tileData.isEmpty())
         node->appendChildNode(new TilesNode(helper.texture(), tileData));
@@ -201,7 +204,19 @@ QSGNode *TileLayerItem::updatePaintNode(QSGNode *node,
 void TileLayerItem::updateVisibleTiles()
 {
     const MapItem *mapItem = static_cast<MapItem*>(parentItem());
-    const QRectF &rect = mapItem->visibleArea();
+
+    QRectF rect = mapItem->visibleArea();
+
+    QMargins drawMargins = mLayer->drawMargins();
+    drawMargins.setTop(drawMargins.top() - mRenderer->map()->tileHeight());
+    drawMargins.setRight(drawMargins.right() - mRenderer->map()->tileWidth());
+
+    rect.adjust(-drawMargins.right(),
+                -drawMargins.bottom(),
+                drawMargins.left(),
+                drawMargins.top());
+
+    rect &= mRenderer->boundingRect(mLayer->localBounds());
 
     if (mVisibleArea != rect) {
         mVisibleArea = rect;

--- a/src/tiled/tilelayeritem.cpp
+++ b/src/tiled/tilelayeritem.cpp
@@ -50,7 +50,7 @@ void TileLayerItem::syncWithTileLayer()
         layerBounds &= tileLayer()->rect();
 
     const MapRenderer *renderer = mMapDocument->renderer();
-    QRectF boundingRect = renderer->boundingRect(layerBounds);
+    const QRect boundingRect = renderer->boundingRect(layerBounds);
 
     QMargins margins = tileLayer()->drawMargins();
     if (const Map *map = tileLayer()->map()) {
@@ -58,10 +58,7 @@ void TileLayerItem::syncWithTileLayer()
         margins.setRight(margins.right() - map->tileWidth());
     }
 
-    mBoundingRect = boundingRect.adjusted(-margins.left(),
-                                          -margins.top(),
-                                          margins.right(),
-                                          margins.bottom());
+    mBoundingRect = boundingRect.marginsAdded(margins);
 }
 
 QRectF TileLayerItem::boundingRect() const


### PR DESCRIPTION
Continues on from https://github.com/bjorn/tiled/pull/2840.

This allows custom tile-rendering code to benefit from the tile position
calculations that the renderers do. It is necessary in order to allow
each tile to be its own QQuickItem.

Discussion about the motivation for this patch can be found here:

https://discourse.mapeditor.org/t/z-ordering-issues-tiledquickplugin/4546