### PR TITLE
Tiled Parity

### DIFF
--- a/util/java/libtiled-java/src/main/java/org/mapeditor/core/MapObject.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/core/MapObject.java
@@ -56,6 +56,9 @@ public class MapObject extends MapObjectData implements Cloneable {
     private Image image;
     private Image scaledImage;
     private Tile tile;
+    private boolean flipHorizontal;
+    private boolean flipVertical;
+    private boolean flipDiagonal;
 
     /**
      * Constructor for MapObject.
@@ -63,9 +66,11 @@ public class MapObject extends MapObjectData implements Cloneable {
     public MapObject() {
         super();
         this.properties = new Properties();
-        this.name = "Object";
+        this.name = "";
         this.type = "";
         this.imageSource = "";
+        this.flipHorizontal = false;
+        this.flipVertical = false;
     }
 
     /**
@@ -204,6 +209,15 @@ public class MapObject extends MapObjectData implements Cloneable {
     public void setTile(Tile tile) {
         this.tile = tile;
     }
+
+    public boolean getFlipHorizontal() { return flipHorizontal; }
+    public void setFlipHorizontal(boolean flip) { this.flipHorizontal = flip; }
+
+    public boolean getFlipVertical() { return flipVertical; }
+    public void setFlipVertical(boolean flip) { this.flipVertical = flip; }
+
+    public boolean getFlipDiagonal() { return flipDiagonal; }
+    public void setFlipDiagonal(boolean flip) { this.flipDiagonal = flip; }
 
     /**
      * Returns the image to be used when drawing this object. This image is

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/core/TileLayer.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/core/TileLayer.java
@@ -531,7 +531,7 @@ public class TileLayer extends TileLayerData {
      * @param y Tile-space y coordinate
      * @return <code>true</code> if tile at (x, y) is flipped horizontally
      */
-    public boolean isFlippedHorizontaly(int x, int y) {
+    public boolean isFlippedHorizontally(int x, int y) {
         return getBounds().contains(x, y) &&
                 (flags[y][x] & (int)TMXMapReader.FLIPPED_HORIZONTALLY_FLAG) != 0;
     }
@@ -555,7 +555,7 @@ public class TileLayer extends TileLayerData {
      * @param y Tile-space y coordinate
      * @return <code>true</code> if tile at (x, y) is flipped diagonally
      */
-    public boolean isFlippedDiagonaly(int x, int y) {
+    public boolean isFlippedDiagonally(int x, int y) {
         return getBounds().contains(x, y) &&
                 (flags[y][x] & (int)TMXMapReader.FLIPPED_DIAGONALLY_FLAG) != 0;
     }

--- a/util/java/libtiled-java/src/main/java/org/mapeditor/io/xml/XMLWriter.java
+++ b/util/java/libtiled-java/src/main/java/org/mapeditor/io/xml/XMLWriter.java
@@ -235,6 +235,19 @@ public class XMLWriter {
      * writeAttribute.
      *
      * @param name a {@link java.lang.String} object.
+     * @param content a long.
+     * @throws java.io.IOException if any.
+     * @throws org.mapeditor.io.xml.XMLWriterException if any.
+     */
+    public void writeAttribute(String name, long content)
+            throws IOException, XMLWriterException {
+        writeAttribute(name, String.valueOf(content));
+    }
+
+    /**
+     * <p>writeAttribute.</p>
+     *
+     * @param name a {@link java.lang.String} object.
      * @param content a float.
      * @throws java.io.IOException if any.
      * @throws org.mapeditor.io.xml.XMLWriterException if any.
@@ -254,7 +267,14 @@ public class XMLWriter {
      */
     public void writeAttribute(String name, double content)
             throws IOException, XMLWriterException {
-        writeAttribute(name, String.valueOf(content));
+        //TODO: Tiled omits the decimals if it's '.0' so this is for parity
+        long longContent = (long)content;
+        if (longContent == content) {
+            writeAttribute(name, String.valueOf(longContent));
+        }
+        else {
+            writeAttribute(name, String.valueOf(content));
+        }
     }
 
     /**

--- a/util/java/libtiled-java/src/main/resources/bindings.xjb
+++ b/util/java/libtiled-java/src/main/resources/bindings.xjb
@@ -38,19 +38,6 @@
 
         <jxb:globalBindings choiceContentProperty="true"/>
 
-        <jxb:bindings node="xs:complexType[@name='Group']">
-            <jxb:bindings node="xs:attribute[@name='x']">
-                <annox:annotate target="setter">@java.lang.Deprecated</annox:annotate>
-                <annox:annotate target="getter">@java.lang.Deprecated</annox:annotate>
-                <annox:annotate target="field">@java.lang.Deprecated</annox:annotate>
-            </jxb:bindings>
-            <jxb:bindings node="xs:attribute[@name='y']">
-                <annox:annotate target="setter">@java.lang.Deprecated</annox:annotate>
-                <annox:annotate target="getter">@java.lang.Deprecated</annox:annotate>
-                <annox:annotate target="field">@java.lang.Deprecated</annox:annotate>
-            </jxb:bindings>
-        </jxb:bindings>
-
         <jxb:bindings node="xs:complexType[@name='Image']">
             <jxb:class name="ImageData" />
             <jxb:bindings node="xs:attribute[@name='id']">
@@ -119,6 +106,18 @@
             </jxb:bindings>		
             <jxb:bindings node="xs:attribute[@name='offsety']">		
                 <jxb:property name="offsetY"/>		
+            </jxb:bindings>
+        </jxb:bindings>
+
+        <jxb:bindings node="xs:complexType[@name='Group']">
+            <jxb:class name="Group"/>
+
+            <jxb:bindings node="xs:complexContent/xs:extension">
+                <jxb:bindings node="xs:sequence">
+                    <jxb:bindings node="xs:choice">
+                        <jxb:property name="layers"/>
+                    </jxb:bindings>
+                </jxb:bindings>
             </jxb:bindings>
         </jxb:bindings>
 

--- a/util/java/libtiled-java/src/main/resources/map.dtd
+++ b/util/java/libtiled-java/src/main/resources/map.dtd
@@ -56,6 +56,8 @@
     staggeraxis CDATA #IMPLIED
     staggerindex CDATA #IMPLIED
     backgroundcolor CDATA #IMPLIED
+    infinite CDATA #IMPLIED
+    nextlayerid ID #IMPLIED
     nextobjectid ID #IMPLIED
 >
 
@@ -129,6 +131,7 @@
 
 <!ELEMENT layer (properties?, data)>
 <!ATTLIST layer
+  id          CDATA   #REQUIRED
   name        CDATA   #REQUIRED
   width       CDATA   #REQUIRED
   height      CDATA   #REQUIRED
@@ -136,10 +139,12 @@
   y           CDATA   #IMPLIED
   opacity     CDATA   #IMPLIED
   visible     (0 | 1) #IMPLIED
+  locked      CDATA   #IMPLIED
 >
 
 <!ELEMENT objectgroup (properties?, object*)>
 <!ATTLIST objectgroup
+  id          CDATA   #REQUIRED
   name        CDATA   #REQUIRED
   width       CDATA   #IMPLIED
   height      CDATA   #IMPLIED
@@ -151,6 +156,7 @@
 
 <!ELEMENT object (properties?)>
 <!ATTLIST object
+  id          CDATA   #REQUIRED
   name        CDATA   #IMPLIED
   type        CDATA   #IMPLIED
   x           CDATA   #REQUIRED
@@ -158,4 +164,5 @@
   width       CDATA   #IMPLIED
   height      CDATA   #IMPLIED
   gid         CDATA   #IMPLIED
+  rotation    CDATA   #IMPLIED
 >

--- a/util/java/libtiled-java/src/main/resources/map.xsd
+++ b/util/java/libtiled-java/src/main/resources/map.xsd
@@ -237,83 +237,35 @@ POSSIBILITY OF SUCH DAMAGE.
                 `visible` recursively affect child layers.
             </xs:documentation>
         </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="Layer">
+                <xs:sequence>
+                    <xs:choice>
+                        <xs:element name="layer" type="TileLayer" maxOccurs="unbounded"/>
+                        <xs:element name="objectgroup" type="ObjectGroup" maxOccurs="unbounded"/>
+                        <xs:element name="imagelayer" type="ImageLayer" maxOccurs="unbounded"/>
+                        <xs:element name="group" type="Group" maxOccurs="unbounded"/>
+                    </xs:choice>
+                </xs:sequence>
 
-        <xs:sequence>
-            <xs:element name="properties" type="Properties"/>
-            <xs:element name="layer" type="TileLayer" maxOccurs="unbounded"/>
-            <xs:element name="objectgroup" type="ObjectGroup" maxOccurs="unbounded"/>
-            <xs:element name="imagelayer" type="ImageLayer" maxOccurs="unbounded"/>
-            <xs:element name="group" type="Group" maxOccurs="unbounded"/>
-        </xs:sequence>
-
-        <xs:attribute name="id" type="xs:int">
-            <xs:annotation>
-                <xs:documentation>
-                    Unique ID of the layer. Each layer that is added to a map gets a
-                    unique id. Even if a layer is deleted, no layer ever gets the
-                    same ID. Can not be changed in Tiled.
-
-                    @since 1.2
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="name" type="xs:string">
-            <xs:annotation>
-                <xs:documentation>
-                    The name of the group layer.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="offsetx" type="xs:int">
-            <xs:annotation>
-                <xs:documentation>
-                    Rendering offset of the group layer in pixels.
-                    Defaults to 0.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="offsety" type="xs:int">
-            <xs:annotation>
-                <xs:documentation>
-                    Rendering offset of the group layer in pixels.
-                    Defaults to 0.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="x" type="xs:int">
-            <xs:annotation>
-                <xs:documentation>
-                    The x position of the group layer in pixels.
-
-                    @deprecated since 0.15
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="y" type="xs:int">
-            <xs:annotation>
-                <xs:documentation>
-                    The y position of the group layer in pixels.
-
-                    @deprecated since 0.15
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="opacity" type="xs:double">
-            <xs:annotation>
-                <xs:documentation>
-                    The opacity of the layer as a value from 0 to 1.
-                    Defaults to 1.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="visible" type="xs:boolean">
-            <xs:annotation>
-                <xs:documentation>
-                    Whether the layer is shown (1) or hidden (0).
-                    Defaults to 1.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
+                <xs:attribute name="color" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The color used to display the objects in this group.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="draworder" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether the objects are drawn according to the order
+                            of appearance ("index") or sorted by their
+                            y-coordinate ("topdown"). Defaults to "topdown".
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
     </xs:complexType>
 
     <xs:complexType name="Image">
@@ -506,6 +458,13 @@ POSSIBILITY OF SUCH DAMAGE.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="locked" type="xs:int">
+            <xs:annotation>
+                <xs:documentation>
+                    Locking flag of the layer (used by Tiled).
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="Map">
@@ -531,14 +490,8 @@ POSSIBILITY OF SUCH DAMAGE.
                 <xs:element name="layer" type="TileLayer" maxOccurs="unbounded"/>
                 <xs:element name="objectgroup" type="ObjectGroup" maxOccurs="unbounded"/>
                 <xs:element name="imagelayer" type="ImageLayer" maxOccurs="unbounded"/>
+                <xs:element name="group" type="Group" maxOccurs="unbounded"/>
             </xs:choice>
-            <xs:element name="group" type="Group" maxOccurs="unbounded">
-                <xs:annotation>
-                    <xs:documentation>
-                        @since 1.0
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
         </xs:sequence>
 
         <xs:attribute name="version" type="xs:string" fixed="1.0">
@@ -701,6 +654,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
         <xs:sequence>
             <xs:element name="properties" type="Properties"/>
+            <xs:element name="point" type="Point"/>
             <xs:element name="ellipse" type="Ellipse">
                 <xs:annotation>
                     <xs:documentation>
@@ -841,6 +795,15 @@ POSSIBILITY OF SUCH DAMAGE.
                 </xs:attribute>
             </xs:extension>
         </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="Point">
+        <xs:annotation>
+            <xs:documentation source="http://doc.mapeditor.org/reference/tmx-map-format/#point">
+                Used to mark an object as a point.
+                The existing x and y attributes are used to determine the position of the point.
+            </xs:documentation>
+        </xs:annotation>
     </xs:complexType>
 
     <xs:complexType name="Polygon">

--- a/util/java/libtiled-java/src/test/java/org/mapeditor/io/MapReaderTest.java
+++ b/util/java/libtiled-java/src/test/java/org/mapeditor/io/MapReaderTest.java
@@ -353,21 +353,21 @@ public class MapReaderTest {
         TileLayer layer = (TileLayer) map.getLayer(0);
         assertNotNull(layer.getTileAt(0, 0));
 
-        assertTrue(layer.isFlippedHorizontaly(0, 0));
+        assertTrue(layer.isFlippedHorizontally(0, 0));
         assertFalse(layer.isFlippedVertically(0, 0));
-        assertFalse(layer.isFlippedDiagonaly(0, 0));
+        assertFalse(layer.isFlippedDiagonally(0, 0));
 
-        assertFalse(layer.isFlippedHorizontaly(1, 0));
+        assertFalse(layer.isFlippedHorizontally(1, 0));
         assertTrue(layer.isFlippedVertically(1, 0));
-        assertFalse(layer.isFlippedDiagonaly(1, 0));
+        assertFalse(layer.isFlippedDiagonally(1, 0));
 
-        assertTrue(layer.isFlippedHorizontaly(2, 0));
+        assertTrue(layer.isFlippedHorizontally(2, 0));
         assertTrue(layer.isFlippedVertically(2, 0));
-        assertFalse(layer.isFlippedDiagonaly(2, 0));
+        assertFalse(layer.isFlippedDiagonally(2, 0));
 
-        assertFalse(layer.isFlippedHorizontaly(3, 0));
+        assertFalse(layer.isFlippedHorizontally(3, 0));
         assertFalse(layer.isFlippedVertically(3, 0));
-        assertFalse(layer.isFlippedDiagonaly(3, 0));
+        assertFalse(layer.isFlippedDiagonally(3, 0));
     }
 
     private URL getUrlFromResources(String filename) {


### PR DESCRIPTION
Reviving work done in https://github.com/bjorn/tiled/pull/2207

I've rebased off master and resolved the conflicts to the best of my knowledge. I'm happy to resolve any other code review comments to try to get this merged.

@bjorn 

From the author's original git commits:

- Added read/write for mapobject id
- added object rotation to TMXMapWriter
- Don’t write name into object if it’s null (inline with the editor)
- Flip flags support for objects
- Fixed typo in tile flips
- 1to1 with my needs of TMX 1.2 for now (not full 1.2 support on writer yet)
- Write tilemap flags
- Reading and writing Groups
- Changed Group layer data structure to be one list (like in MapData) to preserve layer order