### PR TITLE
AppVeyor: Added Qt 5.15 to the build matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,30 +13,37 @@ environment:
   BUTLER_API_KEY:
     secure: j7JM5L6KeqpnQukzJLsm7J6oV92SpmyEZLSoED1pZ3gQ79VIkdxtbQmTkqUNZPsz
   matrix:
-    - QTDIR: C:\Qt\5.12\mingw73_64
+    - QTDIR: C:\Qt\5.12.9\mingw73_64
       PYTHONHOME: C:\Python37-x64
       MINGW: C:\Qt\Tools\mingw730_64
       DEFAULT_PROFILE: x86_64-w64-mingw32
       PUSH_RELEASE: true
       TILED_ITCH_CHANNEL: windows-64bit
-    - QTDIR: C:\Qt\5.6\mingw49_32
+    - QTDIR: C:\Qt\5.6.3\mingw49_32
       PYTHONHOME: C:\Python37
       MINGW: C:\Qt\Tools\mingw492_32
       DEFAULT_PROFILE: i686-w64-mingw32
       PUSH_RELEASE: false
       TILED_ITCH_CHANNEL: winxp-32bit
+    - QTDIR: C:\Qt\5.15.0\mingw81_64
+      PYTHONHOME: C:\Python37-x64
+      MINGW: C:\Qt\Tools\mingw810_64
+      DEFAULT_PROFILE: x86_64-w64-mingw32
+      PUSH_RELEASE: false
 
 matrix:
   exclude:
     - image: Visual Studio 2015
-      QTDIR: C:\Qt\5.12\mingw73_64
+      QTDIR: C:\Qt\5.12.9\mingw73_64
+    - image: Visual Studio 2015
+      QTDIR: C:\Qt\5.15.0\mingw81_64
     - image: Visual Studio 2019
-      QTDIR: C:\Qt\5.6\mingw49_32
+      QTDIR: C:\Qt\5.6.3\mingw49_32
 
 configuration: Release
 
 install:
-  - choco install -y qbs --version 1.13.1
+  - choco install -y qbs --version 1.16.0
   - nuget install secure-file -ExcludeVersion
   - set PATH=%PATH%;%QTDIR%\bin;%MINGW%\bin
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,19 +16,19 @@ environment:
     - QTDIR: C:\Qt\5.12.9\mingw73_64
       PYTHONHOME: C:\Python37-x64
       MINGW: C:\Qt\Tools\mingw730_64
-      DEFAULT_PROFILE: x86_64-w64-mingw32
+      DEFAULT_PROFILE: x86_64-w64-mingw32-gcc-7_3_0
       PUSH_RELEASE: true
       TILED_ITCH_CHANNEL: windows-64bit
     - QTDIR: C:\Qt\5.6.3\mingw49_32
       PYTHONHOME: C:\Python37
       MINGW: C:\Qt\Tools\mingw492_32
-      DEFAULT_PROFILE: i686-w64-mingw32
+      DEFAULT_PROFILE: i686-w64-mingw32-gcc-4_9_2
       PUSH_RELEASE: false
       TILED_ITCH_CHANNEL: winxp-32bit
     - QTDIR: C:\Qt\5.15.0\mingw81_64
       PYTHONHOME: C:\Python37-x64
       MINGW: C:\Qt\Tools\mingw810_64
-      DEFAULT_PROFILE: x86_64-w64-mingw32
+      DEFAULT_PROFILE: x86_64-w64-mingw32-gcc-8_1_0
       PUSH_RELEASE: false
 
 matrix:


### PR DESCRIPTION
Also updated version of Qbs used from 1.13.1 to 1.16.0.