### PR TITLE
GitHub Actions: Added building of the snap package

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -94,7 +94,7 @@ jobs:
 
     - name: Set snap version
       run: |
-        sed -i 's/version: .*/version: '"${TILED_VERSION}"'/g' snap/snapcraft.yaml
+        sed -i 's/^version: .*/version: '"${TILED_VERSION}"'/g' snap/snapcraft.yaml
 
     - name: Build snap
       id: build

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -89,12 +89,25 @@ jobs:
       TILED_VERSION: ${{ needs.version.outputs.version }}
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: snapcore/action-build@v1
-    - uses: actions/upload-artifact@v2
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Build snap
+      uses: snapcore/action-build@v1
+
+    - name: Upload snap artifact
+      uses: actions/upload-artifact@v2
       with:
         name: tiled_amd64.snap
         path: tiled_*_amd64.snap
+
+    - name: Release snap (beta channel)
+      uses: snapcore/action-publish@v1
+      if: github.repository == 'bjorn/tiled' && github.event_name == 'push'
+      with:
+        store_login: ${{ secrets.SNAP_STORE_LOGIN }}
+        snap: ${{ steps.build.outputs.snap }}
+        release: beta
 
   macos:
     name: macOS

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -92,9 +92,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Set snap version
+    - name: Set Tiled version
       run: |
         sed -i 's/^version: .*/version: '"${TILED_VERSION}"'/g' snap/snapcraft.yaml
+        sed -i 's/TILED_VERSION = .*/TILED_VERSION = "'"${TILED_VERSION}"'"/g' tiled.pri
 
     - name: Build snap
       id: build

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -92,6 +92,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
+    - name: Set snap version
+      run: |
+        sed -i 's/version: .*/version: '"${TILED_VERSION}"'/g' snap/snapcraft.yaml
+
     - name: Build snap
       id: build
       uses: snapcore/action-build@v1

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -93,6 +93,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Build snap
+      id: build
       uses: snapcore/action-build@v1
 
     - name: Upload snap artifact

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -32,7 +32,7 @@ jobs:
       run: echo "::set-output name=version::$(date "+%Y.%m.%d")"
 
   linux:
-    name: Linux
+    name: Linux (AppImage)
     runs-on: ubuntu-16.04
     needs: version
 
@@ -79,6 +79,22 @@ jobs:
       with:
         name: Tiled-x86_64.AppImage
         path: Tiled-x86_64.AppImage
+
+  snap:
+    name: Linux (snap)
+    runs-on: ubuntu-latest
+    needs: version
+
+    env:
+      TILED_VERSION: ${{ needs.version.outputs.version }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: snapcore/action-build@v1
+    - uses: actions/upload-artifact@v2
+      with:
+        name: tiled_amd64.snap
+        path: tiled_*_amd64.snap
 
   macos:
     name: macOS
@@ -193,12 +209,6 @@ jobs:
       with:
         name: Tiled-win${{ matrix.arch }}
         path: release/install-root/*
-
-  snap:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: snapcore/action-build@v1
 
   itch:
     name: Upload to itch.io (${{ matrix.channel }})

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -194,6 +194,12 @@ jobs:
         name: Tiled-win${{ matrix.arch }}
         path: release/install-root/*
 
+  snap:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: snapcore/action-build@v1
+
   itch:
     name: Upload to itch.io (${{ matrix.channel }})
     runs-on: ubuntu-latest

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -108,7 +108,7 @@ jobs:
 
     - name: Release snap (beta channel)
       uses: snapcore/action-publish@v1
-      if: github.repository == 'bjorn/tiled' && github.event_name == 'push'
+      if: github.repository == 'bjorn/tiled' && github.event_name == 'push' && github.ref == 'refs/heads/snapshot'
       with:
         store_login: ${{ secrets.SNAP_STORE_LOGIN }}
         snap: ${{ steps.build.outputs.snap }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: tiled
 adopt-info: tiled
+version: git
 license: GPL-2.0
 base: core18
 
@@ -31,9 +32,6 @@ parts:
       - CONFIG+=release
     parse-info:
       - org.mapeditor.Tiled.appdata.xml
-    override-pull: |
-      snapcraftctl pull
-      snapcraftctl set-version "$(git describe | cut -c 2-)"
     source: .
     build-packages:
       - pkg-config


### PR DESCRIPTION
If this works we'll set up publishing of the snap as well. 

This should eventually help with #2828. Even though the edge channel always has a build of the latest master, it would be good to have actual snapshot builds (maybe on beta channel) and to push tags to release or rc channel.