### PR TITLE
using CTRL-SHIFT to toggle snapping to fine grid mode

### DIFF
--- a/src/tiled/snaphelper.cpp
+++ b/src/tiled/snaphelper.cpp
@@ -34,10 +34,13 @@ SnapHelper::SnapHelper(const MapRenderer *renderer,
     mSnapToFineGrid = preferences->snapToFineGrid();
     mSnapToPixels = preferences->snapToPixels();
 
-    if ((modifiers & (Qt::ControlModifier|Qt::ShiftModifier))==(Qt::ControlModifier|Qt::ShiftModifier))
-        toggleFineSnap();
-    else if (modifiers & Qt::ControlModifier)
-        toggleSnap();
+    if (modifiers & Qt::ControlModifier) {
+        if (modifiers & Qt::ShiftModifier) {
+            toggleFineSnap();
+        } else { 
+            toggleSnap();
+        }
+    }
 }
 
 void SnapHelper::toggleSnap()

--- a/src/tiled/snaphelper.cpp
+++ b/src/tiled/snaphelper.cpp
@@ -34,7 +34,9 @@ SnapHelper::SnapHelper(const MapRenderer *renderer,
     mSnapToFineGrid = preferences->snapToFineGrid();
     mSnapToPixels = preferences->snapToPixels();
 
-    if (modifiers & Qt::ControlModifier)
+    if ((modifiers & (Qt::ControlModifier|Qt::ShiftModifier))==(Qt::ControlModifier|Qt::ShiftModifier))
+        toggleFineSnap();
+    else if (modifiers & Qt::ControlModifier)
         toggleSnap();
 }
 
@@ -42,6 +44,12 @@ void SnapHelper::toggleSnap()
 {
     mSnapToGrid = !(mSnapToGrid || mSnapToFineGrid);
     mSnapToFineGrid = false;
+}
+  
+void SnapHelper::toggleFineSnap()
+{
+    mSnapToFineGrid = !(mSnapToGrid || mSnapToFineGrid);
+    mSnapToGrid = false;
 }
 
 void SnapHelper::snap(QPointF &pixelPos) const

--- a/src/tiled/snaphelper.h
+++ b/src/tiled/snaphelper.h
@@ -34,14 +34,20 @@ public:
     
     void toggleFineSnap();
 
-    bool snaps() const { return mSnapToGrid || mSnapToFineGrid || mSnapToPixels; }
+    bool snaps() const { return mSnapMode != NoSnap || mSnapToPixels; }
 
     void snap(QPointF &pixelPos) const;
 
 private:
     const MapRenderer *mRenderer;
-    bool mSnapToGrid;
-    bool mSnapToFineGrid;
+
+    enum SnapMode {
+        NoSnap,
+        SnapToGrid,
+        SnapToFineGrid
+    };
+
+    SnapMode mSnapMode = NoSnap;
     bool mSnapToPixels;
 };
 

--- a/src/tiled/snaphelper.h
+++ b/src/tiled/snaphelper.h
@@ -31,6 +31,8 @@ public:
     SnapHelper(const MapRenderer *renderer, Qt::KeyboardModifiers modifiers = {});
 
     void toggleSnap();
+    
+    void toggleFineSnap();
 
     bool snaps() const { return mSnapToGrid || mSnapToFineGrid || mSnapToPixels; }
 


### PR DESCRIPTION
Well I don't really know if CTRL-SHIFT is a good idea but since CTRL was to toggle snapping to grid, I thought to keep the idea the CTRL 'toggles' snapping, and with SHIFT you switch to fine grid.
Hopefully it makes sense.
